### PR TITLE
Fix pink-ring sparkles appearing as a row of solid dots on movement

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -525,7 +525,14 @@ body {
   height: 4px;
   border-radius: 50%;
   background: radial-gradient(circle, #ffd9f0 0%, #ff86cf 60%, rgba(255, 134, 207, 0) 100%);
-  animation: pinkRingSparkleRise 1.9s ease-out infinite;
+  /* Each sparkle is staggered via animation-delay, and the sprite remounts on
+     every move (enemies are keyed by grid position, not identity) — so all 5
+     delays restart together. Without `backwards`, a delayed animation shows
+     the element's un-animated (fully opaque, untransformed) state while
+     waiting, which reads as a solid row of dots that vanish left-to-right as
+     each one's delay elapses. `backwards` applies the 0% keyframe (opacity 0)
+     during the delay instead, so each sparkle stays invisible until its turn. */
+  animation: pinkRingSparkleRise 1.9s ease-out infinite backwards;
   pointer-events: none;
   z-index: 10400; /* above the ring icon, below enemies (10500) */
 }


### PR DESCRIPTION
Bug reported from prod testing: 5 pink dots would appear in a row under the pink goblin every time it moved, then disappear one by one left to right.

Root cause: the 5 ring sparkles use staggered `animation-delay` for an ambient rising effect, but since enemies are keyed by grid position (not identity), the sparkle elements remount fresh on every move in both modes — restarting all 5 delays in sync. Without `animation-fill-mode`, an element waiting out its delay renders its plain un-animated style (full opacity, no transform) rather than the animation's 0% state (opacity 0) — that's the row of solid dots, which then vanish in delay order as each one's animation actually starts.

Fix: added `backwards` to the animation shorthand so each sparkle honors the 0% keyframe (invisible) during its delay.

Verified: a fresh `.pink-ring-sparkle` element now computes `opacity: 0` immediately instead of `1`; live check in /test-pink-goblin?smooth=0 (matching the reported screenshot) shows no row-of-dots artifact after moving. Build clean, 575/586 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)