### PR TITLE
Bob+tilt walk for regular goblins; faster 170ms walk cadence

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -475,6 +475,21 @@ body {
   }
 }
 
+/* Regular-goblin variant of the slide above: adds a bob + tilt at the
+   midpoint (--smooth-step-mid, computed alongside from/to) so the walk reads
+   as a step rather than a flat glide. */
+@keyframes smoothStepSlideBob {
+  0% {
+    transform: var(--smooth-step-from, none);
+  }
+  50% {
+    transform: var(--smooth-step-mid, none);
+  }
+  100% {
+    transform: var(--smooth-step-to, none);
+  }
+}
+
 /* Smooth movement: the snuffed-torch FOV classes dim each tile via `filter`
    and set `z-index: 0` — BOTH create a per-tile stacking context, which
    confines the wall-top overlays (z 12000) inside their tile and lets the

--- a/components/Tile.tsx
+++ b/components/Tile.tsx
@@ -4,6 +4,7 @@ import { getEnemyIcon } from "../lib/enemies/registry";
 import type { EnemyKind, Facing } from "../lib/enemies/registry";
 import type { NPC } from "../lib/npc";
 import type { SmoothEntityStep } from "../lib/smooth_movement";
+import { ENEMY_GAIT, REGULAR_GOBLIN_KINDS } from "../lib/smooth_movement";
 import styles from "./Tile.module.css";
 import {
   DEFAULT_ENVIRONMENT,
@@ -1146,6 +1147,28 @@ export const Tile: React.FC<TileProps> = ({
     } as React.CSSProperties;
   };
 
+  // Regular-goblin variant: same slide, plus a bob + alternating tilt baked
+  // into a midpoint keyframe (see smoothStepSlideBob in globals.css). The
+  // midpoint is the geometric center of the slide with a vertical lift
+  // subtracted (screen-up is negative Y) and a rotate layered on top; 0%/100%
+  // stay flat-footed so the arc reads as a step, not a wobble at rest.
+  const smoothStepBobStyle = (
+    step: SmoothEntityStep | undefined,
+    base: string
+  ): React.CSSProperties | null => {
+    if (!step) return null;
+    const baseSuffix = !base || base === 'none' ? '' : ` ${base}`;
+    const midX = (step.dx * 40) / 2;
+    const midY = (step.dy * 40) / 2 - ENEMY_GAIT.bobPx;
+    const tilt = (step.seq % 2 ? 1 : -1) * ENEMY_GAIT.tiltDeg;
+    return {
+      ['--smooth-step-from' as string]: `translate(${step.dx * 40}px, ${step.dy * 40}px)${baseSuffix}`,
+      ['--smooth-step-mid' as string]: `translate(${midX}px, ${midY}px) rotate(${tilt}deg)${baseSuffix}`,
+      ['--smooth-step-to' as string]: !base || base === 'none' ? 'none' : base,
+      animation: `smoothStepSlideBob ${step.dur}ms ${step.ease} both`,
+    } as React.CSSProperties;
+  };
+
   // The pink goblin carries its teleport ring with it: unless the ring is
   // cast somewhere else (a PINK_RING subtype tile), it renders directly under
   // the goblin with the same rising sparkles the standing ring has.
@@ -1408,13 +1431,21 @@ export const Tile: React.FC<TileProps> = ({
                 : undefined,
               // Only while actually sliding: once the tween lands the animation
               // style is dropped so the static transform/pose takes over (this
-              // is what lets the snake snap back to its coiled sprite).
+              // is what lets the snake snap back to its coiled sprite). Regular
+              // goblins (fire/water/earth family) get the bob+tilt variant so
+              // their walk reads as a step rather than a flat glide.
               ...(enemySliding
-                ? smoothStepStyle(enemyStep, enemyBaseTransform)
+                ? REGULAR_GOBLIN_KINDS.has(enemyKind ?? '')
+                  ? smoothStepBobStyle(enemyStep, enemyBaseTransform)
+                  : smoothStepStyle(enemyStep, enemyBaseTransform)
                 : null),
             }}
             onAnimationEnd={(e) => {
-              if (e.animationName === 'smoothStepSlide' && enemyStep) {
+              if (
+                (e.animationName === 'smoothStepSlide' ||
+                  e.animationName === 'smoothStepSlideBob') &&
+                enemyStep
+              ) {
                 setSmoothSlideDoneSeq(enemyStep.seq);
               }
             }}

--- a/lib/smooth_movement.ts
+++ b/lib/smooth_movement.ts
@@ -12,9 +12,10 @@ import { Direction } from "./map";
  * legacy path unchanged.
  */
 
-// Tuning signed off in the sandbox review.
+// Tuning signed off in the sandbox review (walkStepMs bumped 270 -> 170 per
+// prod-testing feedback: the walk cadence read as slightly too slow).
 export const SMOOTH_TUNING = {
-  walkStepMs: 270,
+  walkStepMs: 170,
   runStepMs: 120,
   runThreshold: 1, // chained steps before running kicks in
   decayMs: 150, // idle gap (ms) that resets run momentum
@@ -23,6 +24,24 @@ export const SMOOTH_TUNING = {
   tiltDeg: 4, // weight-shift tilt
   squash: 0.04, // squash/stretch amount
 } as const;
+
+// Regular goblins (fire/water/earth family) get a subtle bob + alternating
+// tilt at the midpoint of their tile-to-tile slide — the flat slide alone
+// read as sliding rather than walking. Ghosts, the pink goblin, white-goblin
+// clusters, snakes, and the stone goblin keep the flat slide; their own
+// movement language (hover, slither, heavy trudge) already reads correctly.
+export const ENEMY_GAIT = {
+  bobPx: 3,
+  tiltDeg: 6,
+} as const;
+
+export const REGULAR_GOBLIN_KINDS = new Set([
+  "fire-goblin",
+  "water-goblin",
+  "water-goblin-spear",
+  "earth-goblin",
+  "earth-goblin-knives",
+]);
 
 export function isSmoothMovementEnabled(): boolean {
   if (process.env.NODE_ENV === "test") return false;


### PR DESCRIPTION
Prod-testing feedback: the enemy tile-to-tile slide read as a flat glide, and the walk cadence felt slightly slow.

- Fire/water/earth goblins (the colored humanoid family) get a bob (-3px lift) + alternating tilt (6°) at the midpoint of their slide, composed with the existing translate via a new smoothStepSlideBob keyframe + --smooth-step-mid var. Ghosts, the pink goblin, white-goblin clusters, snakes, and the stone goblin are intentionally excluded — each already has its own movement language (hover, slither, heavy trudge).
- SMOOTH_TUNING.walkStepMs 270 -> 170ms, which also speeds up every enemy/NPC step since their slide duration derives from the hero's current step duration.

Verified live in /test-room-3?smooth=1: captured animation duration 170ms and the mid-keyframe transform (translate + -3px lift + 6deg rotate) on a fire goblin's step. Build clean, 575/586 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)