### PR TITLE
Add about panel to daily completion screen

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -10,6 +10,71 @@
   letter-spacing: 0.5px;
 }
 
+.pixel-button {
+  font-family: 'Press Start 2P', 'VT323', monospace !important;
+  background: linear-gradient(#2b2540, #1c1830);
+  color: #f5f3ff;
+  border: 4px solid #8b7fe0;
+  box-shadow:
+    0 0 0 4px #0d0b1a,
+    inset 0 0 0 2px rgba(255, 255, 255, 0.12);
+  padding: 0.75rem 1rem;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+  image-rendering: pixelated;
+}
+
+.pixel-button:hover {
+  transform: translateY(-1px);
+  box-shadow:
+    0 0 0 4px #0d0b1a,
+    0 6px 0 0 rgba(0, 0, 0, 0.35),
+    inset 0 0 0 2px rgba(255, 255, 255, 0.18);
+}
+
+.pixel-button:active {
+  transform: translateY(1px);
+  box-shadow:
+    0 0 0 4px #0d0b1a,
+    inset 0 0 0 2px rgba(255, 255, 255, 0.1);
+}
+
+.pixel-button:focus-visible {
+  outline: 2px solid #f9d65c;
+  outline-offset: 4px;
+}
+
+.pixel-window {
+  font-family: 'Press Start 2P', 'VT323', monospace !important;
+  background: linear-gradient(#1f1d2d, #161225);
+  color: #f5f3ff;
+  border: 4px solid #8b7fe0;
+  box-shadow: 0 0 0 4px #0d0b1a;
+  padding: 1.25rem;
+  max-width: 20rem;
+  image-rendering: pixelated;
+}
+
+.pixel-window p {
+  margin: 0 0 0.75rem;
+  line-height: 1.6;
+}
+
+.pixel-window p:last-of-type {
+  margin-bottom: 0;
+}
+
+.pixel-window a {
+  color: #9ad1ff;
+  text-decoration: underline;
+}
+
+.pixel-window a:hover {
+  color: #c0e6ff;
+}
+
 :root {
   --background: #1B1B1B;
   --foreground: #ededed;

--- a/components/daily/DailyCompleted.tsx
+++ b/components/daily/DailyCompleted.tsx
@@ -63,8 +63,6 @@ export default function DailyCompleted({ data }: DailyCompletedProps) {
   const isWin = todayResult === "won";
   const [copied, setCopied] = useState(false);
 
-  const [showAbout, setShowAbout] = useState(false);
-
   useEffect(() => {
     try {
       Analytics.trackDailyChallenge?.("completed", {
@@ -576,32 +574,37 @@ export default function DailyCompleted({ data }: DailyCompletedProps) {
         </div>
       </div>
 
-      <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-3">
-        {showAbout && (
-          <div
-            className="pixel-window pixel-text text-xs leading-relaxed flex flex-col gap-3 max-w-xs"
-            role="dialog"
-            id="about-torch-boy"
-            aria-label="About Torch Boy"
-          >
-            <p>Torch Boy was made by Chris Dornink, a web developer out of Seattle, Washington.</p>
-            <p>Hire me to craft your next adventure-ready experience.</p>
-            <div className="flex flex-col gap-2 text-[11px]">
-              <a href="https://chrisdornink.com" target="_blank" rel="noreferrer">Visit chrisdornink.com</a>
-              <a href="https://www.linkedin.com/in/chrisdornink/" target="_blank" rel="noreferrer">Connect on LinkedIn</a>
-              <a href="https://github.com/chrisdornink/dungeon-tiler" target="_blank" rel="noreferrer">View the GitHub repository</a>
-            </div>
+      <div className="max-w-2xl mx-auto mt-8">
+        <div className="pixel-window pixel-text text-xs leading-relaxed flex flex-col gap-3">
+          <p>
+            Torch Boy was made by Chris Dornink, a web developer out of Seattle,
+            Washington.
+          </p>
+          <p>Hire me to craft your next adventure-ready experience.</p>
+          <div className="flex flex-col gap-2 text-[11px]">
+            <a
+              href="https://chrisdornink.com"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Visit chrisdornink.com
+            </a>
+            <a
+              href="https://www.linkedin.com/in/chrisdornink/"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Connect on LinkedIn
+            </a>
+            <a
+              href="https://github.com/chrisdornink/dungeon-tiler"
+              target="_blank"
+              rel="noreferrer"
+            >
+              View the GitHub repository
+            </a>
           </div>
-        )}
-        <button
-          type="button"
-          onClick={() => setShowAbout((prev) => !prev)}
-          className="pixel-button pixel-text text-[10px] leading-none"
-          aria-expanded={showAbout}
-          aria-controls={showAbout ? "about-torch-boy" : undefined}
-        >
-          {showAbout ? 'Close' : 'About Torch Boy'}
-        </button>
+        </div>
       </div>
     </div>
   );

--- a/components/daily/DailyCompleted.tsx
+++ b/components/daily/DailyCompleted.tsx
@@ -63,6 +63,8 @@ export default function DailyCompleted({ data }: DailyCompletedProps) {
   const isWin = todayResult === "won";
   const [copied, setCopied] = useState(false);
 
+  const [showAbout, setShowAbout] = useState(false);
+
   useEffect(() => {
     try {
       Analytics.trackDailyChallenge?.("completed", {
@@ -572,6 +574,34 @@ export default function DailyCompleted({ data }: DailyCompletedProps) {
             )}
           </div>
         </div>
+      </div>
+
+      <div className="fixed bottom-6 right-6 z-50 flex flex-col items-end gap-3">
+        {showAbout && (
+          <div
+            className="pixel-window pixel-text text-xs leading-relaxed flex flex-col gap-3 max-w-xs"
+            role="dialog"
+            id="about-torch-boy"
+            aria-label="About Torch Boy"
+          >
+            <p>Torch Boy was made by Chris Dornink, a web developer out of Seattle, Washington.</p>
+            <p>Hire me to craft your next adventure-ready experience.</p>
+            <div className="flex flex-col gap-2 text-[11px]">
+              <a href="https://chrisdornink.com" target="_blank" rel="noreferrer">Visit chrisdornink.com</a>
+              <a href="https://www.linkedin.com/in/chrisdornink/" target="_blank" rel="noreferrer">Connect on LinkedIn</a>
+              <a href="https://github.com/chrisdornink/dungeon-tiler" target="_blank" rel="noreferrer">View the GitHub repository</a>
+            </div>
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={() => setShowAbout((prev) => !prev)}
+          className="pixel-button pixel-text text-[10px] leading-none"
+          aria-expanded={showAbout}
+          aria-controls={showAbout ? "about-torch-boy" : undefined}
+        >
+          {showAbout ? 'Close' : 'About Torch Boy'}
+        </button>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add a fixed pixel-styled about button to the daily completion screen that reveals hiring information and external links
- create reusable pixel-button and pixel-window styles to match the retro presentation layer

## Testing
- Unable to run `npm run lint` (missing npm/node in environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd5202359c832d964398310fc9dc57