### PR TITLE
Add torch town story room with transition from outdoor clearing

### DIFF
--- a/components/DialogueOverlay.module.css
+++ b/components/DialogueOverlay.module.css
@@ -34,12 +34,21 @@
   letter-spacing: 1px;
 }
 
+/* Hero-specific color accents for better speaker distinction */
+.heroSpeaker {
+  color: #8fd3ff; /* soft sky-blue accent for the Hero name */
+}
+
 .body {
   font-size: 14px;
   line-height: 1.8;
   color: #fefcf2;
   min-height: 44px;
   position: relative;
+}
+
+.heroBody {
+  color: #cfeeff; /* lighter blue-white for Hero text */
 }
 
 .choices {

--- a/components/DialogueOverlay.tsx
+++ b/components/DialogueOverlay.tsx
@@ -40,6 +40,7 @@ const DialogueOverlay: React.FC<DialogueOverlayProps> = ({
     : hasMore
     ? "Next"
     : "Close";
+  const isHero = (speaker ?? "").toLowerCase() === "hero";
 
   const handleOverlayClick = () => {
     if (hasChoices) return;
@@ -57,9 +58,12 @@ const DialogueOverlay: React.FC<DialogueOverlayProps> = ({
     >
       <div className={`${styles.panel} pixel-text`}>
         <div className={styles.header}>
-          <span className={styles.speaker}>{speaker ?? ""}</span>
+          <span className={`${styles.speaker} ${isHero ? styles.heroSpeaker : ""}`}>{speaker ?? ""}</span>
         </div>
-        <div className={styles.body} data-testid="dialogue-text">
+        <div
+          className={`${styles.body} ${isHero ? styles.heroBody : ""}`}
+          data-testid="dialogue-text"
+        >
           {displayText}
           {showCursor ? <span className={styles.cursor}>▌</span> : null}
         </div>

--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -1718,7 +1718,9 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
           event.key === " " ||
           event.key === "Spacebar" ||
           event.key === "ArrowDown" ||
+          event.key === "ArrowUp" ||
           event.key === "ArrowRight" ||
+          event.key === "ArrowLeft" ||
           event.key === "e" ||
           event.key === "E"
         ) {

--- a/lib/map/types.ts
+++ b/lib/map/types.ts
@@ -15,6 +15,7 @@ export interface RoomSnapshot {
   enemies?: PlainEnemy[];
   npcs?: PlainNPC[];
   potOverrides?: Record<string, TileSubtype.FOOD | TileSubtype.MED>;
+  metadata?: Record<string, unknown>;
 }
 
 export interface RoomTransition {

--- a/lib/score_calculator.ts
+++ b/lib/score_calculator.ts
@@ -32,35 +32,35 @@ export class ScoreCalculator {
   // Base scoring weights
   private static readonly WEIGHTS = {
     // Combat scoring
-    DAMAGE_DEALT: 10,        // 10 points per damage dealt
-    ENEMY_DEFEATED: 25,      // 25 points per enemy defeated
-    
+    DAMAGE_DEALT: 10, // 10 points per damage dealt
+    ENEMY_DEFEATED: 25, // 25 points per enemy defeated
+
     // Survival scoring
-    HEALTH_REMAINING: 30,    // 30 points per health point remaining
-    DAMAGE_PENALTY: -5,      // -5 points per damage taken
-    
+    HEALTH_REMAINING: 30, // 30 points per health point remaining
+    DAMAGE_PENALTY: -5, // -5 points per damage taken
+
     // Efficiency scoring (penalty only)
-    STEP_PENALTY: -0.2,      // -0.2 points per step over 50
-    
+    STEP_PENALTY: -0.2, // -0.2 points per step over 50
+
     // Item collection
-    KEY_BONUS: 50,           // 50 points for key
-    EXIT_KEY_BONUS: 75,      // 75 points for exit key
-    SWORD_BONUS: 50,         // 50 points for sword
-    SHIELD_BONUS: 50,        // 50 points for shield
+    KEY_BONUS: 50, // 50 points for key
+    EXIT_KEY_BONUS: 75, // 75 points for exit key
+    SWORD_BONUS: 50, // 50 points for sword
+    SHIELD_BONUS: 50, // 50 points for shield
   };
 
   // Grade thresholds (percentage-based) - more forgiving for winning games
   private static readonly GRADE_THRESHOLDS = [
-    { min: 95, grade: 'S+' },
-    { min: 88, grade: 'S' },
-    { min: 80, grade: 'A+' },
-    { min: 72, grade: 'A' },
-    { min: 65, grade: 'B+' },
-    { min: 58, grade: 'B' },
-    { min: 50, grade: 'C+' },
-    { min: 42, grade: 'C' },
-    { min: 30, grade: 'D' },
-    { min: 0, grade: 'F' },
+    { min: 95, grade: "A+" },
+    { min: 88, grade: "A" },
+    { min: 80, grade: "A-" },
+    { min: 72, grade: "B+" },
+    { min: 65, grade: "B" },
+    { min: 58, grade: "B-" },
+    { min: 50, grade: "C+" },
+    { min: 42, grade: "C" },
+    { min: 30, grade: "D" },
+    { min: 0, grade: "F" },
   ];
 
   /**
@@ -69,9 +69,9 @@ export class ScoreCalculator {
    */
   private static calculateMaxScore(enemyCount: number): number {
     const { WEIGHTS } = ScoreCalculator;
-    
+
     // Calculate two scenarios and take the higher one
-    
+
     // Scenario 1: Speed run (minimal combat, under 50 steps)
     let speedRunScore = 0;
     // Assume killing 1-2 enemies max for keys/exit access
@@ -79,21 +79,25 @@ export class ScoreCalculator {
     const speedRunDamage = speedRunEnemies * 2;
     speedRunScore += speedRunDamage * WEIGHTS.DAMAGE_DEALT;
     speedRunScore += speedRunEnemies * WEIGHTS.ENEMY_DEFEATED;
-    speedRunScore += 5 * WEIGHTS.HEALTH_REMAINING;  // Full health
+    speedRunScore += 5 * WEIGHTS.HEALTH_REMAINING; // Full health
     speedRunScore += WEIGHTS.KEY_BONUS + WEIGHTS.EXIT_KEY_BONUS; // Essential items only
     // No step penalty (under 50 steps)
-    
+
     // Scenario 2: Combat run (kill most enemies, accept step penalty)
     let combatScore = 0;
     const averageDamagePerEnemy = 2;
     const maxDamage = enemyCount * averageDamagePerEnemy;
     combatScore += maxDamage * WEIGHTS.DAMAGE_DEALT;
     combatScore += enemyCount * WEIGHTS.ENEMY_DEFEATED;
-    combatScore += 4 * WEIGHTS.HEALTH_REMAINING;  // Slightly damaged from combat
-    combatScore += WEIGHTS.KEY_BONUS + WEIGHTS.EXIT_KEY_BONUS + WEIGHTS.SWORD_BONUS + WEIGHTS.SHIELD_BONUS;
+    combatScore += 4 * WEIGHTS.HEALTH_REMAINING; // Slightly damaged from combat
+    combatScore +=
+      WEIGHTS.KEY_BONUS +
+      WEIGHTS.EXIT_KEY_BONUS +
+      WEIGHTS.SWORD_BONUS +
+      WEIGHTS.SHIELD_BONUS;
     // Assume ~80 steps for thorough exploration (30 step penalty)
     combatScore += 30 * WEIGHTS.STEP_PENALTY;
-    
+
     // Return the higher of the two strategies
     return Math.max(speedRunScore, combatScore);
   }
@@ -102,84 +106,102 @@ export class ScoreCalculator {
    * Calculate comprehensive score for a completed game
    */
   static calculateScore(
-    outcome: 'win' | 'dead',
+    outcome: "win" | "dead",
     heroHealth: number,
     stats: GameStats,
     inventory: GameInventory
   ): ScoreBreakdown {
     const { WEIGHTS } = ScoreCalculator;
-    
+
     // If player died, reduce scoring potential but not too harshly
-    const deathPenalty = outcome === 'dead' ? 0.6 : 1.0;
-    
+    const deathPenalty = outcome === "dead" ? 0.6 : 1.0;
+
     // PATCH: Fix stone-exciter double counting bug
     // If stone-exciter count seems doubled compared to other enemies, halve it
     let adjustedEnemiesDefeated = stats.enemiesDefeated;
     if (stats.byKind) {
-      const stoneCount = (stats.byKind['stone-exciter'] ?? 0);
+      const stoneCount = stats.byKind["stone-exciter"] ?? 0;
       const otherCount = (stats.byKind.goblin ?? 0) + (stats.byKind.ghost ?? 0);
-      
+
       // If stone-exciter count is suspiciously high compared to others, likely doubled
       if (stoneCount > 0 && (stoneCount >= otherCount * 2 || stoneCount > 4)) {
         const correctedStoneCount = Math.ceil(stoneCount / 2);
         const reduction = stoneCount - correctedStoneCount;
-        adjustedEnemiesDefeated = Math.max(0, stats.enemiesDefeated - reduction);
-        
+        adjustedEnemiesDefeated = Math.max(
+          0,
+          stats.enemiesDefeated - reduction
+        );
+
         // Log the correction for debugging
         try {
-          console.log(`Stone-exciter double count detected: ${stoneCount} -> ${correctedStoneCount}, total enemies: ${stats.enemiesDefeated} -> ${adjustedEnemiesDefeated}`);
+          console.log(
+            `Stone-exciter double count detected: ${stoneCount} -> ${correctedStoneCount}, total enemies: ${stats.enemiesDefeated} -> ${adjustedEnemiesDefeated}`
+          );
         } catch {}
       }
     }
-    
+
     // Base combat scoring
     let combatBonus = 0;
     combatBonus += stats.damageDealt * WEIGHTS.DAMAGE_DEALT;
     combatBonus += adjustedEnemiesDefeated * WEIGHTS.ENEMY_DEFEATED;
-    
+
     // No enemy type bonuses - all enemies worth same base amount
-    
+
     // Survival scoring
     let survivalBonus = 0;
-    const healthRemaining = outcome === 'win' ? heroHealth : 0;
+    const healthRemaining = outcome === "win" ? heroHealth : 0;
     survivalBonus += healthRemaining * WEIGHTS.HEALTH_REMAINING;
     survivalBonus += stats.damageTaken * WEIGHTS.DAMAGE_PENALTY;
-    
+
     // Efficiency scoring (penalty only for excessive steps)
     let efficiencyBonus = 0;
     if (stats.steps && stats.steps > 50) {
       // Penalty for taking more than 50 steps
       efficiencyBonus += (stats.steps - 50) * WEIGHTS.STEP_PENALTY;
     }
-    
+
     // Item collection scoring
     let itemBonus = 0;
     if (inventory.hasKey) itemBonus += WEIGHTS.KEY_BONUS;
     if (inventory.hasExitKey) itemBonus += WEIGHTS.EXIT_KEY_BONUS;
     if (inventory.hasSword) itemBonus += WEIGHTS.SWORD_BONUS;
     if (inventory.hasShield) itemBonus += WEIGHTS.SHIELD_BONUS;
-    
+
     // No perfect bonuses - keep scoring simple
     const perfectBonus = 0;
-    
+
     // Base score is combat + survival
     const baseScore = Math.round((combatBonus + survivalBonus) * deathPenalty);
-    
+
     // Apply death penalty to bonuses as well
     const adjustedEfficiencyBonus = Math.round(efficiencyBonus * deathPenalty);
     const adjustedItemBonus = Math.round(itemBonus * deathPenalty);
     const adjustedPerfectBonus = Math.round(perfectBonus * deathPenalty);
-    
+
     // Calculate total score
-    const totalScore = Math.max(0, baseScore + adjustedEfficiencyBonus + adjustedItemBonus + adjustedPerfectBonus);
-    
+    const totalScore = Math.max(
+      0,
+      baseScore +
+        adjustedEfficiencyBonus +
+        adjustedItemBonus +
+        adjustedPerfectBonus
+    );
+
     // Calculate percentage based on actual enemy count (use adjusted count)
-    const maxPossibleScore = ScoreCalculator.calculateMaxScore(adjustedEnemiesDefeated);
-    const percentage = Math.min(100, Math.round((totalScore / maxPossibleScore) * 100));
-    
+    const maxPossibleScore = ScoreCalculator.calculateMaxScore(
+      adjustedEnemiesDefeated
+    );
+    const percentage = Math.min(
+      100,
+      Math.round((totalScore / maxPossibleScore) * 100)
+    );
+
     // Determine grade
-    const grade = ScoreCalculator.GRADE_THRESHOLDS.find(t => percentage >= t.min)?.grade || 'F';
-    
+    const grade =
+      ScoreCalculator.GRADE_THRESHOLDS.find((t) => percentage >= t.min)
+        ?.grade || "F";
+
     return {
       baseScore,
       combatBonus: Math.round(combatBonus * deathPenalty),
@@ -197,7 +219,9 @@ export class ScoreCalculator {
    * Format score for display
    */
   static formatScore(score: ScoreBreakdown): string {
-    return `${score.grade} (${score.percentage}%) - ${score.totalScore.toLocaleString()} pts`;
+    return `${score.grade} (${
+      score.percentage
+    }%) - ${score.totalScore.toLocaleString()} pts`;
   }
 
   /**
@@ -205,13 +229,23 @@ export class ScoreCalculator {
    */
   static getScoreEmoji(grade: string): string {
     switch (grade) {
-      case 'S+': return '🏆';
-      case 'S': return '🥇';
-      case 'A+': case 'A': return '🥈';
-      case 'B+': case 'B': return '🥉';
-      case 'C+': case 'C': return '⭐';
-      case 'D': return '📈';
-      default: return '💪';
+      case "S+":
+        return "🏆";
+      case "S":
+        return "🥇";
+      case "A+":
+      case "A":
+        return "🥈";
+      case "B+":
+      case "B":
+        return "🥉";
+      case "C+":
+      case "C":
+        return "⭐";
+      case "D":
+        return "📈";
+      default:
+        return "💪";
     }
   }
 }

--- a/lib/story/dialogue_registry.ts
+++ b/lib/story/dialogue_registry.ts
@@ -182,6 +182,19 @@ const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
       },
     ],
   },
+  "town-librarian-default": {
+    id: "town-librarian-default",
+    lines: [
+      {
+        speaker: "Librarian",
+        text: "Welcome to the town stacks. I'm the librarian—keeper of maps, rumors, and the quiet between.",
+      },
+      {
+        speaker: "Librarian",
+        text: "If you bring back scraps of history, I'll make space for them on our shelves.",
+      },
+    ],
+  },
 };
 
 export function getDialogueScript(id: string): DialogueScript | undefined {

--- a/lib/story/dialogue_registry.ts
+++ b/lib/story/dialogue_registry.ts
@@ -31,11 +31,15 @@ const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
       },
       {
         speaker: "Elder Rowan",
-        text: "Word will fly through town. They'll ring the chimes tonight when they hear you've returned.",
+        text: "Word will fly through town. They're will be much excitement when they hear you've returned.",
       },
       {
         speaker: "Hero",
-        text: "It was a long climb. Point me where I'm needed next.",
+        text: "It was a long climb out. Point me where I'm needed next.",
+      },
+      {
+        speaker: "Elder Rowan",
+        text: "Caretaker Lysa has always felt the sanctum breathe before the rest of us. What message did she press into your hands?",
       },
     ],
     onCompleteEffects: [{ eventId: "met-elder-rowan", value: true }],
@@ -116,16 +120,16 @@ const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
       },
     ],
   },
-  "caretaker-lysa-overview": {
-    id: "caretaker-lysa-overview",
+  "caretaker-lysa-intro": {
+    id: "caretaker-lysa-intro",
     lines: [
       {
         speaker: "Caretaker Lysa",
-        text: "Breathe. The climb past the sanctum rattles even seasoned delvers.",
+        text: "I sensed you were coming. The sanctum's pulse is strong today.",
       },
       {
         speaker: "Hero",
-        text: "If you've kept these halls standing, I can keep moving forward.",
+        text: "Did it tell you of my experiences?",
       },
       {
         speaker: "Caretaker Lysa",
@@ -168,6 +172,7 @@ const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
         ],
       },
     ],
+    onCompleteEffects: [{ eventId: "met-caretaker-lysa", value: true }],
   },
   "caretaker-lysa-reminder": {
     id: "caretaker-lysa-reminder",

--- a/lib/story/dialogue_registry.ts
+++ b/lib/story/dialogue_registry.ts
@@ -117,54 +117,68 @@ const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
     lines: [
       {
         speaker: "Caretaker Lysa",
-        text: "I sensed you were coming. The sanctum's pulse is strong today.",
+        text: "The sanctum feels wrong today—the pulse carries a weight I don't like.",
       },
       {
         speaker: "Hero",
-        text: "Did it tell you of my experiences?",
+        text: "Are you sure?",
       },
       {
         speaker: "Caretaker Lysa",
-        text: "Then keep your step light and your blade kinder still. Every rescued spirit strengthens us both.",
+        text: "Other feel it too. The town's been uneasy. I sense a growing, negative current from the bluff northeast of the sanctum—stronger by the hour.",
       },
       {
         speaker: "Caretaker Lysa",
-        text: "How should I mark you down before you ascend again?",
+        text: "My companion went to look into it earlier—a boy who tends the inner torches. He hasn't returned.",
+      },
+      {
+        speaker: "Caretaker Lysa",
+        text: "Can you go check on him?",
         options: [
           {
-            id: "promise-caution",
-            prompt: "Promise to stay cautious",
+            id: "get-directions",
+            prompt: "Where should I go?",
             response: [
               {
-                speaker: "Hero",
-                text: "Write that I'll return when the wards are steadied.",
+                speaker: "Caretaker Lysa",
+                text: "Just outside of this sanctum to the northeast. There is a narrow passageway leading to the bluff.",
               },
               {
                 speaker: "Caretaker Lysa",
-                text: "Good. Take this ember charm—let it flare if the sanctum's floor gives way.",
+                text: "If you need supplies you can head into town first. It is a short walk north of here.",
               },
             ],
-            effects: [{ eventId: "heard-lysa-warning", value: true }],
+            effects: [{ eventId: "heard-missing-boy", value: true }],
           },
           {
             id: "ask-for-details",
-            prompt: "Ask for sanctum details",
+            prompt: "What is this place?",
             response: [
               {
-                speaker: "Hero",
-                text: "Tell me what to watch for when the sanctum turns hostile.",
-              },
-              {
                 speaker: "Caretaker Lysa",
-                text: "Listen for the hum in the stones. If it falters, stop. The next tile may be hollow.",
+                text: "This is the sanctum. We monitor the forces in the stones to keep the town safe. Recent vibration have cause concern. This is why you were sent to the caves. We need to understand what is causing the unrest before its too late",
               },
             ],
-            effects: [{ eventId: "heard-lysa-warning", value: true }],
+            effects: [{ eventId: "heard-missing-boy", value: true }],
+          },
+          {
+            id: "confirm",
+            prompt: "I'll go check on the boy",
+            response: [
+              {
+                speaker: "Caretaker Lysa",
+                text: "Thank you! I'll be here when you return.",
+              },
+            ],
+            effects: [{ eventId: "heard-missing-boy", value: true }],
           },
         ],
       },
     ],
-    onCompleteEffects: [{ eventId: "met-caretaker-lysa", value: true }],
+    onCompleteEffects: [
+      { eventId: "met-caretaker-lysa", value: true },
+      { eventId: "heard-missing-boy", value: true },
+    ],
   },
   "caretaker-lysa-reminder": {
     id: "caretaker-lysa-reminder",
@@ -189,6 +203,41 @@ const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
       {
         speaker: "Librarian",
         text: "If you bring back scraps of history, I'll make space for them on our shelves.",
+      },
+    ],
+  },
+  "librarian-default": {
+    id: "librarian-default",
+    lines: [
+      {
+        speaker: "Librarian",
+        text: "Welcome. How can I help you orient yourself?",
+      },
+    ],
+  },
+  "elder-rowan-missing-boy": {
+    id: "elder-rowan-missing-boy",
+    lines: [
+      {
+        speaker: "Elder Rowan",
+        text: "The air has been restless all day. If Lysa sensed the bluff, go—find the boy and return together.",
+      },
+      {
+        speaker: "Elder Rowan",
+        text: "Keep your step steady. Unease is a warning—not a verdict.",
+      },
+    ],
+  },
+  "librarian-missing-boy": {
+    id: "librarian-missing-boy",
+    lines: [
+      {
+        speaker: "Librarian",
+        text: "The boy from the sanctum hasn't returned? The bluff to the northeast… it's not often kind.",
+      },
+      {
+        speaker: "Librarian",
+        text: "Check the path markers north of the hall. If you find notes, bring them here and I'll catalogue the route.",
       },
     ],
   },

--- a/lib/story/dialogue_registry.ts
+++ b/lib/story/dialogue_registry.ts
@@ -31,7 +31,7 @@ const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
       },
       {
         speaker: "Elder Rowan",
-        text: "Word will fly through town. They're will be much excitement when they hear you've returned.",
+        text: "There will be much excitement when they hear you've returned.",
       },
       {
         speaker: "Hero",
@@ -39,7 +39,7 @@ const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
       },
       {
         speaker: "Elder Rowan",
-        text: "Caretaker Lysa has always felt the sanctum breathe before the rest of us. What message did she press into your hands?",
+        text: "Caretaker Lysa is inside the sanctum preparing for your return.",
       },
     ],
     onCompleteEffects: [{ eventId: "met-elder-rowan", value: true }],
@@ -86,15 +86,7 @@ const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
     lines: [
       {
         speaker: "Elder Rowan",
-        text: "Seek Lysa's guidance before you climb beyond the hall. She hears the sanctum's pulse before anyone else.",
-      },
-      {
-        speaker: "Hero",
-        text: "I'll speak with her next.",
-      },
-      {
-        speaker: "Elder Rowan",
-        text: "Good. Return once her warning settles your stride.",
+        text: "Seek Lysa's guidance before you wander beyond the hall. She hears the sanctum's pulse before anyone else.",
       },
     ],
   },
@@ -192,7 +184,7 @@ const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
     lines: [
       {
         speaker: "Librarian",
-        text: "Welcome to the town stacks. I'm the librarian—keeper of maps, rumors, and the quiet between.",
+        text: "Welcome to the town hall. I'm the librarian—keeper of maps, rumors, and the quiet between.",
       },
       {
         speaker: "Librarian",

--- a/lib/story/event_registry.ts
+++ b/lib/story/event_registry.ts
@@ -48,15 +48,16 @@ const STORY_EVENTS: Record<string, StoryEventDefinition> = {
       summary: "Caretaker Lysa is nice.",
     },
   },
-  "heard-lysa-warning": {
-    id: "heard-lysa-warning",
-    description: "Caretaker Lysa shared the sanctum warning.",
+  "heard-missing-boy": {
+    id: "heard-missing-boy",
+    description:
+      "Caretaker Lysa reported her companion (the boy from the sanctum) went missing near the bluff northeast of the sanctum.",
     defaultValue: false,
     diaryEntry: {
-      id: "heard-lysa-warning",
-      title: "Caretaker Lysa's Warning",
+      id: "heard-missing-boy",
+      title: "Missing at the Bluff",
       summary:
-        "Caretaker Lysa warned that the sanctum's wards are thin. Listen for the hum in the stones before climbing east.",
+        "Lysa senses a growing negative pulse from the bluff northeast of the sanctum. Her companion went to investigate and hasn't returned. I should find him.",
     },
   },
   "elder-rowan-acknowledged-warning": {
@@ -72,7 +73,7 @@ const STORY_EVENTS: Record<string, StoryEventDefinition> = {
     },
     diaryUpdates: [
       {
-        entryId: "heard-lysa-warning",
+        entryId: "heard-missing-boy",
         complete: true,
       },
     ],

--- a/lib/story/event_registry.ts
+++ b/lib/story/event_registry.ts
@@ -35,7 +35,17 @@ const STORY_EVENTS: Record<string, StoryEventDefinition> = {
       id: "met-elder-rowan",
       title: "Elder Rowan's Guidance",
       summary:
-        "Elder Rowan told me to trust the glowing floor runes—they reveal safe footing when shadows deceive.",
+        "Elder Rowan told me to talk to Caretaker Lysa about the sanctum's warning.",
+    },
+  },
+  "met-caretaker-lysa": {
+    id: "met-caretaker-lysa",
+    description: "The hero has met Caretaker Lysa for the first time.",
+    defaultValue: false,
+    diaryEntry: {
+      id: "met-caretaker-lysa",
+      title: "Caretaker Lysa's Introduction",
+      summary: "Caretaker Lysa is nice.",
     },
   },
   "heard-lysa-warning": {

--- a/lib/story/npc_script_registry.ts
+++ b/lib/story/npc_script_registry.ts
@@ -12,6 +12,13 @@ export interface NPCDialogueRule {
 }
 
 const NPC_DIALOGUE_RULES: NPCDialogueRule[] = [
+  // Missing boy reactions take precedence where applicable
+  {
+    npcId: "npc-elder-rowan",
+    scriptId: "elder-rowan-missing-boy",
+    priority: 60,
+    conditions: [{ eventId: "heard-missing-boy", value: true }],
+  },
   // Elder Rowan
   {
     npcId: "npc-elder-rowan",
@@ -30,7 +37,7 @@ const NPC_DIALOGUE_RULES: NPCDialogueRule[] = [
     priority: 35,
     conditions: [
       { eventId: "met-elder-rowan", value: true },
-      { eventId: "heard-lysa-warning", value: false },
+      { eventId: "heard-missing-boy", value: false },
     ],
   },
 
@@ -40,7 +47,7 @@ const NPC_DIALOGUE_RULES: NPCDialogueRule[] = [
     priority: 40,
     conditions: [
       { eventId: "met-elder-rowan", value: true },
-      { eventId: "heard-lysa-warning", value: true },
+      { eventId: "heard-missing-boy", value: true },
       { eventId: "elder-rowan-acknowledged-warning", value: false },
     ],
   },
@@ -56,7 +63,7 @@ const NPC_DIALOGUE_RULES: NPCDialogueRule[] = [
   {
     npcId: "npc-grounds-caretaker",
     scriptId: "caretaker-lysa-default",
-    priority: 5,
+    priority: 0,
   },
   {
     npcId: "npc-grounds-caretaker",
@@ -68,8 +75,14 @@ const NPC_DIALOGUE_RULES: NPCDialogueRule[] = [
   // Librarian
   {
     npcId: "npc-librarian",
+    scriptId: "librarian-missing-boy",
+    priority: 15,
+    conditions: [{ eventId: "heard-missing-boy", value: true }],
+  },
+  {
+    npcId: "npc-librarian",
     scriptId: "librarian-default",
-    priority: 5,
+    priority: 0,
   },
 ];
 

--- a/lib/story/npc_script_registry.ts
+++ b/lib/story/npc_script_registry.ts
@@ -12,15 +12,17 @@ export interface NPCDialogueRule {
 }
 
 const NPC_DIALOGUE_RULES: NPCDialogueRule[] = [
+  // Elder Rowan
   {
     npcId: "npc-elder-rowan",
-    scriptId: "elder-rowan-warning-response",
-    priority: 40,
-    conditions: [
-      { eventId: "met-elder-rowan", value: true },
-      { eventId: "heard-lysa-warning", value: true },
-      { eventId: "elder-rowan-acknowledged-warning", value: false },
-    ],
+    scriptId: "elder-rowan-default",
+    priority: 0,
+  },
+  {
+    npcId: "npc-elder-rowan",
+    scriptId: "elder-rowan-intro",
+    priority: 30,
+    conditions: [{ eventId: "met-elder-rowan", value: false }],
   },
   {
     npcId: "npc-elder-rowan",
@@ -31,26 +33,42 @@ const NPC_DIALOGUE_RULES: NPCDialogueRule[] = [
       { eventId: "heard-lysa-warning", value: false },
     ],
   },
+
   {
     npcId: "npc-elder-rowan",
-    scriptId: "elder-rowan-intro",
-    priority: 30,
-    conditions: [{ eventId: "met-elder-rowan", value: false }],
+    scriptId: "elder-rowan-warning-response",
+    priority: 40,
+    conditions: [
+      { eventId: "met-elder-rowan", value: true },
+      { eventId: "heard-lysa-warning", value: true },
+      { eventId: "elder-rowan-acknowledged-warning", value: false },
+    ],
   },
+
   {
     npcId: "npc-elder-rowan",
     scriptId: "elder-rowan-post-warning",
     priority: 20,
     conditions: [{ eventId: "elder-rowan-acknowledged-warning", value: true }],
   },
-  {
-    npcId: "npc-elder-rowan",
-    scriptId: "elder-rowan-default",
-    priority: 0,
-  },
+
+  // Caretaker Lysa
   {
     npcId: "npc-grounds-caretaker",
     scriptId: "caretaker-lysa-default",
+    priority: 5,
+  },
+  {
+    npcId: "npc-grounds-caretaker",
+    scriptId: "caretaker-lysa-intro",
+    priority: 10,
+    conditions: [{ eventId: "met-caretaker-lysa", value: false }],
+  },
+
+  // Librarian
+  {
+    npcId: "npc-librarian",
+    scriptId: "librarian-default",
     priority: 5,
   },
 ];
@@ -65,7 +83,9 @@ export function resolveNpcDialogueScript(
 ): string | undefined {
   const candidates = NPC_DIALOGUE_RULES.filter((rule) => rule.npcId === npcId);
   if (candidates.length === 0) return undefined;
-  const sorted = [...candidates].sort((a, b) => (b.priority ?? 0) - (a.priority ?? 0));
+  const sorted = [...candidates].sort(
+    (a, b) => (b.priority ?? 0) - (a.priority ?? 0)
+  );
   for (const rule of sorted) {
     if (areStoryConditionsMet(flags, rule.conditions)) {
       return rule.scriptId;

--- a/lib/story/story_mode.ts
+++ b/lib/story/story_mode.ts
@@ -21,6 +21,116 @@ function cloneMapData(mapData: MapData): MapData {
   return JSON.parse(JSON.stringify(mapData)) as MapData;
 }
 
+// 10x40 bluff passageway room with right-side lower opening
+function buildBluffPassageway(): StoryRoom {
+  const height = 10;
+  const width = 40;
+  const tiles: number[][] = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => WALL)
+  );
+  const subtypes: number[][][] = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => [] as number[])
+  );
+
+  // Carve interior floor
+  for (let y = 1; y < height - 1; y++) {
+    for (let x = 1; x < width - 1; x++) {
+      tiles[y][x] = FLOOR;
+    }
+  }
+
+  // Create a static interior pattern: a few wall bands and pillars
+  const bands = [3, 6];
+  for (const by of bands) {
+    for (let x = 5; x < width - 5; x++) {
+      if (x % 6 !== 0) continue; // sparse band posts
+      tiles[by][x] = WALL;
+      subtypes[by][x] = [];
+    }
+  }
+  // Pillars near the middle
+  const midY = Math.floor(height / 2);
+  const midX = Math.floor(width / 2);
+  const pillarSpots: Array<[number, number]> = [
+    [midY - 1, midX - 4],
+    [midY + 1, midX - 2],
+    [midY, midX],
+    [midY - 1, midX + 3],
+    [midY + 1, midX + 6],
+  ];
+  for (const [py, px] of pillarSpots) {
+    if (tiles[py]?.[px] !== undefined) {
+      tiles[py][px] = WALL;
+      subtypes[py][px] = [];
+    }
+  }
+
+  // Opening on right wall near bottom
+  const openY = height - 3; // two tiles up from bottom
+  tiles[openY][width - 1] = FLOOR;
+  subtypes[openY][width - 1] = [TileSubtype.ROOM_TRANSITION];
+
+  const entryPoint: [number, number] = [openY, width - 2]; // step inside from right
+  const entryFromNext: [number, number] = [openY, width - 3];
+  const transitionToPrevious: [number, number] = [openY, width - 1];
+
+  // Enemies: 5 snakes and 1 goblin near center
+  const enemies: Enemy[] = [];
+  const enemySpots: Array<[number, number, 'snake' | 'goblin']> = [
+    [midY, midX - 2, 'snake'],
+    [midY - 1, midX, 'snake'],
+    [midY + 1, midX + 1, 'snake'],
+    [midY, midX + 3, 'snake'],
+    [midY + 2, midX - 1, 'snake'],
+    [midY, midX, 'goblin'],
+  ];
+  for (const [y, x, kind] of enemySpots) {
+    if (tiles[y]?.[x] === FLOOR) {
+      const e = new Enemy({ y, x });
+      e.kind = kind;
+      enemies.push(e);
+    }
+  }
+
+  // NPC boy on the far left, with a goblin near him
+  const boyY = midY;
+  const boyX = 1; // far left inside wall
+  const boy = new NPC({
+    id: "npc-sanctum-boy",
+    name: "Sanctum Acolyte",
+    sprite: "/images/npcs/boy-3.png",
+    y: boyY,
+    x: boyX,
+    facing: Direction.RIGHT,
+    canMove: false,
+    interactionHooks: [
+      {
+        id: "boy-greet",
+        type: "dialogue",
+        description: "Check on the boy",
+        payload: { dialogueId: "librarian-default" },
+      },
+    ],
+    actions: ["talk"],
+  });
+  const guardGoblinPos: [number, number] = [Math.max(1, boyY - 1), Math.min(width - 3, boyX + 3)];
+  if (tiles[guardGoblinPos[0]]?.[guardGoblinPos[1]] === FLOOR) {
+    const guard = new Enemy({ y: guardGoblinPos[0], x: guardGoblinPos[1] });
+    guard.kind = 'goblin';
+    enemies.push(guard);
+  }
+
+  return {
+    id: "story-bluff-passage" as RoomId,
+    mapData: { tiles, subtypes, environment: "outdoor" },
+    entryPoint,
+    entryFromNext,
+    transitionToPrevious,
+    enemies,
+    npcs: [boy],
+  };
+}
+
 function withoutPlayer(mapData: MapData): MapData {
   const clone = cloneMapData(mapData);
   for (let y = 0; y < clone.subtypes.length; y++) {
@@ -508,6 +618,12 @@ function buildOutdoorWorld(): StoryRoom {
 
   const npcs: NPC[] = [elder];
 
+  // Carve an opening at the left wall ~3 tiles down from top to lead to the bluff passageway
+  if (tiles[3]?.[0] !== undefined) {
+    tiles[3][0] = FLOOR;
+    subtypes[3][0] = [TileSubtype.ROOM_TRANSITION];
+  }
+
   return {
     id: "story-outdoor-clearing",
     mapData: { tiles, subtypes, environment: "outdoor" },
@@ -520,6 +636,12 @@ function buildOutdoorWorld(): StoryRoom {
         roomId: "story-torch-town" as RoomId,
         position: torchTownTransition,
         returnEntryPoint: torchTownReturn,
+      },
+      // Opening on the left wall near the top leading to the bluff passageway
+      {
+        roomId: "story-bluff-passage" as RoomId,
+        position: [3, 0],
+        returnEntryPoint: [4, 1],
       },
     ],
     npcs,
@@ -880,6 +1002,7 @@ export function buildStoryModeState(): GameState {
   const outdoor = buildOutdoorWorld();
   const outdoorHouse = buildOutdoorHouse();
   const torchTown = buildTorchTown();
+  const bluffPassage = buildBluffPassageway();
 
   // Generic interior room builder: produces an enclosed room with floor size (wOut*2-1) x (hOut*2-1)
   const buildInteriorRoom = (
@@ -1006,6 +1129,20 @@ export function buildStoryModeState(): GameState {
       }
     }
   }
+
+  // Outdoor -> Bluff Passageway transitions
+  pushTransition(
+    outdoor.id,
+    bluffPassage.id,
+    [3, 0],
+    bluffPassage.entryPoint
+  );
+  pushTransition(
+    bluffPassage.id,
+    outdoor.id,
+    bluffPassage.transitionToPrevious!,
+    [4, 1]
+  );
 
   // Build Torch Town interior rooms and transitions
   const extraRooms: StoryRoom[] = [];
@@ -1182,6 +1319,7 @@ export function buildStoryModeState(): GameState {
     ascent,
     sanctum,
     outdoor,
+    bluffPassage,
     outdoorHouse,
     torchTown,
     ...extraRooms,

--- a/lib/story/story_mode.ts
+++ b/lib/story/story_mode.ts
@@ -1033,7 +1033,7 @@ export function buildStoryModeState(): GameState {
     const libNpcY = Math.max(2, libraryRoom.entryPoint[0] - 2);
     const libNpcX = libraryRoom.entryPoint[1];
     const librarian = new NPC({
-      id: "npc-town-librarian",
+      id: "npc-librarian",
       name: "Town Librarian",
       sprite: "/images/npcs/boy-2.png",
       y: libNpcY,

--- a/lib/story/story_mode.ts
+++ b/lib/story/story_mode.ts
@@ -584,21 +584,30 @@ function buildOutdoorHouse(): StoryRoom {
     },
     interactionHooks: [
       {
-        id: "lysa-chat",
+        id: "lysa-intro",
         type: "dialogue",
-        description: "Ask about the outside world",
+        description: "Hear Lysa's introduction",
         payload: {
-          dialogueId: "caretaker-lysa-default",
+          dialogueId: "caretaker-lysa-intro",
         },
       },
-      {
-        id: "lysa-rest",
-        type: "custom",
-        description: "Request a moment of rest",
-        payload: {
-          action: "rest",
-        },
-      },
+      // {
+      //   id: "lysa-chat",
+      //   type: "dialogue",
+      //   description: "Listen to Lysa's song",
+      //   payload: {
+      //     dialogueId: "caretaker-lysa-default",
+      //   },
+      // },
+
+      // {
+      //   id: "lysa-rest",
+      //   type: "custom",
+      //   description: "Request a moment of rest",
+      //   payload: {
+      //     action: "rest",
+      //   },
+      // },
     ],
     actions: ["talk", "rest"],
     metadata: {
@@ -704,7 +713,10 @@ function buildTorchTown(): StoryRoom {
     const doorRow = top + height - 1;
     const doorCol = left + Math.floor(width / 2);
     // Mark building door as both a door and a room transition entry point
-    subtypes[doorRow][doorCol] = [TileSubtype.DOOR, TileSubtype.ROOM_TRANSITION];
+    subtypes[doorRow][doorCol] = [
+      TileSubtype.DOOR,
+      TileSubtype.ROOM_TRANSITION,
+    ];
 
     return [doorRow, doorCol];
   };
@@ -722,8 +734,10 @@ function buildTorchTown(): StoryRoom {
   // Library: taller building, placed near upper third
   const libraryWidth = 3;
   const libraryHeight = 5;
-  const libraryTop = innerMin + Math.max(2, Math.floor((innerMax - innerMin) / 6));
-  const libraryLeft = innerMin + Math.floor((innerMax - innerMin - libraryWidth) / 2);
+  const libraryTop =
+    innerMin + Math.max(2, Math.floor((innerMax - innerMin) / 6));
+  const libraryLeft =
+    innerMin + Math.floor((innerMax - innerMin - libraryWidth) / 2);
   const libraryDoor = buildStructure(
     libraryTop,
     libraryLeft,
@@ -734,7 +748,10 @@ function buildTorchTown(): StoryRoom {
   // Store: shorter building, placed below library with more spacing
   const storeWidth = 3;
   const storeHeight = 3;
-  const storeTop = Math.min(innerMax - storeHeight - 2, libraryTop + libraryHeight + 8);
+  const storeTop = Math.min(
+    innerMax - storeHeight - 2,
+    libraryTop + libraryHeight + 8
+  );
   const storeLeft = libraryLeft;
   const storeDoor = buildStructure(
     storeTop,
@@ -762,7 +779,8 @@ function buildTorchTown(): StoryRoom {
   const isAreaFree = (top: number, left: number, w: number, h: number) => {
     for (let y = top; y < top + h; y++) {
       for (let x = left; x < left + w; x++) {
-        if (y < innerMin || y > innerMax || x < innerMin || x > innerMax) return false;
+        if (y < innerMin || y > innerMax || x < innerMin || x > innerMax)
+          return false;
         if (tiles[y]?.[x] !== FLOOR) return false; // something already occupies this spot
       }
     }
@@ -770,11 +788,13 @@ function buildTorchTown(): StoryRoom {
   };
   // Base rows (structured), then apply small jitter so they aren't in straight lines
   const baseRows: number[] = [];
-  for (let y = innerMin + 4; y <= innerMax - homeHeight - 4; y += 5) baseRows.push(y);
+  for (let y = innerMin + 4; y <= innerMax - homeHeight - 4; y += 5)
+    baseRows.push(y);
   const leftColBase = innerMin + 3;
   const rightColBase = innerMax - homeWidth - 3;
 
-  const jitter = (range: number) => (Math.floor(Math.random() * (2 * range + 1)) - range);
+  const jitter = (range: number) =>
+    Math.floor(Math.random() * (2 * range + 1)) - range;
   const candidates: Array<{ top: number; left: number }> = [];
   for (const baseTop of baseRows) {
     // Left column home
@@ -790,10 +810,17 @@ function buildTorchTown(): StoryRoom {
     // Apply small jitter (±2 tiles) and clamp inside bounds
     const dy = jitter(2);
     const dx = jitter(2);
-    let top = Math.max(innerMin + 2, Math.min(innerMax - homeHeight - 2, base.top + dy));
-    let left = Math.max(innerMin + 2, Math.min(innerMax - homeWidth - 2, base.left + dx));
+    let top = Math.max(
+      innerMin + 2,
+      Math.min(innerMax - homeHeight - 2, base.top + dy)
+    );
+    let left = Math.max(
+      innerMin + 2,
+      Math.min(innerMax - homeWidth - 2, base.left + dx)
+    );
     // Keep a little breathing room from the center plaza
-    const tooCloseToCenter = Math.abs(top - centerY) <= 2 && Math.abs(left - centerX) <= 2;
+    const tooCloseToCenter =
+      Math.abs(top - centerY) <= 2 && Math.abs(left - centerX) <= 2;
     if (tooCloseToCenter) continue;
     if (!isAreaFree(top, left, homeWidth, homeHeight)) {
       // Try a couple nearby fallbacks without randomness explosion
@@ -806,18 +833,24 @@ function buildTorchTown(): StoryRoom {
       let placed = false;
       for (const [fy, fx] of fallbackSpots) {
         if (
-          fy >= innerMin + 2 && fy <= innerMax - homeHeight - 2 &&
-          fx >= innerMin + 2 && fx <= innerMax - homeWidth - 2 &&
+          fy >= innerMin + 2 &&
+          fy <= innerMax - homeHeight - 2 &&
+          fx >= innerMin + 2 &&
+          fx <= innerMax - homeWidth - 2 &&
           !(Math.abs(fy - centerY) <= 2 && Math.abs(fx - centerX) <= 2) &&
           isAreaFree(fy, fx, homeWidth, homeHeight)
         ) {
-          top = fy; left = fx; placed = true; break;
+          top = fy;
+          left = fx;
+          placed = true;
+          break;
         }
       }
       if (!placed) continue;
     }
     const door = buildStructure(top, left, homeWidth, homeHeight);
-    homeAssignments[`${door[0]},${door[1]}`] = homeLastNames[homesPlaced] ?? `Family ${homesPlaced+1}`;
+    homeAssignments[`${door[0]},${door[1]}`] =
+      homeLastNames[homesPlaced] ?? `Family ${homesPlaced + 1}`;
     homesPlaced++;
   }
 
@@ -985,7 +1018,8 @@ export function buildStoryModeState(): GameState {
         homeSize: [number, number];
       }
     | undefined;
-  const torchTownHomes = (torchTown.metadata?.homes as Record<string, string>) || {};
+  const torchTownHomes =
+    (torchTown.metadata?.homes as Record<string, string>) || {};
 
   if (torchTownBuildings) {
     // Library interior (environment uses 'house' palette for now)
@@ -1070,14 +1104,22 @@ export function buildStoryModeState(): GameState {
     let homeIdx = 0;
     for (const key of Object.keys(torchTownHomes)) {
       const [yStr, xStr] = key.split(",");
-      const doorPos: [number, number] = [parseInt(yStr, 10), parseInt(xStr, 10)];
-      const homeId = (`story-torch-town-home-${homeIdx}`) as RoomId;
+      const doorPos: [number, number] = [
+        parseInt(yStr, 10),
+        parseInt(xStr, 10),
+      ];
+      const homeId = `story-torch-town-home-${homeIdx}` as RoomId;
       const homeRoom = buildInteriorRoom(homeId, homeW, homeH, "house");
       extraRooms.push(homeRoom);
       pushTransition(torchTown.id, homeRoom.id, doorPos, homeRoom.entryPoint);
       // Land outside each home door when exiting interior
       const homeExitTarget: [number, number] = [doorPos[0] + 1, doorPos[1]];
-      pushTransition(homeRoom.id, torchTown.id, homeRoom.transitionToPrevious!, homeExitTarget);
+      pushTransition(
+        homeRoom.id,
+        torchTown.id,
+        homeRoom.transitionToPrevious!,
+        homeExitTarget
+      );
       homeIdx += 1;
     }
   }


### PR DESCRIPTION
## Summary
- open the top-right exit from the outdoor clearing and register a transition toward Torch Town
- build a 25x25 Torch Town map with a thick perimeter wall, library, store, and uniquely named homes
- persist Torch Town metadata in story room snapshots so future systems can reference house assignments

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d4172d7f58832dae440683c6e573db