### PR TITLE
Animate hero slide with map transitions

### DIFF
--- a/components/Tile.module.css
+++ b/components/Tile.module.css
@@ -549,6 +549,11 @@
   bottom: 0;
   z-index: 11000; /* Above torches/enemies but below wall-top overlays */
   background-color: transparent; /* Make sure background is transparent */
+  will-change: transform;
+}
+
+.heroImageSliding {
+  transition: transform 0.3s ease-out;
 }
 
 .npcImage {


### PR DESCRIPTION
## Summary
- track hero tile offsets and trigger slide animations whenever the player position changes
- pass movement offsets into the Tile component and compose transforms so the hero sprite translates smoothly
- add CSS transition styling for the hero image to keep the sprite sliding in sync with the map shift

## Testing
- npm test -- Tile

------
https://chatgpt.com/codex/tasks/task_e_68da2047ae0c832db9dc736e4e0252ff