### PR TITLE
Smooth mode: snake slithers only while sliding, coils on landing

### DIFF
--- a/app/test-snake/page.tsx
+++ b/app/test-snake/page.tsx
@@ -1,0 +1,138 @@
+"use client";
+
+import React, { Suspense } from "react";
+import { TilemapGrid } from "../../components/TilemapGrid";
+import {
+  tileTypes,
+  TileSubtype,
+  type GameState,
+  Direction,
+} from "../../lib/map";
+import { Enemy } from "../../lib/enemy";
+
+const ROOM_SIZE = 20;
+const FLOOR = 0;
+const WALL = 1;
+
+function buildSnakeTestRoom(): GameState {
+  const height = ROOM_SIZE + 2; // +2 for walls
+  const width = ROOM_SIZE + 2;
+
+  const tiles: number[][] = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => WALL)
+  );
+  const subtypes: number[][][] = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => [])
+  );
+
+  // Create floor area
+  for (let y = 1; y <= ROOM_SIZE; y++) {
+    for (let x = 1; x <= ROOM_SIZE; x++) {
+      tiles[y][x] = FLOOR;
+    }
+  }
+
+  // Entry point in the center
+  const centerY = Math.floor(height / 2);
+  const centerX = Math.floor(width / 2);
+  subtypes[centerY][centerX] = [TileSubtype.PLAYER];
+
+  // A few snakes scattered around the hero so their coiled <-> slither pose
+  // swap (and poison behavior) is easy to observe.
+  const enemies: Enemy[] = [];
+  const snakeSpots: Array<[number, number]> = [
+    [centerY - 4, centerX - 3],
+    [centerY - 3, centerX + 4],
+    [centerY + 4, centerX + 2],
+  ];
+  for (const [sy, sx] of snakeSpots) {
+    const snake = new Enemy({ y: sy, x: sx });
+    snake.kind = "snake";
+    enemies.push(snake);
+  }
+
+  // Add wall torches for visibility
+  const torchPositions: Array<[number, number]> = [
+    [0, 5],
+    [0, 16],
+    [0, 11],
+    [21, 5],
+    [21, 16],
+    [21, 11],
+  ];
+
+  for (const [ty, tx] of torchPositions) {
+    subtypes[ty][tx] = [TileSubtype.WALL_TORCH];
+  }
+
+  const gameState: GameState = {
+    hasKey: false,
+    hasExitKey: false,
+    hasSword: true,
+    hasShield: true,
+    showFullMap: true,
+    win: false,
+    playerDirection: Direction.DOWN,
+    enemies,
+    heroHealth: 5,
+    heroMaxHealth: 5,
+    heroAttack: 1,
+    heroTorchLit: true,
+    rockCount: 3,
+    runeCount: 0,
+    foodCount: 0,
+    potionCount: 1,
+    stats: {
+      damageDealt: 0,
+      damageTaken: 0,
+      enemiesDefeated: 0,
+      steps: 0,
+    },
+    mapData: { tiles, subtypes, environment: "cave" },
+    recentDeaths: [],
+    mode: "normal",
+  };
+
+  return gameState;
+}
+
+function TestSnakeInner() {
+  const initialState = buildSnakeTestRoom();
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center justify-center p-4 text-white relative"
+      style={{
+        backgroundImage: "url(/images/presentational/wall-up-close.png)",
+        backgroundRepeat: "repeat",
+        backgroundSize: "auto",
+      }}
+    >
+      <div className="absolute inset-0 bg-black/40 pointer-events-none"></div>
+      <div className="relative z-10 flex flex-col items-center gap-4">
+        <div className="text-center bg-black/70 rounded-lg p-4 backdrop-blur-sm">
+          <h1 className="text-2xl font-bold mb-2">Snake Test Room</h1>
+          <p className="text-sm text-gray-300">
+            3 snakes — watch the coiled ↔ slither pose swap as they move
+          </p>
+          <div className="text-xs text-gray-400 mt-2 space-y-1">
+            <p>🐍 Snake: 2 HP, 1 ATK, poisons on hit</p>
+            <p>Hero: 5 HP, 1 ATK + Sword (+2) + Shield (-1 dmg), 1 potion</p>
+          </div>
+        </div>
+        <TilemapGrid
+          tileTypes={tileTypes}
+          initialGameState={initialState}
+          forceDaylight={true}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function TestSnakePage() {
+  return (
+    <Suspense fallback={null}>
+      <TestSnakeInner />
+    </Suspense>
+  );
+}

--- a/components/Tile.tsx
+++ b/components/Tile.tsx
@@ -118,6 +118,12 @@ export const Tile: React.FC<TileProps> = ({
   smoothMode = false,
 }) => {
   const environmentConfig = getEnvironmentConfig(environment);
+  // Smooth movement: tracks the enemy slide animation finishing (via
+  // onAnimationEnd) so sprites that change pose with motion — the snake's
+  // coiled <-> slither swap — revert the moment the tween lands instead of
+  // waiting for the next turn's re-render. Re-keyed steps (new seq) reset it.
+  const [smoothSlideDoneSeq, setSmoothSlideDoneSeq] = React.useState<number | null>(null);
+  const enemySliding = !!enemyStep && smoothSlideDoneSeq !== enemyStep.seq;
   // Torch animations disabled for performance: render static torch sprite when present.
   // Fast bitmask-based wall variant resolver for perspective.
   // We IGNORE the North (behind) bit and only key off E, S, W.
@@ -1223,6 +1229,10 @@ export const Tile: React.FC<TileProps> = ({
       );
     }
     // Facing flip / scale for the sprite (composed into the slide keyframes too).
+    // Snake pose: in smooth mode the slither sprite shows ONLY while the tile
+    // slide is actually animating (coiled the moment it lands); legacy keeps
+    // the per-turn `moved` flag since there is no tween to sync with.
+    const snakeMoving = smoothMode ? enemySliding : !!enemyMoved;
     const enemyBaseTransform = (() => {
       // Default flip rule (for enemies that only have right-facing art): flip when facing LEFT
       if (enemyKind !== 'snake') {
@@ -1234,8 +1244,7 @@ export const Tile: React.FC<TileProps> = ({
       }
       // Snakes: scale to 50% and flip moving-right to mirror moving-left asset
       const baseScale = 'scale(0.5)';
-      const moved = !!enemyMoved;
-      if (moved && enemyFacing === 'RIGHT') {
+      if (snakeMoving && enemyFacing === 'RIGHT') {
         return 'scaleX(-1) ' + baseScale;
       }
       return baseScale;
@@ -1278,12 +1287,12 @@ export const Tile: React.FC<TileProps> = ({
                   }
                 };
                 const kind: EnemyKind = (enemyKind ?? 'fire-goblin');
-                // For snakes: use moving sprite when enemyMoved, else coiled
+                // For snakes: slither sprite while moving, coiled otherwise
+                // (smooth mode syncs "moving" to the live slide animation)
                 if (kind === 'snake') {
                   const f = enemyFacing;
                   // moving sprite only exists for 'left'; request 'left' for moving, coiled otherwise
-                  const useMoving = !!enemyMoved;
-                  if (useMoving) {
+                  if (snakeMoving) {
                     return getEnemyIcon('snake', 'left');
                   }
                   // coiled sprite follows facing (front/back/right are coiled)
@@ -1310,7 +1319,17 @@ export const Tile: React.FC<TileProps> = ({
               filter: (!environmentConfig.daylight && enemyKind !== 'fire-goblin')
                 ? 'brightness(var(--enemy-dim, 0.80))'
                 : undefined,
-              ...smoothStepStyle(enemyStep, enemyBaseTransform),
+              // Only while actually sliding: once the tween lands the animation
+              // style is dropped so the static transform/pose takes over (this
+              // is what lets the snake snap back to its coiled sprite).
+              ...(enemySliding
+                ? smoothStepStyle(enemyStep, enemyBaseTransform)
+                : null),
+            }}
+            onAnimationEnd={(e) => {
+              if (e.animationName === 'smoothStepSlide' && enemyStep) {
+                setSmoothSlideDoneSeq(enemyStep.seq);
+              }
             }}
             data-testid="enemy-sprite"
           />


### PR DESCRIPTION
Follow-up to #38 per design feedback: the snake should hold its coiled pose whenever at rest and show the slither sprite only during the actual tile slide.

The slide ends in CSS without a re-render, so the sprite div now fires onAnimationEnd → marks the step done → re-renders the resting pose (and drops the completed animation style so the static transform applies). Legacy keeps per-turn pose semantics.

Also adds /test-snake (three snakes in an open room) — there was no test page with a snake, which made the previous round unverifiable live. Verified there: trace shows coiled → slither-while-animating → coiled cycles.

Build clean, 575/586 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)