### PR TITLE
Add road overlays and Torch Town path

### DIFF
--- a/__tests__/components/Tile.test.tsx
+++ b/__tests__/components/Tile.test.tsx
@@ -131,7 +131,7 @@ describe('Tile component', () => {
   it('should render asset-based icons for special subtypes', () => {
     const mockTileType = { id: 0, name: 'floor', color: '#ccc', walkable: true };
     render(<Tile tileId={0} tileType={mockTileType} subtype={[
-      TileSubtype.LIGHTSWITCH, 
+      TileSubtype.LIGHTSWITCH,
       TileSubtype.OPEN_CHEST,
       TileSubtype.KEY,
       TileSubtype.EXITKEY,
@@ -163,6 +163,29 @@ describe('Tile component', () => {
     expect(doorIcon.className).toContain('fullHeightAssetIcon');
     expect(exitIcon.className).toContain('exitIcon');
     expect(exitIcon.className).toContain('fullHeightAssetIcon');
+  });
+
+  it('renders a dirt road overlay with the correct asset and rotation', () => {
+    const mockTileType = { id: 0, name: 'floor', color: '#ccc', walkable: true };
+    render(
+      <Tile
+        tileId={0}
+        tileType={mockTileType}
+        subtype={[
+          TileSubtype.ROAD,
+          TileSubtype.ROAD_STRAIGHT,
+          TileSubtype.ROAD_ROTATE_90,
+        ]}
+        isVisible={true}
+      />
+    );
+
+    const roadOverlay = screen.getByTestId('road-overlay');
+    expect(roadOverlay).toBeInTheDocument();
+    expect(roadOverlay).toHaveStyle(
+      "background-image: url(/images/floor/dirt-road-i.png)"
+    );
+    expect(roadOverlay).toHaveStyle('transform: rotate(90deg)');
   });
 
   it('should not display content when subtype is empty array', () => {

--- a/components/PreloadImages.tsx
+++ b/components/PreloadImages.tsx
@@ -18,6 +18,10 @@ export default function PreloadImages() {
       "/images/floor/outdoor-floor-1000.png",
       "/images/floor/in-house-floor-0000.png",
       "/images/floor/in-house-floor-1000.png",
+      "/images/floor/dirt-road-i.png",
+      "/images/floor/dirt-road-r.png",
+      "/images/floor/dirt-road-t.png",
+      "/images/floor/dirt-road-end.png",
 
       // Walls (all 8 NESW variants implemented)
       "/images/wall/wall-0000.png",

--- a/components/Tile.module.css
+++ b/components/Tile.module.css
@@ -192,6 +192,18 @@
   margin: auto;
 }
 
+.roadOverlay {
+  position: absolute;
+  inset: 0;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: contain;
+  image-rendering: pixelated;
+  pointer-events: none;
+  z-index: 1010;
+  transform-origin: 50% 50%;
+}
+
 /* Special full-height asset icon for doors */
 .fullHeightAssetIcon {
   width: 28px;

--- a/lib/assets_manifest.ts
+++ b/lib/assets_manifest.ts
@@ -35,6 +35,10 @@ export const ASSET_URLS: string[] = [
   "/images/floor/outdoor-floor-1000.png",
   "/images/floor/in-house-floor-0000.png",
   "/images/floor/in-house-floor-1000.png",
+  "/images/floor/dirt-road-i.png",
+  "/images/floor/dirt-road-r.png",
+  "/images/floor/dirt-road-t.png",
+  "/images/floor/dirt-road-end.png",
 
   // Remaining walls
   "/images/wall/wall-0000.png",

--- a/lib/map/constants.ts
+++ b/lib/map/constants.ts
@@ -59,6 +59,14 @@ export enum TileSubtype {
   CHECKPOINT = 22,
   WINDOW = 23,
   CAVE_OPENING = 24,
+  ROAD = 25,
+  ROAD_STRAIGHT = 26,
+  ROAD_CORNER = 27,
+  ROAD_T = 28,
+  ROAD_END = 29,
+  ROAD_ROTATE_90 = 30,
+  ROAD_ROTATE_180 = 31,
+  ROAD_ROTATE_270 = 32,
 }
 
 /**


### PR DESCRIPTION
## Summary
- add dedicated road tile subtypes and render an overlaid dirt road sprite with rotation-aware variants
- preload and register the new dirt road assets for caching
- extend Torch Town with a starter road from the south gate to the central plaza and cover the overlay rendering with a test

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da1b59e81c832d84717d689a4f3b0b