### PR TITLE
Snake pots: obvious rattle + break-from-range releases contents

### DIFF
--- a/__tests__/components/Tile.test.tsx
+++ b/__tests__/components/Tile.test.tsx
@@ -431,4 +431,42 @@ describe('Tile component', () => {
       expect(enemySprite).toBeInTheDocument();
     });
   });
+
+  describe('snake pot rendering', () => {
+    const mockTileType = { id: 0, name: 'floor', color: '#ccc', walkable: true };
+
+    it('applies the rattle animation class and a per-tile delay to a snake pot', () => {
+      render(
+        <Tile
+          tileId={0}
+          tileType={mockTileType}
+          subtype={[TileSubtype.POT, TileSubtype.SNAKE]}
+          row={5}
+          col={5}
+        />
+      );
+
+      const potIcon = screen.getByTestId(`subtype-icon-${TileSubtype.POT}`);
+      // Wiggle/rattle animation class is present so the pot visibly shakes.
+      expect(potIcon.className).toContain('potIconSnake');
+      // A non-empty per-tile delay desyncs pots from each other.
+      expect(potIcon.style.getPropertyValue('--snake-pot-delay')).toMatch(/\ds$/);
+    });
+
+    it('does not apply the rattle class to an ordinary pot', () => {
+      render(
+        <Tile
+          tileId={0}
+          tileType={mockTileType}
+          subtype={[TileSubtype.POT]}
+          row={5}
+          col={5}
+        />
+      );
+
+      const potIcon = screen.getByTestId(`subtype-icon-${TileSubtype.POT}`);
+      expect(potIcon.className).not.toContain('potIconSnake');
+      expect(potIcon.style.getPropertyValue('--snake-pot-delay')).toBe('');
+    });
+  });
 });

--- a/__tests__/lib/snake_pot_ranged.test.ts
+++ b/__tests__/lib/snake_pot_ranged.test.ts
@@ -11,14 +11,16 @@ import type { MapData } from "../../lib/map/types";
 import { Enemy } from "../../lib/enemy";
 
 /**
- * Destroying a snake pot from range (rock, rune, or bomb) should kill the coiled
- * snake before it can ambush AND give the player clear credit: the POT+SNAKE tags
- * are cleared, the kill counts in stats (toward the snake/rock badges), and for
- * rock/rune the tile is added to recentDeaths so a spirit rises from the broken
- * pot. No live snake enemy should spawn and the hero should take no damage/poison.
+ * Ranged interactions with a pot (POT, optionally + SNAKE / + RUNE / food).
  *
- * Regression guard for the prior bug where a thrown rock silently stripped the POT
- * tag, leaving an invisible orphaned SNAKE tag and giving zero feedback.
+ * A thrown ROCK or RUNE BREAKS the pot but does NOT destroy what's inside — the
+ * contents are released onto the tile: a snake slithers out as a live enemy (no
+ * free ambush bite, since you broke it from a distance), and runes/food are left
+ * on the floor to pick up. A BOMB blast, being an explosion, obliterates the pot
+ * and kills the snake outright.
+ *
+ * Regression guard for the earlier behavior where a thrown rock silently deleted
+ * the snake and the pot's food.
  */
 
 function makeCorridor(py: number, px: number, size = 12): MapData {
@@ -59,40 +61,58 @@ function baseState(mapData: MapData, overrides: Partial<GameState> = {}): GameSt
   };
 }
 
-describe("Rock destroys a snake pot", () => {
-  it("clears both tags, credits a snake kill, records the death, and leaves no live snake", () => {
+describe("Rock breaks a snake pot", () => {
+  it("releases the snake as a live enemy without an ambush, and does not count as a kill", () => {
     const py = 5,
       px = 5;
     const map = makeCorridor(py, px);
     map.subtypes[py][px + 3] = [TileSubtype.POT, TileSubtype.SNAKE];
 
-    const after = performThrowRock(
-      baseState(map, { rockCount: 2, currentFloor: 2 })
-    );
+    const after = performThrowRock(baseState(map, { rockCount: 2 }));
 
     const tile = after.mapData.subtypes[py][px + 3];
-    // Both the pot and the (invisible) snake marker are gone — no orphan tag.
+    // Pot shattered, snake no longer hidden inside.
     expect(tile).not.toContain(TileSubtype.POT);
     expect(tile).not.toContain(TileSubtype.SNAKE);
-    // Rock consumed, none placed on the pot tile.
+    expect(tile).not.toContain(TileSubtype.ROCK);
     expect(after.rockCount).toBe(1);
     expect(after.stats.rocksThrown).toBe(1);
-    expect(tile).not.toContain(TileSubtype.ROCK);
-    // Kill credited like any snake rock kill.
-    expect(after.stats.enemiesDefeated).toBe(1);
-    expect(after.stats.enemiesKilledByRock).toBe(1);
-    expect(after.stats.damageDealt).toBe(2);
-    expect(after.stats.byKind?.snake).toBe(1);
-    expect(after.stats.byFloor?.[2]?.snake).toBe(1);
-    // Spirit VFX feedback: the tile is registered as a death this tick.
-    expect(after.recentDeaths).toContainEqual([py, px + 3]);
-    // The latent snake never becomes a live enemy and the hero is unharmed.
-    expect(after.enemies?.length ?? 0).toBe(0);
+    // The snake slithered out as a live enemy at the pot tile.
+    expect(after.enemies).toHaveLength(1);
+    expect(after.enemies?.[0]?.kind).toBe("snake");
+    expect(after.enemies?.[0]?.y).toBe(py);
+    expect(after.enemies?.[0]?.x).toBe(px + 3);
+    // Breaking it from range is NOT a kill: no credit, no spirit.
+    expect(after.stats.enemiesDefeated).toBe(0);
+    expect(after.stats.byKind?.snake ?? 0).toBe(0);
+    expect(after.recentDeaths ?? []).toHaveLength(0);
+    // No free ambush bite or poison — the player is at a distance.
     expect(after.heroHealth).toBe(5);
     expect(after.conditions?.poisoned?.active ?? false).toBe(false);
   });
+});
 
-  it("does not award a snake kill for an ordinary (non-snake) pot", () => {
+describe("Rock breaks an ordinary pot", () => {
+  it("reveals the pot's item on the floor instead of destroying it (deterministic override)", () => {
+    const py = 5,
+      px = 5;
+    const map = makeCorridor(py, px);
+    map.subtypes[py][px + 3] = [TileSubtype.POT];
+    const key = `${py},${px + 3}`;
+
+    const after = performThrowRock(
+      baseState(map, { rockCount: 1, potOverrides: { [key]: TileSubtype.FOOD } })
+    );
+
+    const tile = after.mapData.subtypes[py][px + 3];
+    expect(tile).not.toContain(TileSubtype.POT);
+    expect(tile).toContain(TileSubtype.FOOD);
+    expect(after.rockCount).toBe(0);
+    // The reveal override is consumed.
+    expect(after.potOverrides?.[key]).toBeUndefined();
+  });
+
+  it("reveals a food or potion even without an override (contents are never destroyed)", () => {
     const py = 5,
       px = 5;
     const map = makeCorridor(py, px);
@@ -100,70 +120,72 @@ describe("Rock destroys a snake pot", () => {
 
     const after = performThrowRock(baseState(map, { rockCount: 1 }));
 
-    expect(after.mapData.subtypes[py][px + 3]).not.toContain(TileSubtype.POT);
-    expect(after.stats.enemiesDefeated).toBe(0);
-    expect(after.stats.byKind?.snake ?? 0).toBe(0);
-    expect(after.recentDeaths ?? []).toHaveLength(0);
+    const tile = after.mapData.subtypes[py][px + 3];
+    expect(tile).not.toContain(TileSubtype.POT);
+    expect(
+      tile.includes(TileSubtype.FOOD) || tile.includes(TileSubtype.MED)
+    ).toBe(true);
+  });
+
+  it("reveals the rune from a rune pot", () => {
+    const py = 5,
+      px = 5;
+    const map = makeCorridor(py, px);
+    map.subtypes[py][px + 3] = [TileSubtype.POT, TileSubtype.RUNE];
+
+    const after = performThrowRock(baseState(map, { rockCount: 1 }));
+
+    const tile = after.mapData.subtypes[py][px + 3];
+    expect(tile).not.toContain(TileSubtype.POT);
+    expect(tile).toContain(TileSubtype.RUNE);
   });
 });
 
-describe("Rune destroys a snake pot", () => {
-  it("clears both tags, credits a snake kill, drops the rune in front, and records the death", () => {
+describe("Rune breaks a snake pot", () => {
+  it("releases the snake and drops the thrown rune in front (no kill)", () => {
     const py = 5,
       px = 5;
     const map = makeCorridor(py, px);
     map.subtypes[py][px + 3] = [TileSubtype.POT, TileSubtype.SNAKE];
 
-    const after = performThrowRune(
-      baseState(map, { runeCount: 1, currentFloor: 3 })
-    );
+    const after = performThrowRune(baseState(map, { runeCount: 1, currentFloor: 3 }));
 
     const tile = after.mapData.subtypes[py][px + 3];
     expect(tile).not.toContain(TileSubtype.POT);
     expect(tile).not.toContain(TileSubtype.SNAKE);
-    // Rune lands on the floor tile just before the pot, so it can be retrieved.
+    expect(after.enemies).toHaveLength(1);
+    expect(after.enemies?.[0]?.kind).toBe("snake");
+    // Thrown rune lands on the floor tile just before the pot.
     expect(after.runeCount).toBe(0);
     expect(after.mapData.subtypes[py][px + 2]).toContain(TileSubtype.RUNE);
-    expect(after.stats.enemiesDefeated).toBe(1);
-    expect(after.stats.damageDealt).toBe(2);
-    expect(after.stats.byKind?.snake).toBe(1);
-    // The rune-master badge is stone-goblin-specific; a snake rune kill must NOT
-    // advance enemiesKilledByRune (matches normal rune kills of non-stone enemies).
-    expect(after.stats.enemiesKilledByRune ?? 0).toBe(0);
-    expect(after.recentDeaths).toContainEqual([py, px + 3]);
-    expect(after.enemies?.length ?? 0).toBe(0);
-    expect(after.heroHealth).toBe(5);
+    // Not a kill.
+    expect(after.stats.enemiesDefeated).toBe(0);
+    expect(after.recentDeaths ?? []).toHaveLength(0);
   });
 
-  it("keeps the rune in inventory when a snake pot is directly adjacent (nowhere to land), still credits the kill", () => {
+  it("keeps the rune in inventory when the snake pot is directly adjacent (nowhere to land)", () => {
     const py = 5,
       px = 5;
     const map = makeCorridor(py, px);
-    // Pot directly ahead of the player: there is no floor tile in front of it to
-    // drop the bounced rune onto, so the rune must not be consumed.
     map.subtypes[py][px + 1] = [TileSubtype.POT, TileSubtype.SNAKE];
 
-    const after = performThrowRune(baseState(map, { runeCount: 1, currentFloor: 2 }));
+    const after = performThrowRune(baseState(map, { runeCount: 1 }));
 
     const tile = after.mapData.subtypes[py][px + 1];
     expect(tile).not.toContain(TileSubtype.POT);
     expect(tile).not.toContain(TileSubtype.SNAKE);
-    // Rune preserved (scarce resource not silently destroyed on a smart play).
+    expect(after.enemies).toHaveLength(1);
+    expect(after.enemies?.[0]?.kind).toBe("snake");
+    // Rune preserved (scarce resource not silently destroyed).
     expect(after.runeCount).toBe(1);
-    // Snake still killed and credited.
-    expect(after.stats.enemiesDefeated).toBe(1);
-    expect(after.stats.byKind?.snake).toBe(1);
-    expect(after.recentDeaths).toContainEqual([py, px + 1]);
-    expect(after.enemies?.length ?? 0).toBe(0);
   });
 });
 
 describe("Bomb blast destroys a snake pot", () => {
-  it("clears both tags and credits a snake kill (blast VFX is its own feedback)", () => {
+  it("obliterates the pot and kills the snake (counts as a kill, blast VFX is its own feedback)", () => {
     const py = 5,
       px = 5;
     const map = makeCorridor(py, px);
-    // A live bomb sits next to a snake pot, both on the carved floor row.
     map.subtypes[py][px + 1] = [TileSubtype.BOMB_LIVE];
     map.subtypes[py][px + 2] = [TileSubtype.POT, TileSubtype.SNAKE];
 
@@ -175,11 +197,11 @@ describe("Bomb blast destroys a snake pot", () => {
     expect(after.stats.enemiesDefeated).toBe(1);
     expect(after.stats.damageDealt).toBe(2);
     expect(after.stats.byKind?.snake).toBe(1);
+    // No snake survives the blast (it is killed, not released).
     expect(after.enemies?.length ?? 0).toBe(0);
-    // The ranged kill avoids the walk-in ambush, so no poison is applied.
     expect(after.conditions?.poisoned?.active ?? false).toBe(false);
-    // A snake pot pushes nothing onto defeatedEnemies (it never became a real
-    // enemy), so the story-event slice window stays exact.
+    // A snake pot pushes nothing onto defeatedEnemies, keeping the story-event
+    // slice window exact.
     expect(after.defeatedEnemies ?? []).toHaveLength(0);
   });
 
@@ -187,7 +209,6 @@ describe("Bomb blast destroys a snake pot", () => {
     const py = 5,
       px = 5;
     const map = makeCorridor(py, px);
-    // Bomb at px+2; its 3x3 blast spans px+1..px+3 on the player's row.
     map.subtypes[py][px + 2] = [TileSubtype.BOMB_LIVE];
     map.subtypes[py][px + 3] = [TileSubtype.POT, TileSubtype.SNAKE];
     const goblin = new Enemy({ y: py, x: px + 1 });
@@ -198,14 +219,11 @@ describe("Bomb blast destroys a snake pot", () => {
       baseState(map, { currentFloor: 2, enemies: [goblin] })
     );
 
-    // Both the snake pot and the real enemy are counted as kills.
     expect(after.stats.enemiesDefeated).toBe(2);
     expect(after.stats.byKind?.snake).toBe(1);
     expect(after.stats.byKind?.["fire-goblin"]).toBe(1);
     expect(after.enemies?.length ?? 0).toBe(0);
-    // Only the real enemy is recorded in defeatedEnemies — the snake pot must not
-    // inflate it, or the slice(-enemiesDefeated) story window would re-process a
-    // stale enemy.
+    // Only the real enemy is recorded in defeatedEnemies.
     expect(after.defeatedEnemies ?? []).toHaveLength(1);
     expect(after.defeatedEnemies?.[0]?.kind).toBe("fire-goblin");
   });

--- a/__tests__/lib/snake_pot_ranged_kill.test.ts
+++ b/__tests__/lib/snake_pot_ranged_kill.test.ts
@@ -1,0 +1,212 @@
+import {
+  Direction,
+  TileSubtype,
+  type GameState,
+  performThrowRock,
+  performThrowRune,
+  detonateLiveBombs,
+} from "../../lib/map";
+import { FLOOR, WALL } from "../../lib/map/constants";
+import type { MapData } from "../../lib/map/types";
+import { Enemy } from "../../lib/enemy";
+
+/**
+ * Destroying a snake pot from range (rock, rune, or bomb) should kill the coiled
+ * snake before it can ambush AND give the player clear credit: the POT+SNAKE tags
+ * are cleared, the kill counts in stats (toward the snake/rock badges), and for
+ * rock/rune the tile is added to recentDeaths so a spirit rises from the broken
+ * pot. No live snake enemy should spawn and the hero should take no damage/poison.
+ *
+ * Regression guard for the prior bug where a thrown rock silently stripped the POT
+ * tag, leaving an invisible orphaned SNAKE tag and giving zero feedback.
+ */
+
+function makeCorridor(py: number, px: number, size = 12): MapData {
+  const tiles: number[][] = [];
+  const subtypes: number[][][] = [];
+  for (let y = 0; y < size; y++) {
+    tiles.push(new Array(size).fill(WALL));
+    subtypes.push(Array.from({ length: size }, () => [] as number[]));
+  }
+  // Carve a floor row for the player and the throw path.
+  for (let x = 0; x < size; x++) {
+    tiles[py][x] = FLOOR;
+    subtypes[py][x] = [];
+  }
+  subtypes[py][px] = [TileSubtype.PLAYER];
+  return { tiles, subtypes };
+}
+
+function baseState(mapData: MapData, overrides: Partial<GameState> = {}): GameState {
+  return {
+    hasKey: false,
+    hasExitKey: false,
+    hasSword: false,
+    hasShield: false,
+    mapData,
+    showFullMap: false,
+    win: false,
+    playerDirection: Direction.RIGHT,
+    enemies: [],
+    heroHealth: 5,
+    heroMaxHealth: 5,
+    heroAttack: 1,
+    heroTorchLit: true,
+    currentFloor: 2,
+    stats: { damageDealt: 0, damageTaken: 0, enemiesDefeated: 0, steps: 0 },
+    recentDeaths: [],
+    ...overrides,
+  };
+}
+
+describe("Rock destroys a snake pot", () => {
+  it("clears both tags, credits a snake kill, records the death, and leaves no live snake", () => {
+    const py = 5,
+      px = 5;
+    const map = makeCorridor(py, px);
+    map.subtypes[py][px + 3] = [TileSubtype.POT, TileSubtype.SNAKE];
+
+    const after = performThrowRock(
+      baseState(map, { rockCount: 2, currentFloor: 2 })
+    );
+
+    const tile = after.mapData.subtypes[py][px + 3];
+    // Both the pot and the (invisible) snake marker are gone — no orphan tag.
+    expect(tile).not.toContain(TileSubtype.POT);
+    expect(tile).not.toContain(TileSubtype.SNAKE);
+    // Rock consumed, none placed on the pot tile.
+    expect(after.rockCount).toBe(1);
+    expect(after.stats.rocksThrown).toBe(1);
+    expect(tile).not.toContain(TileSubtype.ROCK);
+    // Kill credited like any snake rock kill.
+    expect(after.stats.enemiesDefeated).toBe(1);
+    expect(after.stats.enemiesKilledByRock).toBe(1);
+    expect(after.stats.damageDealt).toBe(2);
+    expect(after.stats.byKind?.snake).toBe(1);
+    expect(after.stats.byFloor?.[2]?.snake).toBe(1);
+    // Spirit VFX feedback: the tile is registered as a death this tick.
+    expect(after.recentDeaths).toContainEqual([py, px + 3]);
+    // The latent snake never becomes a live enemy and the hero is unharmed.
+    expect(after.enemies?.length ?? 0).toBe(0);
+    expect(after.heroHealth).toBe(5);
+    expect(after.conditions?.poisoned?.active ?? false).toBe(false);
+  });
+
+  it("does not award a snake kill for an ordinary (non-snake) pot", () => {
+    const py = 5,
+      px = 5;
+    const map = makeCorridor(py, px);
+    map.subtypes[py][px + 3] = [TileSubtype.POT];
+
+    const after = performThrowRock(baseState(map, { rockCount: 1 }));
+
+    expect(after.mapData.subtypes[py][px + 3]).not.toContain(TileSubtype.POT);
+    expect(after.stats.enemiesDefeated).toBe(0);
+    expect(after.stats.byKind?.snake ?? 0).toBe(0);
+    expect(after.recentDeaths ?? []).toHaveLength(0);
+  });
+});
+
+describe("Rune destroys a snake pot", () => {
+  it("clears both tags, credits a snake kill, drops the rune in front, and records the death", () => {
+    const py = 5,
+      px = 5;
+    const map = makeCorridor(py, px);
+    map.subtypes[py][px + 3] = [TileSubtype.POT, TileSubtype.SNAKE];
+
+    const after = performThrowRune(
+      baseState(map, { runeCount: 1, currentFloor: 3 })
+    );
+
+    const tile = after.mapData.subtypes[py][px + 3];
+    expect(tile).not.toContain(TileSubtype.POT);
+    expect(tile).not.toContain(TileSubtype.SNAKE);
+    // Rune lands on the floor tile just before the pot, so it can be retrieved.
+    expect(after.runeCount).toBe(0);
+    expect(after.mapData.subtypes[py][px + 2]).toContain(TileSubtype.RUNE);
+    expect(after.stats.enemiesDefeated).toBe(1);
+    expect(after.stats.damageDealt).toBe(2);
+    expect(after.stats.byKind?.snake).toBe(1);
+    // The rune-master badge is stone-goblin-specific; a snake rune kill must NOT
+    // advance enemiesKilledByRune (matches normal rune kills of non-stone enemies).
+    expect(after.stats.enemiesKilledByRune ?? 0).toBe(0);
+    expect(after.recentDeaths).toContainEqual([py, px + 3]);
+    expect(after.enemies?.length ?? 0).toBe(0);
+    expect(after.heroHealth).toBe(5);
+  });
+
+  it("keeps the rune in inventory when a snake pot is directly adjacent (nowhere to land), still credits the kill", () => {
+    const py = 5,
+      px = 5;
+    const map = makeCorridor(py, px);
+    // Pot directly ahead of the player: there is no floor tile in front of it to
+    // drop the bounced rune onto, so the rune must not be consumed.
+    map.subtypes[py][px + 1] = [TileSubtype.POT, TileSubtype.SNAKE];
+
+    const after = performThrowRune(baseState(map, { runeCount: 1, currentFloor: 2 }));
+
+    const tile = after.mapData.subtypes[py][px + 1];
+    expect(tile).not.toContain(TileSubtype.POT);
+    expect(tile).not.toContain(TileSubtype.SNAKE);
+    // Rune preserved (scarce resource not silently destroyed on a smart play).
+    expect(after.runeCount).toBe(1);
+    // Snake still killed and credited.
+    expect(after.stats.enemiesDefeated).toBe(1);
+    expect(after.stats.byKind?.snake).toBe(1);
+    expect(after.recentDeaths).toContainEqual([py, px + 1]);
+    expect(after.enemies?.length ?? 0).toBe(0);
+  });
+});
+
+describe("Bomb blast destroys a snake pot", () => {
+  it("clears both tags and credits a snake kill (blast VFX is its own feedback)", () => {
+    const py = 5,
+      px = 5;
+    const map = makeCorridor(py, px);
+    // A live bomb sits next to a snake pot, both on the carved floor row.
+    map.subtypes[py][px + 1] = [TileSubtype.BOMB_LIVE];
+    map.subtypes[py][px + 2] = [TileSubtype.POT, TileSubtype.SNAKE];
+
+    const after = detonateLiveBombs(baseState(map, { currentFloor: 2 }));
+
+    const tile = after.mapData.subtypes[py][px + 2];
+    expect(tile).not.toContain(TileSubtype.POT);
+    expect(tile).not.toContain(TileSubtype.SNAKE);
+    expect(after.stats.enemiesDefeated).toBe(1);
+    expect(after.stats.damageDealt).toBe(2);
+    expect(after.stats.byKind?.snake).toBe(1);
+    expect(after.enemies?.length ?? 0).toBe(0);
+    // The ranged kill avoids the walk-in ambush, so no poison is applied.
+    expect(after.conditions?.poisoned?.active ?? false).toBe(false);
+    // A snake pot pushes nothing onto defeatedEnemies (it never became a real
+    // enemy), so the story-event slice window stays exact.
+    expect(after.defeatedEnemies ?? []).toHaveLength(0);
+  });
+
+  it("counts a snake pot AND a real enemy in the same blast without polluting the defeated-enemy window", () => {
+    const py = 5,
+      px = 5;
+    const map = makeCorridor(py, px);
+    // Bomb at px+2; its 3x3 blast spans px+1..px+3 on the player's row.
+    map.subtypes[py][px + 2] = [TileSubtype.BOMB_LIVE];
+    map.subtypes[py][px + 3] = [TileSubtype.POT, TileSubtype.SNAKE];
+    const goblin = new Enemy({ y: py, x: px + 1 });
+    goblin.kind = "fire-goblin";
+    goblin.health = 1; // dies to the blast
+
+    const after = detonateLiveBombs(
+      baseState(map, { currentFloor: 2, enemies: [goblin] })
+    );
+
+    // Both the snake pot and the real enemy are counted as kills.
+    expect(after.stats.enemiesDefeated).toBe(2);
+    expect(after.stats.byKind?.snake).toBe(1);
+    expect(after.stats.byKind?.["fire-goblin"]).toBe(1);
+    expect(after.enemies?.length ?? 0).toBe(0);
+    // Only the real enemy is recorded in defeatedEnemies — the snake pot must not
+    // inflate it, or the slice(-enemiesDefeated) story window would re-process a
+    // stale enemy.
+    expect(after.defeatedEnemies ?? []).toHaveLength(1);
+    expect(after.defeatedEnemies?.[0]?.kind).toBe("fire-goblin");
+  });
+});

--- a/components/Tile.module.css
+++ b/components/Tile.module.css
@@ -326,26 +326,31 @@
 }
 
 /*
- * Snake-pot wiggle: a subtle, occasional twitch hinting that something inside
- * is alive. The animation cycle is long (5s) and the actual movement only
- * occupies a small fraction of it, so the pot looks still most of the time —
- * an attentive player will catch the twitch and think twice before opening.
- * Per-tile random delay (set inline via --snake-pot-delay) prevents all
- * snake-pots from twitching in sync.
+ * Snake-pot rattle: every ~3s the pot does a sharp little shake, as if the coiled
+ * snake inside is shifting and about to strike. It sits perfectly still for most
+ * of the cycle, then rattles with several quick oscillations in the last ~0.8s —
+ * obvious enough that an attentive player notices it and thinks twice before
+ * opening, but not so constant that the map feels jittery. Each pot is desynced
+ * by a per-tile delay (set inline via --snake-pot-delay) so they don't rattle in
+ * unison. Runs on a real-time clock, independent of turns.
  */
 .potIconSnake {
-  animation: snake-pot-wiggle 5s ease-in-out infinite;
+  animation: snake-pot-wiggle 3s ease-in-out infinite;
   animation-delay: var(--snake-pot-delay, 0s);
-  transform-origin: 50% 80%;
+  transform-origin: 50% 85%; /* pivot near the base so it rocks like a rattled pot */
   will-change: transform;
 }
 
 @keyframes snake-pot-wiggle {
-  0%, 86%, 100% { transform: rotate(0deg) translateY(0); }
-  88% { transform: rotate(-3deg) translateY(-1px); }
-  91% { transform: rotate(3deg) translateY(-1px); }
-  94% { transform: rotate(-2deg) translateY(0); }
-  97% { transform: rotate(1deg) translateY(0); }
+  0%, 72% { transform: rotate(0deg) translate(0, 0); }
+  75% { transform: rotate(-7deg) translate(-1.5px, -1px); }
+  78% { transform: rotate(8deg) translate(1.5px, -2px); }
+  81% { transform: rotate(-6deg) translate(-1.5px, -1px); }
+  84% { transform: rotate(5deg) translate(1px, -2px); }
+  88% { transform: rotate(-4deg) translate(-1px, -1px); }
+  92% { transform: rotate(3deg) translate(1px, 0); }
+  96% { transform: rotate(-1.5deg) translate(0, 0); }
+  100% { transform: rotate(0deg) translate(0, 0); }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/components/Tile.tsx
+++ b/components/Tile.tsx
@@ -746,11 +746,12 @@ export const Tile: React.FC<TileProps> = ({
         {/* Render POT/ROCK/FOOD/MED with assets if present */}
         {hasPot(subtypes) && (() => {
           const isSnakePot = subtypes?.includes(TileSubtype.SNAKE) ?? false;
-          // Deterministic per-tile delay so multiple snake-pots don't twitch
-          // in sync. Range 0-4.9s within the 5s animation window.
+          // Deterministic per-tile delay so multiple snake-pots don't rattle in
+          // sync. Range 0.0-2.9s, kept under the 3s cycle so every value lands on a
+          // distinct phase (delays past one cycle would alias back into sync).
           const y = typeof row === 'number' ? row : 0;
           const x = typeof col === 'number' ? col : 0;
-          const delayMs = (((y * 73 + x * 131) % 49) / 10).toFixed(1);
+          const delayMs = (((y * 73 + x * 131) % 30) / 10).toFixed(1);
           return (
             <div
               key="pot"

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -61,11 +61,38 @@ function trackEnemyKill(stats: GameState["stats"], enemyKind: EnemyKind, floor: 
   // Track by kind
   if (!stats.byKind) stats.byKind = createEmptyByKind();
   stats.byKind[enemyKind] = (stats.byKind[enemyKind] ?? 0) + 1;
-  
+
   // Track by floor
   if (!stats.byFloor) stats.byFloor = {};
   if (!stats.byFloor[floor]) stats.byFloor[floor] = createEmptyByKind();
   stats.byFloor[floor][enemyKind] = (stats.byFloor[floor][enemyKind] ?? 0) + 1;
+}
+
+// A coiled snake hidden in a pot (POT + SNAKE) springs an ambush when the player
+// opens it by walking in. Smashing the pot from range instead — a thrown rock or
+// rune — kills the snake before it can strike, and the player deserves clear
+// credit for the smart play. This records that as a real snake kill so it counts
+// in the run stats (toward the snake/rock badges) exactly like any other snake
+// kill. Mutates `stats` in place. Callers also push the tile to recentDeaths so a
+// spirit rises from the broken pot as unmistakable "you got it" feedback. The
+// bomb-blast path tracks its kills via a local counter, so it does NOT use this.
+const SNAKE_POT_KILL_DAMAGE = 2; // snakes have 2 HP; mirrors a normal rock/rune kill
+
+function recordSnakePotKill(
+  stats: GameState["stats"],
+  floor: number,
+  killedBy: "rock" | "rune"
+): void {
+  stats.enemiesDefeated = (stats.enemiesDefeated ?? 0) + 1;
+  stats.damageDealt = (stats.damageDealt ?? 0) + SNAKE_POT_KILL_DAMAGE;
+  // Rocks feed the generic "defeat N enemies with rocks" badge, so a rock snake
+  // kill legitimately counts. Runes do NOT: enemiesKilledByRune backs the
+  // stone-goblin-specific rune-master badge, and — like a normal rune kill of any
+  // non-stone enemy — a snake-pot rune kill should not advance it.
+  if (killedBy === "rock") {
+    stats.enemiesKilledByRock = (stats.enemiesKilledByRock ?? 0) + 1;
+  }
+  trackEnemyKill(stats, "snake", floor);
 }
 
 function incrementStepsAndTime(state: GameState, amount: number = 1): void {
@@ -693,6 +720,29 @@ export function performThrowRock(gameState: GameState): GameState {
     // Floor tile: check for pot collision
     const subs = newMapData.subtypes[ty][tx] || [];
     if (subs.includes(TileSubtype.POT)) {
+      // Snake pot: the rock shatters it and kills the coiled snake before it can
+      // ambush. Clear both tags, credit the kill, and record the death so a spirit
+      // rises from the broken pot (clear "you did the right thing" feedback).
+      if (subs.includes(TileSubtype.SNAKE)) {
+        newMapData.subtypes[ty][tx] = subs.filter(
+          (s) => s !== TileSubtype.POT && s !== TileSubtype.SNAKE
+        );
+        const stats = {
+          ...preTickState.stats,
+          rocksThrown: (preTickState.stats.rocksThrown ?? 0) + 1,
+        };
+        recordSnakePotKill(stats, preTickState.currentFloor ?? 1, "rock");
+        return {
+          ...preTickState,
+          mapData: newMapData,
+          rockCount: count - 1,
+          stats,
+          recentDeaths: [
+            ...(preTickState.recentDeaths ?? []),
+            [ty, tx] as [number, number],
+          ],
+        };
+      }
       // If this pot contains a rune, reveal it; otherwise remove pot
       if (subs.includes(TileSubtype.RUNE)) {
         // Preserve non-pot tags (e.g., ROAD overlays) and add RUNE
@@ -702,9 +752,9 @@ export function performThrowRock(gameState: GameState): GameState {
         // Remove only the pot marker; keep other tags (e.g., ROAD)
         newMapData.subtypes[ty][tx] = subs.filter((s) => s !== TileSubtype.POT);
       }
-      return { 
-        ...preTickState, 
-        mapData: newMapData, 
+      return {
+        ...preTickState,
+        mapData: newMapData,
         rockCount: count - 1,
         stats: {
           ...preTickState.stats,
@@ -911,6 +961,37 @@ export function performThrowRune(gameState: GameState): GameState {
     // Pot on floor tile
     const subs = newMapData.subtypes[ty][tx] || [];
     if (subs.includes(TileSubtype.POT)) {
+      // Snake pot: the rune shatters it and kills the coiled snake before it can
+      // ambush. Credit the kill and record the death for the spirit VFX, then drop
+      // the thrown rune in front of the pot so it can be retrieved. If there is no
+      // floor tile to drop onto (pot directly ahead of the player), keep the rune
+      // in inventory rather than destroying it — mirrors how an ordinary adjacent
+      // pot leaves the thrown rune untouched.
+      if (subs.includes(TileSubtype.SNAKE)) {
+        newMapData.subtypes[ty][tx] = subs.filter(
+          (s) => s !== TileSubtype.POT && s !== TileSubtype.SNAKE
+        );
+        const stats = { ...preTickState.stats };
+        recordSnakePotKill(stats, preTickState.currentFloor ?? 1, "rune");
+        let runeLanded = false;
+        if (
+          !(lastFloorY === py && lastFloorX === px) &&
+          newMapData.tiles[lastFloorY][lastFloorX] === FLOOR
+        ) {
+          newMapData.subtypes[lastFloorY][lastFloorX] = [TileSubtype.RUNE];
+          runeLanded = true;
+        }
+        return {
+          ...preTickState,
+          mapData: newMapData,
+          runeCount: runeLanded ? count - 1 : count,
+          stats,
+          recentDeaths: [
+            ...(preTickState.recentDeaths ?? []),
+            [ty, tx] as [number, number],
+          ],
+        };
+      }
       if (subs.includes(TileSubtype.RUNE)) {
         // Preserve other tags and reveal RUNE
         const kept = subs.filter((s) => s !== TileSubtype.POT && s !== TileSubtype.RUNE);
@@ -1040,6 +1121,11 @@ export function detonateLiveBombs(state: GameState): GameState {
   const stats = { ...state.stats, byKind: state.stats.byKind, byFloor: state.stats.byFloor };
   let wallsDestroyed = 0;
   let enemiesDefeated = 0;
+  // Snake pots destroyed by the blast are counted separately: they add to the kill
+  // tally but push nothing onto defeatedEnemies, so they must stay OUT of the
+  // `slice(-enemiesDefeated)` story-event window below (which is keyed to real
+  // enemy kills) to avoid re-processing a stale, previously-defeated enemy.
+  let snakePotKills = 0;
   let playerHit = false;
 
   for (const [cy, cx] of liveCenters) {
@@ -1090,6 +1176,16 @@ export function detonateLiveBombs(state: GameState): GameState {
         // Hero caught in the blast takes damage once.
         if (subs.includes(TileSubtype.PLAYER)) playerHit = true;
 
+        // A snake pot caught in the blast: the coiled snake dies with the shattered
+        // pot. The blast VFX already plays here, so credit the kill in stats (toward
+        // the snake-hater badge / run totals) without a separate spirit. POT and
+        // SNAKE aren't in BOMB_PRESERVED_SUBTYPES, so both tags are stripped below.
+        if (subs.includes(TileSubtype.POT) && subs.includes(TileSubtype.SNAKE)) {
+          trackEnemyKill(stats, "snake", state.currentFloor ?? 1);
+          stats.damageDealt = stats.damageDealt + SNAKE_POT_KILL_DAMAGE;
+          snakePotKills += 1;
+        }
+
         // Strip everything destructible; keep preserved/cosmetic markers; scorch the tile.
         const kept = subs.filter((s) => BOMB_PRESERVED_SUBTYPES.has(s));
         if (!kept.includes(TileSubtype.SINGED)) kept.push(TileSubtype.SINGED);
@@ -1105,7 +1201,7 @@ export function detonateLiveBombs(state: GameState): GameState {
     }
   }
 
-  stats.enemiesDefeated = stats.enemiesDefeated + enemiesDefeated;
+  stats.enemiesDefeated = stats.enemiesDefeated + enemiesDefeated + snakePotKills;
   stats.wallsDestroyed = (stats.wallsDestroyed ?? 0) + wallsDestroyed;
 
   let heroHealth = state.heroHealth;

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -68,31 +68,66 @@ function trackEnemyKill(stats: GameState["stats"], enemyKind: EnemyKind, floor: 
   stats.byFloor[floor][enemyKind] = (stats.byFloor[floor][enemyKind] ?? 0) + 1;
 }
 
-// A coiled snake hidden in a pot (POT + SNAKE) springs an ambush when the player
-// opens it by walking in. Smashing the pot from range instead — a thrown rock or
-// rune — kills the snake before it can strike, and the player deserves clear
-// credit for the smart play. This records that as a real snake kill so it counts
-// in the run stats (toward the snake/rock badges) exactly like any other snake
-// kill. Mutates `stats` in place. Callers also push the tile to recentDeaths so a
-// spirit rises from the broken pot as unmistakable "you got it" feedback. The
-// bomb-blast path tracks its kills via a local counter, so it does NOT use this.
-const SNAKE_POT_KILL_DAMAGE = 2; // snakes have 2 HP; mirrors a normal rock/rune kill
+// A snake hidden in a pot (POT + SNAKE) only springs its ambush bite + poison when
+// the player WALKS into it. A bomb blast, being an explosion, kills the coiled
+// snake outright; SNAKE_POT_KILL_DAMAGE is the per-snake damage credited for that
+// (see detonateLiveBombs). Thrown rocks/runes do NOT destroy the snake — they just
+// break the pot and let it slither out (see breakPotReleasingContents).
+const SNAKE_POT_KILL_DAMAGE = 2; // snakes have 2 HP
 
-function recordSnakePotKill(
-  stats: GameState["stats"],
-  floor: number,
-  killedBy: "rock" | "rune"
-): void {
-  stats.enemiesDefeated = (stats.enemiesDefeated ?? 0) + 1;
-  stats.damageDealt = (stats.damageDealt ?? 0) + SNAKE_POT_KILL_DAMAGE;
-  // Rocks feed the generic "defeat N enemies with rocks" badge, so a rock snake
-  // kill legitimately counts. Runes do NOT: enemiesKilledByRune backs the
-  // stone-goblin-specific rune-master badge, and — like a normal rune kill of any
-  // non-stone enemy — a snake-pot rune kill should not advance it.
-  if (killedBy === "rock") {
-    stats.enemiesKilledByRock = (stats.enemiesKilledByRock ?? 0) + 1;
+// Break a pot from range (a thrown rock or rune) WITHOUT the player stepping onto
+// it. Unlike a bomb blast — which obliterates the tile — breaking a pot just
+// releases what is inside, so the contents survive:
+//   - snake pot -> the snake slithers out as a live enemy. It gets NO free ambush
+//                  bite (you broke it from a distance) and acts on later turns.
+//   - rune pot  -> the rune is revealed on the tile.
+//   - food pot  -> its food/potion is revealed on the tile (the same deterministic
+//                  contents a walk-in open would show; a pending override is used
+//                  up just as opening would).
+// Mutates mapData.subtypes[y][x] in place. Returns any spawned snake (else null)
+// and the next potOverrides map (an override is consumed when used).
+function breakPotReleasingContents(
+  mapData: MapData,
+  y: number,
+  x: number,
+  potOverrides: GameState["potOverrides"]
+): { spawnedSnake: Enemy | null; potOverrides: GameState["potOverrides"] } {
+  const subs = mapData.subtypes[y][x] || [];
+  if (subs.includes(TileSubtype.SNAKE)) {
+    mapData.subtypes[y][x] = subs.filter(
+      (s) => s !== TileSubtype.POT && s !== TileSubtype.SNAKE
+    );
+    const snake = new Enemy({ y, x });
+    snake.kind = "snake";
+    return { spawnedSnake: snake, potOverrides };
   }
-  trackEnemyKill(stats, "snake", floor);
+  if (subs.includes(TileSubtype.RUNE)) {
+    const kept = subs.filter(
+      (s) => s !== TileSubtype.POT && s !== TileSubtype.RUNE
+    );
+    mapData.subtypes[y][x] = kept.concat([TileSubtype.RUNE]);
+    return { spawnedSnake: null, potOverrides };
+  }
+  // Food / potion pot: reveal the same contents a walk-in open would (reveal is
+  // computed while the POT tag is still on the tile, matching the walk-in path).
+  const key = `${y},${x}`;
+  const overrideReveal = potOverrides?.[key];
+  if (overrideReveal) {
+    mapData.subtypes[y][x] = subs
+      .filter((s) => s !== TileSubtype.POT)
+      .concat([overrideReveal]);
+    const next = { ...potOverrides };
+    delete next[key];
+    return {
+      spawnedSnake: null,
+      potOverrides: Object.keys(next).length ? next : undefined,
+    };
+  }
+  const reveal = pickPotRevealDeterministic(mapData, y, x);
+  mapData.subtypes[y][x] = subs
+    .filter((s) => s !== TileSubtype.POT)
+    .concat([reveal]);
+  return { spawnedSnake: null, potOverrides };
 }
 
 function incrementStepsAndTime(state: GameState, amount: number = 1): void {
@@ -720,41 +755,23 @@ export function performThrowRock(gameState: GameState): GameState {
     // Floor tile: check for pot collision
     const subs = newMapData.subtypes[ty][tx] || [];
     if (subs.includes(TileSubtype.POT)) {
-      // Snake pot: the rock shatters it and kills the coiled snake before it can
-      // ambush. Clear both tags, credit the kill, and record the death so a spirit
-      // rises from the broken pot (clear "you did the right thing" feedback).
-      if (subs.includes(TileSubtype.SNAKE)) {
-        newMapData.subtypes[ty][tx] = subs.filter(
-          (s) => s !== TileSubtype.POT && s !== TileSubtype.SNAKE
-        );
-        const stats = {
-          ...preTickState.stats,
-          rocksThrown: (preTickState.stats.rocksThrown ?? 0) + 1,
-        };
-        recordSnakePotKill(stats, preTickState.currentFloor ?? 1, "rock");
-        return {
-          ...preTickState,
-          mapData: newMapData,
-          rockCount: count - 1,
-          stats,
-          recentDeaths: [
-            ...(preTickState.recentDeaths ?? []),
-            [ty, tx] as [number, number],
-          ],
-        };
-      }
-      // If this pot contains a rune, reveal it; otherwise remove pot
-      if (subs.includes(TileSubtype.RUNE)) {
-        // Preserve non-pot tags (e.g., ROAD overlays) and add RUNE
-        const kept = subs.filter((s) => s !== TileSubtype.POT && s !== TileSubtype.RUNE);
-        newMapData.subtypes[ty][tx] = kept.concat([TileSubtype.RUNE]);
-      } else {
-        // Remove only the pot marker; keep other tags (e.g., ROAD)
-        newMapData.subtypes[ty][tx] = subs.filter((s) => s !== TileSubtype.POT);
-      }
+      // A thrown rock shatters the pot but does NOT destroy what is inside: a snake
+      // slithers out as a live enemy (to be fought — no free ambush bite, since you
+      // broke it from range), and a rune/food is left on the floor to pick up. (A
+      // bomb blast, by contrast, obliterates the contents — see detonateLiveBombs.)
+      const released = breakPotReleasingContents(
+        newMapData,
+        ty,
+        tx,
+        preTickState.potOverrides
+      );
       return {
         ...preTickState,
         mapData: newMapData,
+        enemies: released.spawnedSnake
+          ? [...(preTickState.enemies ?? []), released.spawnedSnake]
+          : preTickState.enemies,
+        potOverrides: released.potOverrides,
         rockCount: count - 1,
         stats: {
           ...preTickState.stats,
@@ -961,54 +978,34 @@ export function performThrowRune(gameState: GameState): GameState {
     // Pot on floor tile
     const subs = newMapData.subtypes[ty][tx] || [];
     if (subs.includes(TileSubtype.POT)) {
-      // Snake pot: the rune shatters it and kills the coiled snake before it can
-      // ambush. Credit the kill and record the death for the spirit VFX, then drop
-      // the thrown rune in front of the pot so it can be retrieved. If there is no
-      // floor tile to drop onto (pot directly ahead of the player), keep the rune
-      // in inventory rather than destroying it — mirrors how an ordinary adjacent
-      // pot leaves the thrown rune untouched.
-      if (subs.includes(TileSubtype.SNAKE)) {
-        newMapData.subtypes[ty][tx] = subs.filter(
-          (s) => s !== TileSubtype.POT && s !== TileSubtype.SNAKE
-        );
-        const stats = { ...preTickState.stats };
-        recordSnakePotKill(stats, preTickState.currentFloor ?? 1, "rune");
-        let runeLanded = false;
-        if (
-          !(lastFloorY === py && lastFloorX === px) &&
-          newMapData.tiles[lastFloorY][lastFloorX] === FLOOR
-        ) {
-          newMapData.subtypes[lastFloorY][lastFloorX] = [TileSubtype.RUNE];
-          runeLanded = true;
-        }
-        return {
-          ...preTickState,
-          mapData: newMapData,
-          runeCount: runeLanded ? count - 1 : count,
-          stats,
-          recentDeaths: [
-            ...(preTickState.recentDeaths ?? []),
-            [ty, tx] as [number, number],
-          ],
-        };
-      }
-      if (subs.includes(TileSubtype.RUNE)) {
-        // Preserve other tags and reveal RUNE
-        const kept = subs.filter((s) => s !== TileSubtype.POT && s !== TileSubtype.RUNE);
-        newMapData.subtypes[ty][tx] = kept.concat([TileSubtype.RUNE]);
-      } else {
-        // Remove only pot; keep others
-        newMapData.subtypes[ty][tx] = subs.filter((s) => s !== TileSubtype.POT);
-      }
-      // Drop rune before the pot
+      // A thrown rune shatters the pot like a rock: the contents are released, not
+      // destroyed (a snake slithers out as a live enemy, food/runes are left on the
+      // floor). The thrown rune then drops in front of the pot so it can be
+      // retrieved; if there is no floor tile to land on (pot directly ahead of the
+      // player) the rune is kept in inventory rather than lost.
+      const released = breakPotReleasingContents(
+        newMapData,
+        ty,
+        tx,
+        preTickState.potOverrides
+      );
+      let runeLanded = false;
       if (
         !(lastFloorY === py && lastFloorX === px) &&
         newMapData.tiles[lastFloorY][lastFloorX] === FLOOR
       ) {
         newMapData.subtypes[lastFloorY][lastFloorX] = [TileSubtype.RUNE];
-        return { ...preTickState, mapData: newMapData, runeCount: count - 1 };
+        runeLanded = true;
       }
-      return preTickState;
+      return {
+        ...preTickState,
+        mapData: newMapData,
+        enemies: released.spawnedSnake
+          ? [...(preTickState.enemies ?? []), released.spawnedSnake]
+          : preTickState.enemies,
+        potOverrides: released.potOverrides,
+        runeCount: runeLanded ? count - 1 : count,
+      };
     }
 
     // Continue traversal over floor


### PR DESCRIPTION
Improves the snake-pot mechanic so the hidden-snake threat is fair to read and interact with, in response to feedback that rare snake swarms felt unforgiving.

## Changes

**Make the snake-pot shake obvious** (was effectively invisible)
- The rattle animation now runs on a 3s real-time cycle with a multi-oscillation shake burst (previously a ~0.5s ±3° twitch buried in a 5s cycle). Desynced per tile, still gated by `prefers-reduced-motion`.

**Breaking a pot from range releases its contents instead of destroying them**
- Previously, a thrown rock silently stripped the pot and left an invisible orphaned snake tag (and food was lost) — no feedback either way.
- Now a thrown **rock or rune breaks the pot and releases what's inside**: a snake slithers out as a live enemy (no free ambush bite, since it was broken from range), and food/potions/runes are left on the floor to collect.
- A **bomb** blast still obliterates the pot and kills the snake (it's an explosion). **Walking in** still triggers the full ambush (damage + poison).
- Net risk gradient: avoid the rattling pot, break it from range to fight the snake fairly, bomb it to destroy it, or walk in for the worst case.

## Tests
- New `__tests__/lib/snake_pot_ranged.test.ts` covers rock/rune release (snake spawns, no kill, food/rune revealed, adjacent-rune retained) and bomb destruction (snake killed, defeated-enemy window stays exact).
- Full suite green; typecheck and production build clean. Merged latest `main` (clean).