### PR TITLE
Add golden dog NPC that follows the hero

### DIFF
--- a/components/Tile.tsx
+++ b/components/Tile.tsx
@@ -11,6 +11,7 @@ import {
   getFloorAsset,
   getWallAsset,
 } from "../lib/environment";
+import HeartPopAnimation from "./HeartPopAnimation";
 
 type NeighborInfo = {
   top: number | null;
@@ -794,6 +795,19 @@ export const Tile: React.FC<TileProps> = ({
   })();
   const showNpcPrompt = shouldShowNpc && npcInteractable;
 
+  const isDogNpc = (() => {
+    if (!npc) return false;
+    if (Array.isArray(npc.tags) && npc.tags.includes('dog')) return true;
+    const metadata = npc.metadata as Record<string, unknown> | undefined;
+    const typeValue = metadata?.['type'];
+    if (typeof typeValue === 'string' && typeValue === 'dog') return true;
+    const speciesValue = metadata?.['species'];
+    return typeof speciesValue === 'string' && speciesValue === 'dog';
+  })();
+  const dogHeartTrigger = isDogNpc ? npc?.memory?.['dogHeartTriggerId'] : undefined;
+  const showDogHeart =
+    isDogNpc && typeof dogHeartTrigger === 'number' && dogHeartTrigger > 0;
+
   // If this is a floor tile
   if (tileId === 0) {
     // Floor tiles - only visible if within player's field of view
@@ -910,6 +924,13 @@ export const Tile: React.FC<TileProps> = ({
               }}
               aria-hidden="true"
               data-testid="npc-sprite"
+            />
+          )}
+          {shouldShowNpc && npc && showDogHeart && (
+            <HeartPopAnimation
+              key={`${npc.id}-heart-${dogHeartTrigger}`}
+              isTriggered={true}
+              className="left-1/2 top-0 -translate-x-1/2 -translate-y-2"
             />
           )}
           {showNpcPrompt && (

--- a/lib/assets_manifest.ts
+++ b/lib/assets_manifest.ts
@@ -134,4 +134,10 @@ export const ASSET_URLS: string[] = [
   "/images/npcs/girl-2.png",
   "/images/npcs/girl-3.png",
   "/images/npcs/girl-4.png",
+  "/images/dog-golden/dog-front-1.png",
+  "/images/dog-golden/dog-front-2.png",
+  "/images/dog-golden/dog-front-3.png",
+  "/images/dog-golden/dog-front-4.png",
+  "/images/dog-golden/dog-back-1.png",
+  "/images/dog-golden/dog-back-2.png",
 ];

--- a/lib/story/rooms/chapter1/torch_town.ts
+++ b/lib/story/rooms/chapter1/torch_town.ts
@@ -550,6 +550,34 @@ export function buildTorchTown(): StoryRoom {
     metadata: { dayLocation: "plaza", nightLocation: "house7", house: HOUSE_LABELS.HOUSE_7 },
   }));
 
+  // 19. Brisket (Golden Dog) - Day: Plaza near Tavi
+  npcs.push(new NPC({
+    id: "npc-dog-torch-town",
+    name: "Brisket",
+    sprite: "/images/dog-golden/dog-front-1.png",
+    y: 14,
+    x: 13,
+    facing: Direction.DOWN,
+    canMove: true,
+    tags: ["dog"],
+    metadata: {
+      type: "dog",
+      species: "dog",
+      dayLocation: "plaza",
+      dogFollowChance: 0.75,
+      dogFrontFrames: [
+        "/images/dog-golden/dog-front-1.png",
+        "/images/dog-golden/dog-front-2.png",
+        "/images/dog-golden/dog-front-3.png",
+        "/images/dog-golden/dog-front-4.png",
+      ],
+      dogBackFrames: [
+        "/images/dog-golden/dog-back-1.png",
+        "/images/dog-golden/dog-back-2.png",
+      ],
+    },
+  }));
+
   return {
     id: "story-torch-town",
     mapData: { tiles, subtypes, environment: "outdoor" },
@@ -583,6 +611,7 @@ export function buildTorchTown(): StoryRoom {
         "npc-dara": { removeWhen: [{ timeOfDay: "night" }] },
         "npc-fenna": { removeWhen: [{ timeOfDay: "night" }] },
         "npc-tavi": { removeWhen: [{ timeOfDay: "night" }] },
+        "npc-dog-torch-town": { removeWhen: [{ timeOfDay: "night" }] },
         "npc-arin": { removeWhen: [{ timeOfDay: "night" }] },
         "npc-haro": { removeWhen: [{ timeOfDay: "night" }] },
         "npc-len": { removeWhen: [{ timeOfDay: "night" }] },


### PR DESCRIPTION
## Summary
- add the new golden dog NPC to Torch Town and preload its sprite set
- update NPC handling so dog companions pursue the hero and trigger a pet heart effect when bumped
- render heart pop animations for dog NPCs so the affection feedback is visible in game

## Testing
- npm test -- --runTestsByPath __tests__/components/Tile.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68f661c5e330832da41ff48ebd5b06d9