### PR TITLE
Match under-goblin ring size to the deployed ring icon

### DIFF
--- a/components/Tile.tsx
+++ b/components/Tile.tsx
@@ -1155,12 +1155,19 @@ export const Tile: React.FC<TileProps> = ({
         key="pink-ring-under"
         aria-hidden="true"
         style={{
+          // Mirror the deployed ring's .assetIcon sizing (24x24, centered in
+          // the tile) so the ring looks identical whether it's under the
+          // goblin or parked on its own tile.
           position: 'absolute',
-          inset: 0,
+          left: '50%',
+          top: '50%',
+          width: 24,
+          height: 24,
+          transform: 'translate(-50%, -50%)',
           backgroundImage: `url('/images/enemies/fire-goblin/pink-ring-no-sparkle.png')`,
           backgroundSize: 'contain',
           backgroundRepeat: 'no-repeat',
-          backgroundPosition: 'center bottom',
+          backgroundPosition: 'center',
           pointerEvents: 'none',
         }}
       />


### PR DESCRIPTION
Prod-testing fix: the ring under the pink goblin rendered full-tile (40px) while the deployed ring subtype is a 24x24 centered icon, so the ring ballooned when the goblin stood over it. Now both render at the same 24x24 centered box.

Verified: under-ring measures exactly the icon size at layout scale, centered; visually matches the freestanding ring. Build clean, 575/586 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)