### PR TITLE
Pink goblin flee-or-zap rework + portal ring at hero's feet

### DIFF
--- a/__tests__/lib/pink_goblin_stun.test.ts
+++ b/__tests__/lib/pink_goblin_stun.test.ts
@@ -1,10 +1,11 @@
 import { Enemy, updateEnemies } from "../../lib/enemy";
 import { TileSubtype } from "../../lib/map";
-import { FLOOR } from "../../lib/map/constants";
+import { FLOOR, WALL } from "../../lib/map/constants";
 
-// Stunned pink goblin: taking a hit (health drop between ticks) permanently
-// disables teleporting. From then on it melees when adjacent and otherwise
-// keeps backing away from the hero one tile per turn.
+// Pink goblin as a ranged skirmisher: at point-blank range it prefers to open
+// up distance (so it can laser) and only zaps when it's boxed in. Taking a hit
+// does NOT permanently change its behavior — it keeps its full teleport/laser
+// kit and simply reacts.
 
 const SIZE = 12;
 
@@ -21,67 +22,61 @@ function emptySubtypes(): number[][][] {
 function makePinkGoblin(y: number, x: number): Enemy {
   const e = new Enemy({ y, x });
   e.kind = "pink-goblin";
+  e.behaviorMemory.aware = true;
   return e;
 }
 
 const neutralRng = () => 0.5;
 
-describe("pink goblin — stunned mode after taking a hit", () => {
-  test("a health drop since last tick flags stunned and backs it off one tile", () => {
-    const grid = openGrid();
-    const subtypes = emptySubtypes();
-    const player = { y: 5, x: 2 };
-    const goblin = makePinkGoblin(5, 5); // LOS down the row, distance 3
-    goblin.health = 2;
-    goblin.behaviorMemory.aware = true;
-    goblin.behaviorMemory.lastHealth = 4; // snapshot from before the rock hit
-
-    updateEnemies(grid, subtypes, [goblin], player, { rng: neutralRng });
-
-    expect(goblin.behaviorMemory.stunned).toBe(true);
-    // Backed away along the row (player is left, so it retreats right).
-    expect(goblin.y).toBe(5);
-    expect(goblin.x).toBe(6);
-  });
-
-  test("stunned goblin removes its deployed ring and never teleports", () => {
-    const grid = openGrid();
-    const subtypes = emptySubtypes();
-    const player = { y: 5, x: 2 };
-    const goblin = makePinkGoblin(5, 6);
-    goblin.health = 2;
-    goblin.behaviorMemory.aware = true;
-    goblin.behaviorMemory.stunned = true;
-    // A ring it had deployed before getting hit
-    goblin.behaviorMemory.ringY = 2;
-    goblin.behaviorMemory.ringX = 9;
-    goblin.behaviorMemory.ringOrigSubs = [];
-    subtypes[2][9] = [TileSubtype.PINK_RING];
-
-    // Several ticks: the ring disappears and every move is a single step.
-    for (let i = 0; i < 5; i++) {
-      const [prevY, prevX] = [goblin.y, goblin.x];
-      updateEnemies(grid, subtypes, [goblin], player, { rng: neutralRng });
-      const stepSize =
-        Math.abs(goblin.y - prevY) + Math.abs(goblin.x - prevX);
-      expect(stepSize).toBeLessThanOrEqual(1); // no teleport
-    }
-
-    expect(subtypes[2][9]).not.toContain(TileSubtype.PINK_RING);
-    expect(goblin.behaviorMemory.ringY).toBeUndefined();
-    expect(goblin.behaviorMemory.ringX).toBeUndefined();
-    // Retreated from (5,6) away from the player at (5,2)
-    expect(goblin.x).toBeGreaterThan(6);
-  });
-
-  test("stunned goblin still melees when the hero is adjacent", () => {
+describe("pink goblin — point-blank flee-or-zap", () => {
+  test("adjacent with room to retreat backs off one tile and does not attack", () => {
     const grid = openGrid();
     const subtypes = emptySubtypes();
     const player = { y: 5, x: 5 };
-    const goblin = makePinkGoblin(5, 6); // directly right of player
-    goblin.health = 2;
-    goblin.behaviorMemory.aware = true;
-    goblin.behaviorMemory.stunned = true;
+    const goblin = makePinkGoblin(5, 6); // directly right of player, open space right
+
+    const result = updateEnemies(grid, subtypes, [goblin], player, {
+      rng: neutralRng,
+    }) as { damage: number; attackingEnemies: unknown[] };
+
+    // Opened up distance instead of trading blows
+    expect(Math.abs(goblin.y - 5) + Math.abs(goblin.x - 5)).toBeGreaterThan(1);
+    expect(result.damage).toBe(0);
+    expect(result.attackingEnemies).toHaveLength(0);
+  });
+
+  test("adjacent but fully cornered zaps for close-range damage", () => {
+    const grid = openGrid();
+    const subtypes = emptySubtypes();
+    // Seal the goblin into a one-tile pocket: walls on three sides, the player
+    // adjacent on the fourth, so no move can increase the distance.
+    const gy = 5, gx = 5;
+    grid[gy - 1][gx] = WALL; // up
+    grid[gy + 1][gx] = WALL; // down
+    grid[gy][gx + 1] = WALL; // right
+    const goblin = makePinkGoblin(gy, gx);
+    const player = { y: gy, x: gx - 1 }; // directly left, adjacent
+
+    const result = updateEnemies(grid, subtypes, [goblin], player, {
+      rng: neutralRng,
+    }) as {
+      damage: number;
+      attackingEnemies: Array<{ kind: string; ranged: boolean }>;
+    };
+
+    // Could not increase distance -> stayed put and zapped
+    expect(goblin.y).toBe(gy);
+    expect(goblin.x).toBe(gx);
+    expect(result.damage).toBeGreaterThanOrEqual(1);
+    expect(result.attackingEnemies).toHaveLength(1);
+    expect(result.attackingEnemies[0].kind).toBe("pink-goblin");
+  });
+
+  test("still lasers at range with a clear line of sight", () => {
+    const grid = openGrid();
+    const subtypes = emptySubtypes();
+    const player = { y: 5, x: 1 };
+    const goblin = makePinkGoblin(5, 5); // distance 4, LOS down the row
 
     const result = updateEnemies(grid, subtypes, [goblin], player, {
       rng: neutralRng,
@@ -92,24 +87,24 @@ describe("pink goblin — stunned mode after taking a hit", () => {
 
     expect(result.damage).toBeGreaterThanOrEqual(1);
     expect(result.attackingEnemies).toHaveLength(1);
-    expect(result.attackingEnemies[0].kind).toBe("pink-goblin");
-    expect(result.attackingEnemies[0].ranged).toBe(false);
+    expect(result.attackingEnemies[0].ranged).toBe(true); // fires a beam
   });
 
-  test("cornered stunned goblin sidesteps along the wall instead of freezing", () => {
+  test("taking a hit does not disable teleporting — a ring is still deployed with no LOS", () => {
     const grid = openGrid();
     const subtypes = emptySubtypes();
-    // Player left of the goblin, goblin against the right wall
-    const player = { y: 5, x: 8 };
-    const goblin = makePinkGoblin(5, 11);
-    goblin.health = 2;
-    goblin.behaviorMemory.aware = true;
-    goblin.behaviorMemory.stunned = true;
+    // A wall between goblin and player breaks LOS so the goblin uses its ring.
+    for (let y = 0; y < SIZE; y++) grid[y][4] = WALL;
+    const player = { y: 5, x: 1 };
+    const goblin = makePinkGoblin(5, 8);
+    goblin.health = 2; // already damaged by a rock
 
-    updateEnemies(grid, subtypes, [goblin], player, { rng: neutralRng });
+    updateEnemies(grid, subtypes, [goblin], player, { rng: () => 0.1 });
 
-    // Away axis (x) is blocked by the wall, so it falls back to a y sidestep.
-    expect(goblin.x).toBe(11);
-    expect(Math.abs(goblin.y - 5)).toBe(1);
+    // With no LOS it drops a teleport ring rather than being permanently defanged
+    const ringOut = subtypes.some((row) =>
+      row.some((cell) => cell.includes(TileSubtype.PINK_RING))
+    );
+    expect(ringOut).toBe(true);
   });
 });

--- a/__tests__/lib/pink_ring.test.ts
+++ b/__tests__/lib/pink_ring.test.ts
@@ -6,7 +6,7 @@ import {
   detonateLiveBombs,
   performThrowRune,
 } from "../../lib/map";
-import { FLOOR } from "../../lib/map/constants";
+import { FLOOR, WALL } from "../../lib/map/constants";
 import type { MapData } from "../../lib/map/types";
 import { Enemy } from "../../lib/enemy";
 
@@ -93,7 +93,12 @@ describe("Pink goblin ring on death", () => {
 
   it("a melee kill leaves no ring behind", () => {
     const map = arena(12, 5, 5); // player at (5,5)
-    const goblin = new Enemy({ y: 5, x: 6 }); // adjacent
+    // Pink goblins now dodge melee if they can retreat, so wall the goblin into
+    // a pocket (walls right / above / below) — cornered, it takes the hit.
+    map.tiles[5][7] = WALL;
+    map.tiles[4][6] = WALL;
+    map.tiles[6][6] = WALL;
+    const goblin = new Enemy({ y: 5, x: 6 }); // adjacent, boxed in
     goblin.kind = "pink-goblin";
     goblin.health = 1; // one strong hit kills it
 

--- a/components/Tile.tsx
+++ b/components/Tile.tsx
@@ -940,9 +940,23 @@ export const Tile: React.FC<TileProps> = ({
             <div
               key="portal"
               data-testid={`subtype-icon-${TileSubtype.PORTAL}`}
-              className={`${styles.assetIcon} ${styles.rockIcon}`}
+              aria-hidden="true"
               style={{
+                // Nudged down a few px (matching the pink goblin's under-ring)
+                // so the ring ellipse sits at the hero's feet when he's standing
+                // on the portal, instead of overlapping his body.
+                position: 'absolute',
+                left: '50%',
+                top: 'calc(50% + 5px)',
+                width: 24,
+                height: 24,
+                transform: 'translate(-50%, -50%)',
                 backgroundImage: `url('/images/enemies/fire-goblin/blue-ring-no-sparkle.png')`,
+                backgroundSize: 'contain',
+                backgroundRepeat: 'no-repeat',
+                backgroundPosition: 'center',
+                zIndex: 1030,
+                pointerEvents: 'none',
               }}
             />
             {[0, 1, 2, 3, 4].map((i) => (

--- a/lib/enemies/registry.ts
+++ b/lib/enemies/registry.ts
@@ -180,33 +180,14 @@ export const EnemyRegistry: Record<EnemyKind, EnemyConfig> = {
         const isFloor = (y: number, x: number) => isIn(y, x) && grid[y][x] === 0;
         const manhattan = Math.abs(e.y - py) + Math.abs(e.x - px);
 
-        // Memory keys: aware, ringY, ringX, ringOrigSubs (saved subtypes), ringAge (turns
-        // since ring placed), lastHealth/stunned (hit-reaction defensive mode)
+        // Memory keys: aware, ringY, ringX, ringOrigSubs (saved subtypes), ringAge (turns since ring placed)
         const mem = e.memory as {
           aware?: boolean;
           ringY?: number;
           ringX?: number;
           ringOrigSubs?: number[];
           ringAge?: number;
-          lastHealth?: number;
-          stunned?: boolean;
         };
-
-        // Taking a hit breaks the goblin's concentration: compare health against last
-        // tick's snapshot — a drop means the hero connected (rock or melee). From then
-        // on it is "stunned": it can never teleport again, and it either swipes at an
-        // adjacent hero or keeps backing away (branch below, dungeon variant only).
-        // ctx.enemy omits health, so read it off the enemies array by index.
-        const selfHealth = ctx.enemies[ctx.enemyIndex]?.health;
-        if (
-          typeof selfHealth === "number" &&
-          typeof mem.lastHealth === "number" &&
-          selfHealth < mem.lastHealth
-        ) {
-          mem.stunned = true;
-          mem.aware = true;
-        }
-        if (typeof selfHealth === "number") mem.lastHealth = selfHealth;
 
         // --- Pink mist (realm only): if standing in the haze the goblin is disoriented.
         // It can only shuffle ONE tile toward the nearest clear tile and cannot attack;
@@ -402,6 +383,35 @@ export const EnemyRegistry: Record<EnemyKind, EnemyConfig> = {
           }
         };
 
+        // Helper: take one step that INCREASES distance from the player. Tries
+        // the direct away-move on each axis first, then perpendicular sidesteps
+        // (which still open up distance from point-blank range). Returns whether
+        // it actually moved — the caller uses that to decide flee-vs-attack.
+        const stepAwayFromPlayer = (): boolean => {
+          const dy = py - e.y;
+          const dx = px - e.x;
+          const candidates: Array<[number, number]> = [];
+          if (dx !== 0) candidates.push([0, dx > 0 ? -1 : 1]); // straight away on x
+          if (dy !== 0) candidates.push([dy > 0 ? -1 : 1, 0]); // straight away on y
+          // Perpendicular sidesteps as a fallback when the direct lane is blocked.
+          if (dx !== 0) candidates.push([-1, 0], [1, 0]);
+          if (dy !== 0) candidates.push([0, -1], [0, 1]);
+          for (const [my, mx] of candidates) {
+            const ny = e.y + my;
+            const nx = e.x + mx;
+            if (ny === py && nx === px) continue;
+            if (Math.abs(py - ny) + Math.abs(px - nx) <= manhattan) continue; // must gain distance
+            if (isFloor(ny, nx)) {
+              e.facing = mx !== 0 ? (mx > 0 ? "RIGHT" : "LEFT") : my > 0 ? "DOWN" : "UP";
+              e.y = ny;
+              e.x = nx;
+              e.memory.moved = true;
+              return true;
+            }
+          }
+          return false;
+        };
+
         // Ranged attack damage by manhattan distance
         const rangedDamage = (dist: number): number => {
           if (dist <= 1) return 1;
@@ -497,40 +507,6 @@ export const EnemyRegistry: Record<EnemyKind, EnemyConfig> = {
           return 0;
         }
 
-        // --- Stunned (has taken a hit): teleporting is permanently disabled. ---
-        // Melee if adjacent, otherwise keep backing away one tile per turn. Ninjas
-        // never reach here (their branch above always returns).
-        if (mem.stunned === true) {
-          if (hasRing) {
-            removeRing();
-            delete mem.ringAge;
-          }
-          facePlayer();
-          if (manhattan === 1) {
-            // Cornered swipe — same base damage as the un-stunned adjacent case.
-            return 1;
-          }
-          // Back away along the larger-gap axis, falling back to the other axis.
-          const dy = py - e.y;
-          const dx = px - e.x;
-          const awayY: [number, number] = [dy > 0 ? -1 : 1, 0];
-          const awayX: [number, number] = [0, dx > 0 ? -1 : 1];
-          const tryMoves = Math.abs(dy) >= Math.abs(dx) ? [awayY, awayX] : [awayX, awayY];
-          for (const [my, mx] of tryMoves) {
-            const ny = e.y + my;
-            const nx = e.x + mx;
-            if (ny === py && nx === px) continue;
-            if (isFloor(ny, nx)) {
-              e.y = ny;
-              e.x = nx;
-              e.memory.moved = true;
-              break;
-            }
-          }
-          facePlayer(); // keep eyes on the hero even while retreating
-          return 0;
-        }
-
         if (hasLOS) {
           // --- LOS mode: ranged attack + positioning, no teleportation ---
           // Clean up any existing ring since we have direct sight
@@ -544,11 +520,17 @@ export const EnemyRegistry: Record<EnemyKind, EnemyConfig> = {
             return 0;
           }
 
-          // Adjacent (manhattan === 1): always melee, no back-away. Pink goblins should
-          // be at least as threatening as a basic goblin when the hero stands right in
-          // front of them — base 1 damage matching fire/water/earth goblins.
+          // Adjacent (manhattan === 1): pink goblins are ranged skirmishers, so
+          // point-blank they'd rather open up distance than trade blows. Try to
+          // back off a tile; only if boxed in with nowhere to retreat do they
+          // lash out with a close-range zap (same damage as the laser at
+          // distance 1). Being hit never locks this out — they keep their full
+          // teleport/laser kit and simply react.
           if (manhattan === 1) {
-            return 1;
+            if (stepAwayFromPlayer()) {
+              return 0; // fled — no attack this turn
+            }
+            return rangedDamage(1); // cornered — zap
           }
 
           // Within attack range (4-5): always attack at ideal distance


### PR DESCRIPTION
Follow-up to PR #49 addressing playtest feedback.

## Pink goblin behavior
The previous "stun" reaction (hit → permanently can't teleport → back away every turn) was too defanging. Reworked so the goblin keeps its full kit and just behaves like a proper ranged skirmisher:

- **Point-blank (adjacent):** opens up distance instead of trading melee — direct away-step, then a perpendicular sidestep that still gains distance. Only when **fully cornered** (no tile increases the distance) does it zap for close-range damage (same as the laser at distance 1).
- **At range with LOS:** still lasers (beam + bang VFX unchanged).
- **No LOS:** still drops and uses its teleport ring.

Being hit no longer changes any of this — no permanent lockout. A natural consequence: pink goblins now dodge melee in the open, so you corner them or use rocks/bombs.

"Your attack takes precedence" is already handled: `performThrowRock` pre-scans the rock's path and fully skips (no move, no attack) any enemy the rock will *kill*, so a goblin can't laser you on the same turn your rock finishes it.

## Portal position
Nudged the snake-medallion portal's blue ring down a few px (matching the pink goblin's under-ring) so the hero looks like he's standing on it rather than overlapping it.

## Testing
- 580 tests pass; rewrote the pink-goblin suite (flee-with-room / cornered-zap / laser-at-range-with-beam / teleport-retained-after-hit) and cornered the goblin in the melee-kill ring test so the hit lands
- Live-verified: goblin backs away from adjacency (dist 1→2), lasers deal damage, MutationObserver captured the beam (80px, horizontal) + hero bang, portal ring measured 4px below hero center at his feet
- `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)