### PR TITLE
Smooth-mode fixes: snake pose, aura slide, snuffed-torch z-order; bombs kill stone goblins

### DIFF
--- a/__tests__/lib/bomb_throwing.test.ts
+++ b/__tests__/lib/bomb_throwing.test.ts
@@ -199,14 +199,13 @@ describe("Bomb blast - fixed damage values", () => {
     expect(withShield.heroHealth).toBe(5); // 9 - 4
   });
 
-  it("a stone goblin (8 HP) survives a single bomb", () => {
+  it("a stone goblin (8 HP) is destroyed by a single bomb", () => {
     const map = makeArena(12, 5, 5);
     map.subtypes[5][6] = [TileSubtype.BOMB_LIVE];
     const goblin = new Enemy({ y: 5, x: 5 }); // in the 3x3
     goblin.kind = "stone-goblin";
     const blown = detonateLiveBombs(baseState(map, { enemies: [goblin], bombCount: 0 }));
-    expect(blown.enemies?.length).toBe(1);
-    expect(blown.enemies?.[0].health).toBe(2); // 8 - 6
+    expect(blown.enemies?.length).toBe(0); // 8 damage kills its 8 HP outright
   });
 });
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -475,6 +475,33 @@ body {
   }
 }
 
+/* Smooth movement: the snuffed-torch FOV classes dim each tile via `filter`
+   and set `z-index: 0` — BOTH create a per-tile stacking context, which
+   confines the wall-top overlays (z 12000) inside their tile and lets the
+   map-space hero (z 11000) paint over them. Scope-limited fix: drop the
+   context creators and dim with an ::after overlay instead. The overlay sits
+   at z 13000 so it darkens the wall tops AND the hero passing through, which
+   is exactly what the legacy whole-tile filter did. Legacy mode untouched. */
+.smooth-movement .fov-tier-snuff-core,
+.smooth-movement .fov-tier-snuff-ring {
+  filter: none;
+  z-index: auto;
+}
+.smooth-movement .fov-tier-snuff-core::after,
+.smooth-movement .fov-tier-snuff-ring::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 13000;
+}
+.smooth-movement .fov-tier-snuff-core::after {
+  background: rgba(0, 0, 0, 0.48); /* ~ brightness(0.52) */
+}
+.smooth-movement .fov-tier-snuff-ring::after {
+  background: rgba(0, 0, 0, 0.75); /* ~ brightness(0.25) */
+}
+
 /* Smooth movement: perpetual ambient drift for ghosts — a slow, slightly
    irregular hover (up/down with a little sideways sway). Runs on the INNER
    ghost sprite so it composes with the tile-to-tile slide on the wrapper. */

--- a/components/Tile.tsx
+++ b/components/Tile.tsx
@@ -1244,7 +1244,14 @@ export const Tile: React.FC<TileProps> = ({
       <>
         {enemyAura && (
           <div
+            // Slide with the goblin: the aura renders in the destination tile,
+            // so without this it snaps a tile ahead while the sprite glides.
+            // The class's own centering translate composes into the keyframes.
+            key={enemyStep ? `enemy-aura-step-${enemyStep.seq}` : 'enemy-aura-static'}
             className={styles.exitGlow}
+            style={{
+              ...smoothStepStyle(enemyStep, 'translate(-50%, -50%)'),
+            }}
             aria-hidden="true"
           />
         )}

--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -3869,7 +3869,9 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
           {/* Centered map container */}
           <div className="flex justify-center items-center">
             <div
-              className={`${styles.viewportContainer} max-w-full overflow-auto`}
+              // .smooth-movement scopes CSS overrides that keep per-tile FOV
+              // classes from creating stacking contexts (see globals.css).
+              className={`${styles.viewportContainer} max-w-full overflow-auto${smoothEnabled ? " smooth-movement" : ""}`}
               data-testid="tilemap-grid-container"
               style={{
                 gridTemplateColumns:

--- a/lib/enemies/registry.ts
+++ b/lib/enemies/registry.ts
@@ -873,6 +873,11 @@ export const EnemyRegistry: Record<EnemyKind, EnemyConfig> = {
         const py = ctx.player.y;
         const px = ctx.player.x;
 
+        // Reset the per-turn UI flag: `moved` was only ever set to true, so the
+        // snake stuck on its slither sprite after its first move instead of
+        // alternating coiled <-> moving each turn.
+        e.memory.moved = false;
+
         // If adjacent, attack
         const manhattan = Math.abs(e.y - py) + Math.abs(e.x - px);
         if (manhattan === 1) {

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -1045,8 +1045,8 @@ const BOMB_THROW_RANGE = 4;
 const BOMB_PLAYER_DAMAGE = 6;
 /** Reduced hero damage when carrying a shield. */
 const BOMB_PLAYER_DAMAGE_SHIELD = 4;
-/** Damage dealt to each enemy in the blast. ~kills most; a stone goblin (8 HP) survives one. */
-const BOMB_ENEMY_DAMAGE = 6;
+/** Damage dealt to each enemy in the blast. Kills everything, incl. a stone goblin (8 HP). */
+const BOMB_ENEMY_DAMAGE = 8;
 /** Each chest bomb pickup grants this many bombs. */
 export const BOMB_PACK_SIZE = 3;
 


### PR DESCRIPTION
Four fixes from prod testing:

1. **Snake two-pose animation restored** — the `moved` flag was never reset, so the sprite never alternated coiled/slither. Root fix in the snake behavior (helps legacy too).
2. **Stone-goblin aura glides with the goblin** — it was snapping to the destination tile while the sprite slid.
3. **Snuffed-torch z-order** — the snuff FOV classes created per-tile stacking contexts (filter + z-index:0), re-breaking hero-vs-wall-top occlusion when the light was out. Smooth-scoped CSS dims via ::after overlays instead; verified computed styles (filter none / z auto / overlays 0.48 & 0.75 @ z13000).
4. **Bombs deal 8 damage** — stone goblins (8 HP) now die to a single bomb, per design decision. Test updated.

Verified live: aura slide animation observed (270ms ease-in-out with composed translate), snuff state exercised via ghost light-steal in /test-room-2. Build clean, 575/586 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)