### PR TITLE
Self-host pixel fonts via next/font (drop Google Fonts @import)

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -2,16 +2,16 @@
 @tailwind components;
 @tailwind utilities;
 
-/* Pixel/retro fonts for share preview */
-@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&family=VT323&display=swap');
+/* Pixel/retro fonts are self-hosted via next/font in app/layout.tsx and
+   exposed as --font-press-start-2p / --font-vt323 (zero CLS, no CDN request). */
 
 .pixel-text {
-  font-family: 'Press Start 2P', 'VT323', monospace !important;
+  font-family: var(--font-press-start-2p), var(--font-vt323), monospace !important;
   letter-spacing: 0.5px;
 }
 
 .pixel-button {
-  font-family: 'Press Start 2P', 'VT323', monospace !important;
+  font-family: var(--font-press-start-2p), var(--font-vt323), monospace !important;
   background: linear-gradient(#2b2540, #1c1830);
   color: #f5f3ff;
   border: 4px solid #8b7fe0;
@@ -47,7 +47,7 @@
 }
 
 .pixel-window {
-  font-family: 'Press Start 2P', 'VT323', monospace !important;
+  font-family: var(--font-press-start-2p), var(--font-vt323), monospace !important;
   background: linear-gradient(#1f1d2d, #161225);
   color: #f5f3ff;
   border: 4px solid #8b7fe0;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono, Press_Start_2P } from "next/font/google";
+import { Geist, Geist_Mono, Press_Start_2P, VT323 } from "next/font/google";
 import "./globals.css";
 import PreloadImages from "../components/PreloadImages";
 import PostHogProvider from "../components/PostHogProvider";
@@ -21,6 +21,15 @@ const pressStart2P = Press_Start_2P({
   subsets: ["latin"],
   display: "swap",
   variable: "--font-press-start-2p",
+});
+
+// Retro terminal font used as the pixel-text fallback (previously loaded via a
+// CSS @import from fonts.googleapis.com; now self-hosted through next/font).
+const vt323 = VT323({
+  weight: "400",
+  subsets: ["latin"],
+  display: "swap",
+  variable: "--font-vt323",
 });
 
 export const metadata: Metadata = {
@@ -79,7 +88,7 @@ export default function RootLayout({
         <link rel="preload" as="image" href="/images/hero/hero-front-static.png" />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} ${pressStart2P.variable} ${pressStart2P.className} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} ${pressStart2P.variable} ${vt323.variable} ${pressStart2P.className} antialiased`}
       >
         <PostHogProvider>
           <PreloadImages />

--- a/components/BedInteractionModal.module.css
+++ b/components/BedInteractionModal.module.css
@@ -45,7 +45,7 @@
   font-size: 24px;
   margin: 0 0 16px 0;
   text-align: center;
-  font-family: 'Press Start 2P', monospace;
+  font-family: var(--font-press-start-2p), monospace;
   text-shadow: 2px 2px 4px rgba(0, 0, 0, 0.5);
 }
 

--- a/components/DeathScreen.tsx
+++ b/components/DeathScreen.tsx
@@ -72,7 +72,7 @@ export function DeathScreen({ deathCause, onRestart, hasCheckpoint = true }: Dea
           <h1
             className="text-6xl font-bold text-red-500 tracking-wider"
             style={{
-              fontFamily: '"Press Start 2P", "Courier New", monospace',
+              fontFamily: 'var(--font-press-start-2p), "Courier New", monospace',
               textShadow: '4px 4px 0px rgba(0, 0, 0, 0.8)',
             }}
           >
@@ -83,7 +83,7 @@ export function DeathScreen({ deathCause, onRestart, hasCheckpoint = true }: Dea
           <p
             className="text-xl text-gray-300"
             style={{
-              fontFamily: '"Press Start 2P", "Courier New", monospace',
+              fontFamily: 'var(--font-press-start-2p), "Courier New", monospace',
               textShadow: '2px 2px 0px rgba(0, 0, 0, 0.8)',
             }}
           >
@@ -97,7 +97,7 @@ export function DeathScreen({ deathCause, onRestart, hasCheckpoint = true }: Dea
           onClick={onRestart}
           className="mt-8 px-8 py-4 text-lg font-bold text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-all duration-200 transform hover:scale-105 active:scale-95 shadow-lg hover:shadow-xl"
           style={{
-            fontFamily: '"Press Start 2P", "Courier New", monospace',
+            fontFamily: 'var(--font-press-start-2p), "Courier New", monospace',
             textShadow: '2px 2px 0px rgba(0, 0, 0, 0.5)',
           }}
         >


### PR DESCRIPTION
globals.css was re-fetching Press Start 2P (already loaded via next/font) plus VT323 from fonts.googleapis.com through a CSS @import — a render-blocking external request and a layout-shift source.

- VT323 now loads through next/font/google; both pixel fonts exposed as CSS variables
- @import removed; all font-family references (.pixel-text/.pixel-button, bed modal, DeathScreen inline styles) point at the variables
- Verified: identical rendering, self-hosted woff2s only, zero fonts.googleapis.com/gstatic requests, typecheck + 575 tests + build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)