### PR TITLE
Add story-driven NPC dialogue system with choices

### DIFF
--- a/__tests__/components/DialogueOverlay.test.tsx
+++ b/__tests__/components/DialogueOverlay.test.tsx
@@ -33,4 +33,29 @@ describe("DialogueOverlay", () => {
     fireEvent.click(screen.getByTestId("dialogue-overlay"));
     expect(onAdvance).toHaveBeenCalledTimes(1);
   });
+
+  it("renders selectable choices and handles selection", () => {
+    const onSelectChoice = jest.fn();
+    const onAdvance = jest.fn();
+    render(
+      <DialogueOverlay
+        {...baseProps}
+        choices={[
+          { id: "a", label: "Affirm the warning" },
+          { id: "b", label: "Ask for details" },
+        ]}
+        selectedChoiceIndex={1}
+        onSelectChoice={onSelectChoice}
+        onAdvance={onAdvance}
+      />
+    );
+    expect(screen.getByRole("listbox", { name: "Responses" })).toBeInTheDocument();
+    const options = screen.getAllByRole("button");
+    expect(options).toHaveLength(2);
+    fireEvent.click(options[0]);
+    expect(onSelectChoice).toHaveBeenCalledWith("a");
+    // Clicking overlay should not trigger advance while choices are visible
+    fireEvent.click(screen.getByTestId("dialogue-overlay"));
+    expect(onAdvance).not.toHaveBeenCalled();
+  });
 });

--- a/__tests__/lib/dialogue_registry.test.ts
+++ b/__tests__/lib/dialogue_registry.test.ts
@@ -6,6 +6,9 @@ describe("dialogue registry", () => {
     expect(script).toBeTruthy();
     expect(script?.lines).toHaveLength(3);
     expect(script?.lines[0].speaker).toBe("Elder Rowan");
+    expect(script?.onCompleteEffects).toEqual([
+      { eventId: "met-elder-rowan", value: true },
+    ]);
   });
 
   it("lists all registered scripts", () => {
@@ -13,6 +16,16 @@ describe("dialogue registry", () => {
     const ids = all.map((entry) => entry.id);
     expect(ids).toContain("elder-rowan-intro");
     expect(ids).toContain("caretaker-lysa-overview");
+    expect(ids).toContain("caretaker-lysa-reminder");
+  });
+
+  it("exposes dialogue choices when available", () => {
+    const script = getDialogueScript("caretaker-lysa-overview");
+    expect(script).toBeTruthy();
+    const finalLine = script?.lines[script.lines.length - 1];
+    expect(finalLine?.options).toBeDefined();
+    expect(finalLine?.options).toHaveLength(2);
+    expect(finalLine?.options?.[0].prompt).toContain("Promise");
   });
 
   it("returns undefined for missing ids", () => {

--- a/__tests__/lib/npc.test.ts
+++ b/__tests__/lib/npc.test.ts
@@ -64,7 +64,8 @@ describe("NPC interaction events", () => {
     expect(event.npcId).toBe("solo");
     expect(event.type).toBe("dialogue");
     expect(event.hookId).toBe("solo-dialogue");
-    expect(event.availableHooks).toHaveLength(0);
+    expect(event.availableHooks).toHaveLength(1);
+    expect(event.availableHooks[0]?.id).toBe("solo-dialogue");
   });
 
   test("first hook metadata is surfaced when available", () => {
@@ -93,5 +94,33 @@ describe("NPC interaction events", () => {
     expect(event.availableHooks).toHaveLength(2);
     expect(event.availableHooks[1]?.id).toBe("mentor-gift");
     expect(event.memory?.mentor).toBeUndefined();
+  });
+
+  test("custom hook is prioritized when provided", () => {
+    const npc = new NPC({
+      id: "scribe",
+      name: "Scribe",
+      sprite: "/images/hero/hero-front-static.png",
+      y: 0,
+      x: 0,
+      interactionHooks: [
+        {
+          id: "scribe-default",
+          type: "dialogue",
+          description: "Talk",
+        },
+      ],
+    });
+
+    const event = npc.createInteractionEvent("action", {
+      id: "story-dialogue:custom",
+      type: "dialogue",
+      description: "Discuss current events",
+      payload: { dialogueId: "custom" },
+    });
+
+    expect(event.hookId).toBe("story-dialogue:custom");
+    expect(event.availableHooks[0]?.id).toBe("story-dialogue:custom");
+    expect(event.availableHooks).toHaveLength(2);
   });
 });

--- a/__tests__/lib/story/event_registry.test.ts
+++ b/__tests__/lib/story/event_registry.test.ts
@@ -1,0 +1,39 @@
+import {
+  applyStoryEffects,
+  areStoryConditionsMet,
+  createInitialStoryFlags,
+  listStoryEvents,
+} from "../../../lib/story/event_registry";
+
+describe("story event registry", () => {
+  it("creates initial flags for each event", () => {
+    const flags = createInitialStoryFlags();
+    const events = listStoryEvents();
+    for (const event of events) {
+      expect(flags).toHaveProperty(event.id, event.defaultValue ?? false);
+    }
+  });
+
+  it("evaluates story conditions against flags", () => {
+    const flags = createInitialStoryFlags();
+    flags["met-elder-rowan"] = true;
+    expect(
+      areStoryConditionsMet(flags, [
+        { eventId: "met-elder-rowan", value: true },
+      ])
+    ).toBe(true);
+    expect(
+      areStoryConditionsMet(flags, [
+        { eventId: "met-elder-rowan", value: false },
+      ])
+    ).toBe(false);
+  });
+
+  it("applies story effects and returns updated flags", () => {
+    const flags = createInitialStoryFlags();
+    const next = applyStoryEffects(flags, [
+      { eventId: "heard-lysa-warning", value: true },
+    ]);
+    expect(next?.["heard-lysa-warning"]).toBe(true);
+  });
+});

--- a/__tests__/lib/story/npc_script_registry.test.ts
+++ b/__tests__/lib/story/npc_script_registry.test.ts
@@ -1,0 +1,32 @@
+import {
+  listNpcDialogueRules,
+  resolveNpcDialogueScript,
+} from "../../../lib/story/npc_script_registry";
+import { createInitialStoryFlags } from "../../../lib/story/event_registry";
+
+describe("npc script registry", () => {
+  it("lists registered NPC dialogue rules", () => {
+    const rules = listNpcDialogueRules();
+    expect(rules.some((rule) => rule.npcId === "npc-elder-rowan")).toBe(true);
+  });
+
+  it("resolves scripts based on story flags", () => {
+    const flags = createInitialStoryFlags();
+    // Intro should be selected before meeting the elder
+    expect(resolveNpcDialogueScript("npc-elder-rowan", flags)).toBe(
+      "elder-rowan-intro"
+    );
+    flags["met-elder-rowan"] = true;
+    expect(resolveNpcDialogueScript("npc-elder-rowan", flags)).toBe(
+      "elder-rowan-default"
+    );
+    flags["heard-lysa-warning"] = true;
+    expect(resolveNpcDialogueScript("npc-elder-rowan", flags)).toBe(
+      "elder-rowan-warning-response"
+    );
+    flags["elder-rowan-acknowledged-warning"] = true;
+    expect(resolveNpcDialogueScript("npc-elder-rowan", flags)).toBe(
+      "elder-rowan-post-warning"
+    );
+  });
+});

--- a/components/DialogueOverlay.module.css
+++ b/components/DialogueOverlay.module.css
@@ -42,6 +42,58 @@
   position: relative;
 }
 
+.choices {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.choiceButton {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  background: rgba(250, 245, 220, 0.08);
+  border: 1px solid rgba(250, 245, 220, 0.18);
+  border-radius: 10px;
+  padding: 8px 12px;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  transition: background 0.18s ease, border-color 0.18s ease;
+}
+
+.choiceButton:hover,
+.choiceButton:focus {
+  background: rgba(250, 245, 220, 0.16);
+  border-color: rgba(250, 245, 220, 0.3);
+}
+
+.choiceButtonActive {
+  background: rgba(255, 217, 136, 0.18);
+  border-color: rgba(255, 217, 136, 0.6);
+  box-shadow: 0 0 8px rgba(255, 217, 136, 0.35);
+}
+
+.choiceBadge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 9999px;
+  background: rgba(250, 245, 220, 0.22);
+  font-size: 11px;
+  font-weight: 700;
+  color: rgba(18, 18, 22, 0.9);
+}
+
+.choiceLabel {
+  flex: 1;
+  text-align: left;
+  font-size: 13px;
+}
+
 .cursor {
   display: inline-block;
   width: 8px;

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -36,6 +36,10 @@ import {
 import { addPlayerToMap, findPlayerPosition, removePlayerFromMapData } from "./player";
 import { addRunePotsForStoneExciters, generateCompleteMap } from "./map-features";
 import { addSnakesPerRules } from "./enemy-features";
+import {
+  createInitialStoryFlags,
+  type StoryFlags,
+} from "../story/event_registry";
 
 import { pickPotRevealDeterministic } from "./pots";
 
@@ -551,6 +555,7 @@ export interface GameState {
       stepInterval: number;
     };
   };
+  storyFlags?: StoryFlags;
   rooms?: Record<RoomId, RoomSnapshot>;
   currentRoomId?: RoomId;
   roomTransitions?: RoomTransition[];
@@ -665,6 +670,7 @@ export function initializeGameState(): GameState {
     },
     recentDeaths: [],
     npcInteractionQueue: [],
+    storyFlags: createInitialStoryFlags(),
   };
 }
 
@@ -718,6 +724,7 @@ export function initializeGameStateFromMap(mapData: MapData): GameState {
     },
     recentDeaths: [],
     npcInteractionQueue: [],
+    storyFlags: createInitialStoryFlags(),
   };
 }
 

--- a/lib/story/dialogue_registry.ts
+++ b/lib/story/dialogue_registry.ts
@@ -1,11 +1,24 @@
+import type { StoryEffect } from "./event_registry";
+
+export interface DialogueChoice {
+  id: string;
+  prompt: string;
+  response?: DialogueLine[];
+  nextDialogueId?: string;
+  effects?: StoryEffect[];
+}
+
 export interface DialogueLine {
   speaker?: string;
   text: string;
+  options?: DialogueChoice[];
+  effects?: StoryEffect[];
 }
 
 export interface DialogueScript {
   id: string;
   lines: DialogueLine[];
+  onCompleteEffects?: StoryEffect[];
 }
 
 const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
@@ -25,6 +38,49 @@ const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
         text: "Trust the floor runes. Their glow marks safe footing when the shadows lie to you.",
       },
     ],
+    onCompleteEffects: [{ eventId: "met-elder-rowan", value: true }],
+  },
+  "elder-rowan-warning-response": {
+    id: "elder-rowan-warning-response",
+    lines: [
+      {
+        speaker: "Elder Rowan",
+        text: "Caretaker Lysa has always felt the sanctum breathe before the rest of us. What message did she press into your hands?",
+      },
+      {
+        speaker: "Hero",
+        text: "She warned that the sanctum's wards are thin. One misstep and the climb could swallow me whole.",
+      },
+      {
+        speaker: "Elder Rowan",
+        text: "Then let this ring anchor you. When the sanctum howls, hold your ground and listen before you leap.",
+      },
+    ],
+    onCompleteEffects: [
+      { eventId: "elder-rowan-acknowledged-warning", value: true },
+    ],
+  },
+  "elder-rowan-post-warning": {
+    id: "elder-rowan-post-warning",
+    lines: [
+      {
+        speaker: "Elder Rowan",
+        text: "Every step after the sanctum is a bargain with older things. Let Lysa's warning settle in your bones.",
+      },
+      {
+        speaker: "Hero",
+        text: "It has. I'll measure my breath and my stride.",
+      },
+    ],
+  },
+  "elder-rowan-default": {
+    id: "elder-rowan-default",
+    lines: [
+      {
+        speaker: "Elder Rowan",
+        text: "The town listens for your return. Even in quiet hours the stones remember your passing.",
+      },
+    ],
   },
   "caretaker-lysa-overview": {
     id: "caretaker-lysa-overview",
@@ -40,6 +96,55 @@ const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
       {
         speaker: "Caretaker Lysa",
         text: "Then keep your step light and your blade kinder still. Every rescued spirit strengthens us both.",
+      },
+      {
+        speaker: "Caretaker Lysa",
+        text: "How should I mark you down before you ascend again?",
+        options: [
+          {
+            id: "promise-caution",
+            prompt: "Promise to stay cautious",
+            response: [
+              {
+                speaker: "Hero",
+                text: "Write that I'll return when the wards are steadied.",
+              },
+              {
+                speaker: "Caretaker Lysa",
+                text: "Good. Take this ember charm—let it flare if the sanctum's floor gives way.",
+              },
+            ],
+            effects: [{ eventId: "heard-lysa-warning", value: true }],
+          },
+          {
+            id: "ask-for-details",
+            prompt: "Ask for sanctum details",
+            response: [
+              {
+                speaker: "Hero",
+                text: "Tell me what to watch for when the sanctum turns hostile.",
+              },
+              {
+                speaker: "Caretaker Lysa",
+                text: "Listen for the hum in the stones. If it falters, stop. The next tile may be hollow.",
+              },
+            ],
+            effects: [{ eventId: "heard-lysa-warning", value: true }],
+          },
+        ],
+      },
+    ],
+  },
+  "caretaker-lysa-reminder": {
+    id: "caretaker-lysa-reminder",
+    lines: [
+      {
+        speaker: "Caretaker Lysa",
+        text: "You already carry my warning. Check the charm if the air tastes of ash.",
+      },
+      {
+        speaker: "Hero",
+        text: "I'll keep it close.",
       },
     ],
   },

--- a/lib/story/event_registry.ts
+++ b/lib/story/event_registry.ts
@@ -1,0 +1,83 @@
+export interface StoryEventDefinition {
+  id: string;
+  description: string;
+  defaultValue?: boolean;
+}
+
+export type StoryFlags = Record<string, boolean>;
+
+export interface StoryCondition {
+  eventId: string;
+  value?: boolean;
+}
+
+export interface StoryEffect {
+  eventId: string;
+  value?: boolean;
+}
+
+const STORY_EVENTS: Record<string, StoryEventDefinition> = {
+  "met-elder-rowan": {
+    id: "met-elder-rowan",
+    description: "The hero has met Elder Rowan for the first time.",
+    defaultValue: false,
+  },
+  "heard-lysa-warning": {
+    id: "heard-lysa-warning",
+    description: "Caretaker Lysa shared the sanctum warning.",
+    defaultValue: false,
+  },
+  "elder-rowan-acknowledged-warning": {
+    id: "elder-rowan-acknowledged-warning",
+    description:
+      "Elder Rowan has acknowledged the warning relayed from Caretaker Lysa.",
+    defaultValue: false,
+  },
+};
+
+export function listStoryEvents(): StoryEventDefinition[] {
+  return Object.values(STORY_EVENTS);
+}
+
+export function getStoryEvent(id: string): StoryEventDefinition | undefined {
+  return STORY_EVENTS[id];
+}
+
+export function createInitialStoryFlags(): StoryFlags {
+  const flags: StoryFlags = {};
+  for (const event of Object.values(STORY_EVENTS)) {
+    flags[event.id] = event.defaultValue ?? false;
+  }
+  return flags;
+}
+
+export function areStoryConditionsMet(
+  flags: StoryFlags | undefined,
+  conditions?: StoryCondition[]
+): boolean {
+  if (!conditions || conditions.length === 0) return true;
+  const source = flags ?? {};
+  return conditions.every((condition) => {
+    const expected = condition.value ?? true;
+    return Boolean(source[condition.eventId]) === expected;
+  });
+}
+
+export function applyStoryEffects(
+  flags: StoryFlags | undefined,
+  effects?: StoryEffect[]
+): StoryFlags | undefined {
+  if (!effects || effects.length === 0) {
+    return flags;
+  }
+  const next: StoryFlags = { ...(flags ?? {}) };
+  let changed = false;
+  for (const effect of effects) {
+    const value = effect.value ?? true;
+    if (next[effect.eventId] !== value) {
+      next[effect.eventId] = value;
+      changed = true;
+    }
+  }
+  return changed ? next : flags ?? next;
+}

--- a/lib/story/npc_script_registry.ts
+++ b/lib/story/npc_script_registry.ts
@@ -1,0 +1,73 @@
+import {
+  areStoryConditionsMet,
+  type StoryCondition,
+  type StoryFlags,
+} from "./event_registry";
+
+export interface NPCDialogueRule {
+  npcId: string;
+  scriptId: string;
+  priority?: number;
+  conditions?: StoryCondition[];
+}
+
+const NPC_DIALOGUE_RULES: NPCDialogueRule[] = [
+  {
+    npcId: "npc-elder-rowan",
+    scriptId: "elder-rowan-warning-response",
+    priority: 40,
+    conditions: [
+      { eventId: "met-elder-rowan", value: true },
+      { eventId: "heard-lysa-warning", value: true },
+      { eventId: "elder-rowan-acknowledged-warning", value: false },
+    ],
+  },
+  {
+    npcId: "npc-elder-rowan",
+    scriptId: "elder-rowan-intro",
+    priority: 30,
+    conditions: [{ eventId: "met-elder-rowan", value: false }],
+  },
+  {
+    npcId: "npc-elder-rowan",
+    scriptId: "elder-rowan-post-warning",
+    priority: 20,
+    conditions: [{ eventId: "elder-rowan-acknowledged-warning", value: true }],
+  },
+  {
+    npcId: "npc-elder-rowan",
+    scriptId: "elder-rowan-default",
+    priority: 0,
+  },
+  {
+    npcId: "npc-grounds-caretaker",
+    scriptId: "caretaker-lysa-overview",
+    priority: 20,
+    conditions: [{ eventId: "heard-lysa-warning", value: false }],
+  },
+  {
+    npcId: "npc-grounds-caretaker",
+    scriptId: "caretaker-lysa-reminder",
+    priority: 10,
+    conditions: [{ eventId: "heard-lysa-warning", value: true }],
+  },
+];
+
+export function listNpcDialogueRules(): NPCDialogueRule[] {
+  return [...NPC_DIALOGUE_RULES];
+}
+
+export function resolveNpcDialogueScript(
+  npcId: string,
+  flags: StoryFlags | undefined
+): string | undefined {
+  const candidates = NPC_DIALOGUE_RULES.filter((rule) => rule.npcId === npcId);
+  if (candidates.length === 0) return undefined;
+  const sorted = [...candidates].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+  for (const rule of sorted) {
+    if (areStoryConditionsMet(flags, rule.conditions)) {
+      return rule.scriptId;
+    }
+  }
+  return undefined;
+}

--- a/lib/story/story_mode.ts
+++ b/lib/story/story_mode.ts
@@ -8,6 +8,7 @@ import {
 } from "../map";
 import { Enemy, EnemyState, rehydrateEnemies, type PlainEnemy } from "../enemy";
 import { NPC, rehydrateNPCs, serializeNPCs } from "../npc";
+import { createInitialStoryFlags } from "./event_registry";
 
 const FLOOR = 0;
 const WALL = 1;
@@ -164,7 +165,7 @@ function buildEntranceHall(): StoryRoom {
         type: "dialogue",
         description: "Greet the elder",
         payload: {
-          dialogueId: "elder-rowan-intro",
+          dialogueId: "elder-rowan-default",
         },
       },
       {
@@ -556,7 +557,7 @@ function buildOutdoorHouse(): StoryRoom {
         type: "dialogue",
         description: "Ask about the outside world",
         payload: {
-          dialogueId: "caretaker-lysa-overview",
+          dialogueId: "caretaker-lysa-reminder",
         },
       },
       {
@@ -777,6 +778,7 @@ export function buildStoryModeState(): GameState {
     rooms: roomSnapshots,
     roomTransitions: transitions,
     potOverrides: initialPotOverrides,
+    storyFlags: createInitialStoryFlags(),
   };
 
   return gameState;


### PR DESCRIPTION
## Summary
- add a story event registry and NPC dialogue rules to drive conditional conversations
- extend dialogue scripts, overlay UI, and TilemapGrid logic to support branching choices and story flag updates
- update game state initialization and tests to cover the new narrative systems

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d313f1d6e8832dbbd9f27bcff483d6