### PR TITLE
Enemies fall face-first into the abyss like the hero

### DIFF
--- a/__tests__/lib/enemy_defeat_story_events.test.ts
+++ b/__tests__/lib/enemy_defeat_story_events.test.ts
@@ -163,6 +163,7 @@ describe("Enemy Defeat Story Events", () => {
         y: 5,
         x: 5,
         kind: "fire-goblin",
+        id: expect.any(String), // auto-generated stable render id
         behaviorMemory: { isKalenThreat: true, moved: false }
       });
     });
@@ -176,6 +177,7 @@ describe("Enemy Defeat Story Events", () => {
         y: 5,
         x: 5,
         kind: "fire-goblin",
+        id: expect.any(String), // auto-generated stable render id
         behaviorMemory: {}
       });
     });

--- a/app/globals.css
+++ b/app/globals.css
@@ -502,6 +502,27 @@ body {
   background: rgba(0, 0, 0, 0.75); /* ~ brightness(0.25) */
 }
 
+/* An enemy dropping face-first into a freshly opened abyss (mirrors the
+   hero's dive). --fall-from lets smooth mode slide the sprite in from the
+   tile it fell from before it shrinks into the hole; legacy leaves it unset
+   and the sprite just shrinks in place. */
+@keyframes enemyAbyssFall {
+  0% {
+    transform: var(--fall-from, none);
+    opacity: 1;
+    animation-timing-function: ease-in-out;
+  }
+  45% {
+    transform: translate(0px, 0px) scale(1);
+    opacity: 1;
+    animation-timing-function: ease-in;
+  }
+  100% {
+    transform: scale(0);
+    opacity: 0.9;
+  }
+}
+
 /* Smooth movement: perpetual ambient drift for ghosts — a slow, slightly
    irregular hover (up/down with a little sideways sway). Runs on the INNER
    ghost sprite so it composes with the tile-to-tile slide on the wrapper. */

--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -1776,6 +1776,12 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
   const [spirits, setSpirits] = useState<
     Array<{ id: string; y: number; x: number; createdAt: number }>
   >([]);
+  // Transient "enemy fell into the abyss" dives (spawn when a defeated
+  // enemy's tile just became an open abyss). fallFrom is the smooth-mode
+  // slide-in offset from the tile it fell from, when known.
+  const [enemyAbyssFalls, setEnemyAbyssFalls] = useState<
+    Array<{ id: string; y: number; x: number; kind: string; fallFrom?: string }>
+  >([]);
   // Transient floating damage numbers (hero/enemy hits)
   const [floating, setFloating] = useState<FloatingNumber[]>([]);
   const [heroDeathPhase, setHeroDeathPhase] = useState<HeroDeathPhase>("idle");
@@ -2820,6 +2826,46 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
       // Spawn spirits only for actual deaths reported by the engine this tick
       const died = newGameState.recentDeaths || [];
       if (died.length > 0) {
+        // Enemies whose tile just became an open abyss fell into the pit —
+        // show them dropping face-first into the hole (mirrors the hero's
+        // dive). Enemies can never die ON an abyss tile any other way, so
+        // this cleanly separates falls from combat deaths. Read BEFORE
+        // defeatedEnemies is cleared below.
+        const fell = (newGameState.defeatedEnemies ?? []).filter((d) =>
+          newGameState.mapData.subtypes[d.y]?.[d.x]?.includes(
+            TileSubtype.OPEN_ABYSS
+          )
+        );
+        if (fell.length > 0) {
+          const nowTs = Date.now();
+          const entries = fell.map((f) => {
+            // Smooth mode: slide in from the tile it fell from. The entity
+            // diff hasn't rebuilt yet, so the prev map still holds pre-move
+            // positions for this turn.
+            let fallFrom: string | undefined;
+            if (smoothEnabled && f.id) {
+              const p = smoothEntityPrevRef.current.get(`e:${f.id}`);
+              if (p && Math.abs(p[0] - f.y) + Math.abs(p[1] - f.x) === 1) {
+                fallFrom = `translate(${(p[1] - f.x) * 40}px, ${(p[0] - f.y) * 40}px) scale(1)`;
+              }
+            }
+            return {
+              id: `fall-${f.y},${f.x}-${nowTs}-${Math.random()
+                .toString(36)
+                .slice(2, 7)}`,
+              y: f.y,
+              x: f.x,
+              kind: f.kind,
+              fallFrom,
+            };
+          });
+          setEnemyAbyssFalls((prev) => [...prev, ...entries]);
+          for (const e of entries) {
+            setTimeout(() => {
+              setEnemyAbyssFalls((curr) => curr.filter((c) => c.id !== e.id));
+            }, 800);
+          }
+        }
         // onEnemyDefeat processing is now handled directly in game-state.ts
         // Clear defeated enemies after processing
         if (newGameState.defeatedEnemies) {
@@ -4095,6 +4141,40 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
                         >
                           {f.miss ? "miss" : `${f.sign}${f.amount}`}
                         </div>
+                      );
+                    });
+                  })()}
+                {/* Enemies dropping face-first into a freshly opened abyss */}
+                {enemyAbyssFalls.length > 0 &&
+                  (() => {
+                    const tileSize = 40; // px
+                    return enemyAbyssFalls.map((f) => {
+                      const pxLeft = (f.x + 0.5) * tileSize;
+                      const pxTop = (f.y + 0.5) * tileSize;
+                      return (
+                        <div
+                          key={f.id}
+                          aria-hidden="true"
+                          className="absolute pointer-events-none"
+                          style={{
+                            left: `${pxLeft - tileSize / 2}px`,
+                            top: `${pxTop - tileSize / 2}px`,
+                            width: `${tileSize}px`,
+                            height: `${tileSize}px`,
+                            backgroundImage: `url(${getEnemyIcon(
+                              f.kind as EnemyKind,
+                              "front"
+                            )})`,
+                            backgroundSize: "contain",
+                            backgroundRepeat: "no-repeat",
+                            backgroundPosition: "center",
+                            zIndex: 10500, // same layer as live enemies
+                            animation: "enemyAbyssFall 620ms forwards",
+                            ...(f.fallFrom
+                              ? ({ ["--fall-from" as string]: f.fallFrom } as React.CSSProperties)
+                              : null),
+                          }}
+                        />
                       );
                     });
                   })()}

--- a/lib/map/enemy-defeat-handler.ts
+++ b/lib/map/enemy-defeat-handler.ts
@@ -65,12 +65,16 @@ export function createDefeatedEnemyInfo(enemy: Enemy): {
   y: number;
   x: number;
   kind: string;
+  id?: string;
   behaviorMemory?: Record<string, unknown>;
 } {
   return {
     y: enemy.y,
     x: enemy.x,
     kind: enemy.kind,
+    // Render-layer identity: lets the UI animate this specific enemy's death
+    // (e.g. sliding into the abyss from the tile it fell from).
+    id: enemy.id,
     behaviorMemory: enemy.behaviorMemory
   };
 }

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -1425,6 +1425,9 @@ export interface GameState {
     y: number;
     x: number;
     kind: string;
+    // Stable render-layer id (lets the UI animate a specific enemy's death,
+    // e.g. sliding into the abyss from its previous tile).
+    id?: string;
     behaviorMemory?: Record<string, unknown>;
   }>;
   npcInteractionQueue?: NPCInteractionEvent[];


### PR DESCRIPTION
Design parity from prod testing: enemies that walk onto a faulty floor previously just vanished. They now dive into the pit — front sprite slides in from the tile they fell from (smooth mode) and shrinks into the freshly opened hole over ~620ms, mirroring the hero's dive; the spirit still rises after.

Falls are derived from the engine's existing signals (defeated enemy + tile just became OPEN_ABYSS — no other death can happen on an abyss tile). DefeatedEnemyInfo now carries the enemy render id for the previous-tile lookup.

Verified live in /test-room-3?smooth=1: lured a fire goblin onto a faulty tile — captured `enemyAbyssFall` running with `fire-goblin-front.png` and `--fall-from: translate(40px, 0px)`. Works in legacy too (shrinks in place). Build clean, 575/586 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)