### PR TITLE
Smooth mode: ghosts glide through walls and hover ambiently

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -475,6 +475,27 @@ body {
   }
 }
 
+/* Smooth movement: perpetual ambient drift for ghosts — a slow, slightly
+   irregular hover (up/down with a little sideways sway). Runs on the INNER
+   ghost sprite so it composes with the tile-to-tile slide on the wrapper. */
+@keyframes ghostFloat {
+  0% {
+    transform: translate(0px, 0px);
+  }
+  25% {
+    transform: translate(2.5px, -3px);
+  }
+  50% {
+    transform: translate(-1px, -5px);
+  }
+  75% {
+    transform: translate(-3px, -1.5px);
+  }
+  100% {
+    transform: translate(0px, 0px);
+  }
+}
+
 /* Responsive scaling: scale all game UI (except bottom controls) as a single unit below 650px */
 
 /* Scale the entire game UI (excluding MobileControls) from a 600px baseline */

--- a/components/Tile.tsx
+++ b/components/Tile.tsx
@@ -1121,6 +1121,44 @@ export const Tile: React.FC<TileProps> = ({
   // branches so the smooth slide-in logic lives in one place.
   const renderEnemySprite = () => {
     if (!hasEnemy) return null;
+    // Smooth mode: ghosts glide their whole phase move (through walls — that
+    // reads exactly right for a ghost) AND hover with a perpetual ambient
+    // drift. Two transform animations can't share one element, so the slide
+    // runs on the outer wrapper and the float + opacity flicker on the inner
+    // sprite. (The inline animation list must re-include ghost-flicker: the
+    // inline property overrides the .ghostFlicker class's animation.)
+    if (smoothMode && enemyKind === 'ghost') {
+      if ((enemyVisible ?? isVisible) !== true) return null;
+      return (
+        <div
+          key={enemyStep ? `enemy-step-${enemyStep.seq}` : 'enemy-static'}
+          className="absolute inset-0 pointer-events-none"
+          style={{
+            zIndex: 10500, // above fog (10000), below wall tops (12000)
+            ...smoothStepStyle(enemyStep, 'none'),
+          }}
+          data-testid="enemy-sprite"
+        >
+          <div
+            className="ghostFlicker"
+            style={{
+              position: 'absolute',
+              inset: 0,
+              backgroundImage: `url(${getEnemyIcon('ghost', 'front')})`,
+              backgroundSize: 'contain',
+              backgroundRepeat: 'no-repeat',
+              backgroundPosition: 'center',
+              // Same cave dimming as the legacy ghost sprite
+              filter: !environmentConfig.daylight
+                ? 'brightness(var(--enemy-dim, 0.80))'
+                : undefined,
+              animation:
+                'ghost-flicker 2000ms ease-in-out infinite, ghostFloat 3600ms ease-in-out infinite',
+            }}
+          />
+        </div>
+      );
+    }
     // Phase 3 (smooth mode only): white-goblin swarms render as N overlaid
     // SINGLE goblins instead of the baked 1-4 pack images. Singles have real
     // right-facing art, so sideways packs mirror properly instead of the

--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -1736,11 +1736,17 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
       if (!p) return;
       const dy = p[0] - y;
       const dx = p[1] - x;
-      // Only animate single-tile steps. 0 = stood still; >1 = ghost wall-phase,
-      // pink-ninja slide/blink, room warp — those should snap, not glide.
-      if (Math.abs(dy) + Math.abs(dx) !== 1) return;
-      // Ghosts flicker-phase (and carry their own CSS animation) — never slide.
-      if (kind === "ghost") return;
+      const dist = Math.abs(dy) + Math.abs(dx);
+      if (dist === 0) return; // stood still
+      if (kind === "ghost") {
+        // Ghosts glide their whole phase move — drifting through walls reads
+        // exactly right for them. Cap it so cross-map warps still snap.
+        if (dist > 6) return;
+      } else if (dist !== 1) {
+        // Non-ghosts animate single-tile steps only; pink-ninja slides/blinks
+        // and room warps snap.
+        return;
+      }
       steps.set(`${keyPrefix}:${y},${x}`, { dy, dx, dur, ease, seq });
     };
     for (const e of gameState.enemies ?? []) {


### PR DESCRIPTION
Prod-testing feedback: ghosts snapped while everything else glided. They were deliberately excluded (multi-tile wall-phasing + the slide animation would override their opacity flicker).

- Ghosts now glide their whole phase move — through walls, which reads perfectly ghostly (capped at 6 tiles so warps still snap)
- New perpetual hover: slow irregular up/down + sideways drift (ghostFloat keyframes)
- Slide on an outer wrapper, float + flicker on the inner sprite — all three animations compose

Verified live in /test-room-2?smooth=1: flicker + float running concurrently, glides observed at both walk (270ms) and run (120ms) cadences. Flag-gated; legacy untouched (575/586 tests pass, build clean). Also merges main into the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)