### PR TITLE
Rework mobile layout: item strip controls, edge-clamped camera, tighter HUD

### DIFF
--- a/__tests__/components/CameraClamp.test.ts
+++ b/__tests__/components/CameraClamp.test.ts
@@ -1,0 +1,32 @@
+import {
+  calculateMapTransform,
+  heroViewportPosition,
+} from "../../components/TilemapGrid";
+
+// 600px viewport, 40px tiles. A 20x20 map is 800px, so valid camera offsets
+// are [-200, 0] on each axis.
+describe("camera clamping", () => {
+  it("centers the player when away from map edges", () => {
+    expect(calculateMapTransform([10, 10], 20, 20)).toBe("-120px, -120px");
+    expect(heroViewportPosition([10, 10], 20, 20)).toEqual({ x: 300, y: 300 });
+  });
+
+  it("clamps at the top-left so the viewport never shows past the map edge", () => {
+    expect(calculateMapTransform([0, 0], 20, 20)).toBe("0px, 0px");
+    expect(heroViewportPosition([0, 0], 20, 20)).toEqual({ x: 20, y: 20 });
+  });
+
+  it("clamps at the bottom-right edge", () => {
+    expect(calculateMapTransform([19, 19], 20, 20)).toBe("-200px, -200px");
+    expect(heroViewportPosition([19, 19], 20, 20)).toEqual({ x: 580, y: 580 });
+  });
+
+  it("centers maps smaller than the viewport regardless of player position", () => {
+    expect(calculateMapTransform([0, 0], 10, 10)).toBe("100px, 100px");
+    expect(heroViewportPosition([9, 9], 10, 10)).toEqual({ x: 480, y: 480 });
+  });
+
+  it("falls back to unclamped centering when map dimensions are unknown", () => {
+    expect(calculateMapTransform([0, 0])).toBe("280px, 280px");
+  });
+});

--- a/__tests__/components/MobileControls.test.tsx
+++ b/__tests__/components/MobileControls.test.tsx
@@ -60,4 +60,43 @@ describe('MobileControls', () => {
     fireEvent.click(screen.getByTestId('mobile-control-right'));
     expect(handleMove).toHaveBeenCalledWith('RIGHT');
   });
+
+  it('shows usable inventory items as buttons in the mobile strip', () => {
+    global.innerWidth = 500;
+    global.dispatchEvent(new Event('resize'));
+
+    const handleUseFood = jest.fn();
+    render(
+      <MobileControls
+        onMove={jest.fn()}
+        inventoryItems={[
+          { key: 'rock', label: 'Rock', icon: '/images/items/rock-1.png', count: 3, onUse: jest.fn() },
+          { key: 'food', label: 'Food', icon: '/images/items/food-1.png', count: 2, onUse: handleUseFood },
+          { key: 'sword', label: 'Sword', icon: '/images/items/sword.png' },
+        ]}
+      />
+    );
+
+    // Rock keeps its long-standing action testid
+    expect(screen.getByTestId('mobile-action-rock')).toBeInTheDocument();
+
+    // Usable item triggers its handler
+    fireEvent.click(screen.getByTestId('mobile-inventory-item-food'));
+    expect(handleUseFood).toHaveBeenCalled();
+
+    // Passive items (no onUse) are not part of the strip
+    expect(screen.queryByTestId('mobile-inventory-item-sword')).not.toBeInTheDocument();
+  });
+
+  it('does not render inventory strip items on desktop', () => {
+    global.innerWidth = 800;
+    global.dispatchEvent(new Event('resize'));
+    render(
+      <MobileControls
+        onMove={jest.fn()}
+        inventoryItems={[{ key: 'food', label: 'Food', onUse: jest.fn() }]}
+      />
+    );
+    expect(screen.queryByTestId('mobile-inventory-item-food')).not.toBeInTheDocument();
+  });
 });

--- a/app/globals.css
+++ b/app/globals.css
@@ -182,6 +182,13 @@
   }
 }
 
+html {
+  /* Keep the layout viewport at device width: without this, the 600px game
+     boxes can expand the mobile layout viewport and push fixed bottom
+     controls out of view. */
+  overflow-x: clip;
+}
+
 body {
   background: var(--background);
   color: var(--foreground);
@@ -192,7 +199,7 @@ body {
   /* The game grid is a fixed-width (600px) scaled box; on sub-600px phones it
      would otherwise overhang and let the whole page pan sideways. Clip it so
      the playfield stays put on narrow screens. */
-  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 /* Global theme tokens moved from CSS Modules to avoid purity errors on Vercel */
@@ -663,6 +670,16 @@ body {
   margin: 0 auto; /* keep centered when scaled */
   will-change: transform;
   display: block;
+}
+
+/* Desktop: cap the game unit at ~550px wide (600 baseline * 0.9167). zoom
+   rather than transform so the layout box shrinks with it — the page gets
+   shorter instead of leaving a dead strip below the board. Below 600px the
+   transform steps further down take over (zoom stays 1 there). */
+@media (min-width: 601px) {
+  .game-scale {
+    zoom: 0.9167;
+  }
 }
 
 /* Reserve space for HUD above the grid so it doesn't overlap when there's room */

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,8 +3,6 @@ import { Geist, Geist_Mono, Press_Start_2P, VT323 } from "next/font/google";
 import "./globals.css";
 import PreloadImages from "../components/PreloadImages";
 import PostHogProvider from "../components/PostHogProvider";
-import FeedbackButton from "../components/FeedbackButton";
-import HowToPlayButton from "../components/HowToPlayButton";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -102,8 +100,6 @@ export default function RootLayout({
         <PostHogProvider>
           <PreloadImages />
           {children}
-          <FeedbackButton />
-          <HowToPlayButton />
         </PostHogProvider>
       </body>
     </html>

--- a/components/GameView.tsx
+++ b/components/GameView.tsx
@@ -193,7 +193,7 @@ function GameViewInner({
 
   return (
     <div
-      className="min-h-screen flex flex-row items-start justify-center p-4 gap-4 text-white relative"
+      className="min-h-screen flex flex-row items-start justify-center p-4 max-[600px]:p-2 gap-4 text-white relative"
       style={{
         backgroundImage: "url(/images/presentational/wall-up-close.png)",
         backgroundRepeat: "repeat",
@@ -202,7 +202,7 @@ function GameViewInner({
     >
       <div className="absolute inset-0 bg-black/40 pointer-events-none"></div>
       <div className="flex flex-col items-center relative z-10">
-        <h1 className="text-1xl font-bold text-center mb-4 text-gray-400">
+        <h1 className="text-1xl font-bold text-center mb-4 max-[600px]:mb-1 text-gray-400">
           Torch Boy
         </h1>
         <TilemapGrid

--- a/components/MobileControls.tsx
+++ b/components/MobileControls.tsx
@@ -1,5 +1,14 @@
 import React, { useState, useEffect, useCallback } from 'react';
 
+export interface MobileInventoryItem {
+  key: string;
+  label: string;
+  icon?: string;
+  emoji?: string;
+  count?: number;
+  onUse?: () => void;
+}
+
 interface MobileControlsProps {
   onMove: (direction: string) => void;
   onThrowRock?: () => void;
@@ -8,7 +17,55 @@ interface MobileControlsProps {
   runeCount?: number;
   onThrowBomb?: () => void;
   bombCount?: number;
+  inventoryItems?: MobileInventoryItem[];
 }
+
+const ARROW_ROTATION: Record<string, number> = {
+  UP: 0,
+  RIGHT: 90,
+  DOWN: 180,
+  LEFT: 270,
+};
+
+const DirectionArrow = ({ direction }: { direction: string }) => (
+  <svg
+    width="20"
+    height="20"
+    viewBox="0 0 20 20"
+    aria-hidden="true"
+    style={{ transform: `rotate(${ARROW_ROTATION[direction]}deg)` }}
+  >
+    <path
+      d="M10 5 L15.5 14 H4.5 Z"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const ItemIcon = ({ src, size }: { src: string; size: number }) => (
+  <span
+    aria-hidden="true"
+    style={{
+      display: 'inline-block',
+      width: size,
+      height: size,
+      backgroundImage: `url(${src})`,
+      backgroundSize: 'contain',
+      backgroundRepeat: 'no-repeat',
+      backgroundPosition: 'center',
+    }}
+  />
+);
+
+// 3x3 d-pad layout; null cells are empty spacers
+const DPAD_CELLS: (string | null)[] = [
+  null, 'UP', null,
+  'LEFT', null, 'RIGHT',
+  null, 'DOWN', null,
+];
 
 const MobileControls: React.FC<MobileControlsProps> = ({
   onMove,
@@ -18,8 +75,10 @@ const MobileControls: React.FC<MobileControlsProps> = ({
   runeCount,
   onThrowBomb,
   bombCount,
+  inventoryItems = [],
 }) => {
   const [isMobile, setIsMobile] = useState(false);
+  const [viewportWidth, setViewportWidth] = useState(0);
   const [activeKeys, setActiveKeys] = useState<Record<string, boolean>>({
     UP: false,
     DOWN: false,
@@ -31,6 +90,7 @@ const MobileControls: React.FC<MobileControlsProps> = ({
   useEffect(() => {
     const checkMobile = () => {
       setIsMobile(window.innerWidth < 600);
+      setViewportWidth(window.innerWidth);
     };
 
     // Initial check
@@ -46,7 +106,7 @@ const MobileControls: React.FC<MobileControlsProps> = ({
   // Handle keyboard events to highlight the corresponding button
   const handleKeyDown = useCallback((event: KeyboardEvent) => {
     let direction = '';
-    
+
     switch (event.key) {
       case 'ArrowUp':
         direction = 'UP';
@@ -63,9 +123,9 @@ const MobileControls: React.FC<MobileControlsProps> = ({
       default:
         return;
     }
-    
+
     setActiveKeys(prev => ({ ...prev, [direction]: true }));
-    
+
     // Reset after a short delay to create a flash effect
     setTimeout(() => {
       setActiveKeys(prev => ({ ...prev, [direction]: false }));
@@ -79,169 +139,155 @@ const MobileControls: React.FC<MobileControlsProps> = ({
     };
   }, [handleKeyDown]);
 
-  // Determine button style based on mobile/desktop and active state
-  const getButtonStyle = (direction: string) => {
-    const isActive = activeKeys[direction];
-    
-    if (isMobile) {
-      // Mobile style - more prominent
-      return isActive
-        ? "bg-[#555555] text-white p-3 rounded-md transition-colors"
-        : "bg-[#333333] text-white p-3 rounded-md hover:bg-[#444444] transition-colors";
-    } else {
-      // Desktop style - subtle outline
-      return isActive
-        ? "bg-[#333333] text-white p-2 rounded-md border border-[#555555] transition-colors"
-        : "bg-transparent text-[#777777] p-2 rounded-md border border-[#444444] hover:border-[#555555] transition-colors";
-    }
-  };
+  const quickActions = [
+    {
+      key: 'rock',
+      testId: 'mobile-action-rock',
+      icon: '/images/items/rock-1.png',
+      count: rockCount ?? 0,
+      onUse: onThrowRock,
+      label: 'Throw Rock',
+      title: `Throw rock (${rockCount})`,
+    },
+    {
+      key: 'rune',
+      testId: 'mobile-action-rune',
+      icon: '/images/items/rune1.png',
+      count: runeCount ?? 0,
+      onUse: onUseRune,
+      label: 'Use Rune',
+      title: `Use rune (${runeCount})`,
+    },
+    {
+      key: 'bomb',
+      testId: 'mobile-action-bomb',
+      icon: '/images/items/bomb-black.png',
+      count: bombCount ?? 0,
+      onUse: onThrowBomb,
+      label: 'Throw Bomb',
+      title: `Throw bomb (${bombCount})`,
+    },
+  ].filter((action) => action.count > 0 && action.onUse);
 
-  // Always render the controls, but with different styles based on device
-  return (
-    <div 
-      data-testid="mobile-controls" 
-      className={`fixed right-4 z-10 ${!isMobile ? 'opacity-70 scale-90' : ''}`}
-      style={{ bottom: 'max(1rem, env(safe-area-inset-bottom, 1rem))' }}
-    >
-      {/* Action bar above d-pad: Rock and Rune buttons */}
-      <div className="flex justify-end gap-2 mb-2">
-        {(rockCount ?? 0) > 0 && (
+  const renderDpad = (buttonClass: (direction: string) => string, gapClass: string) => (
+    <div className={`grid grid-cols-3 ${gapClass}`}>
+      {DPAD_CELLS.map((direction, i) =>
+        direction ? (
           <button
-            data-testid="mobile-action-rock"
-            className={`${isMobile ? 'p-3' : 'p-2'} rounded-md ${
-              (rockCount ?? 0) > 0
-                ? (isMobile
-                    ? 'bg-[#333333] hover:bg-[#444444] text-white'
-                    : 'bg-transparent border border-[#444444] hover:border-[#555555] text-[#dddddd]')
-                : 'bg-[#222222] text-[#666666] cursor-not-allowed'
-            }`}
-            onClick={() => (rockCount ?? 0) > 0 && onThrowRock && onThrowRock()}
-            aria-label="Throw Rock"
-            title={`Throw rock (${rockCount})`}
+            key={direction}
+            data-testid={`mobile-control-${direction.toLowerCase()}`}
+            className={buttonClass(direction)}
+            onClick={() => onMove(direction)}
+            aria-label={`Move ${direction.charAt(0)}${direction.slice(1).toLowerCase()}`}
           >
-            <span
-              aria-hidden="true"
-              style={{
-                display: 'inline-block',
-                width: isMobile ? 22 : 18,
-                height: isMobile ? 22 : 18,
-                backgroundImage: "url(/images/items/rock-1.png)",
-                backgroundSize: 'contain',
-                backgroundRepeat: 'no-repeat',
-                backgroundPosition: 'center',
-                verticalAlign: 'middle'
-              }}
-            />
+            <DirectionArrow direction={direction} />
           </button>
-        )}
-        {(runeCount ?? 0) > 0 && (
-          <button
-            data-testid="mobile-action-rune"
-            className={`${isMobile ? 'p-3' : 'p-2'} rounded-md ${
-              (runeCount ?? 0) > 0
-                ? (isMobile
-                    ? 'bg-[#333333] hover:bg-[#444444] text-white'
-                    : 'bg-transparent border border-[#444444] hover:border-[#555555] text-[#dddddd]')
-                : 'bg-[#222222] text-[#666666] cursor-not-allowed'
-            }`}
-            onClick={() => (runeCount ?? 0) > 0 && onUseRune && onUseRune()}
-            aria-label="Use Rune"
-            title={`Use rune (${runeCount})`}
-          >
-            <span
-              aria-hidden="true"
-              style={{
-                display: 'inline-block',
-                width: isMobile ? 22 : 18,
-                height: isMobile ? 22 : 18,
-                backgroundImage: "url(/images/items/rune1.png)",
-                backgroundSize: 'contain',
-                backgroundRepeat: 'no-repeat',
-                backgroundPosition: 'center',
-                verticalAlign: 'middle'
-              }}
-            />
-          </button>
-        )}
-        {(bombCount ?? 0) > 0 && (
-          <button
-            data-testid="mobile-action-bomb"
-            className={`${isMobile ? 'p-3' : 'p-2'} rounded-md ${
-              isMobile
-                ? 'bg-[#333333] hover:bg-[#444444] text-white'
-                : 'bg-transparent border border-[#444444] hover:border-[#555555] text-[#dddddd]'
-            }`}
-            onClick={() => (bombCount ?? 0) > 0 && onThrowBomb && onThrowBomb()}
-            aria-label="Throw Bomb"
-            title={`Throw bomb (${bombCount})`}
-          >
-            <span
-              aria-hidden="true"
-              style={{
-                display: 'inline-block',
-                width: isMobile ? 22 : 18,
-                height: isMobile ? 22 : 18,
-                backgroundImage: "url(/images/items/bomb-black.png)",
-                backgroundSize: 'contain',
-                backgroundRepeat: 'no-repeat',
-                backgroundPosition: 'center',
-                verticalAlign: 'middle'
-              }}
-            />
-          </button>
-        )}
+        ) : (
+          <div key={`spacer-${i}`} />
+        )
+      )}
+    </div>
+  );
+
+  if (!isMobile) {
+    // Desktop: subtle outline controls pinned bottom-right
+    const desktopDpadClass = (direction: string) =>
+      activeKeys[direction]
+        ? 'flex h-9 w-9 items-center justify-center bg-[#333333] text-white rounded-md border border-[#555555] transition-colors'
+        : 'flex h-9 w-9 items-center justify-center bg-transparent text-[#777777] rounded-md border border-[#444444] hover:border-[#555555] transition-colors';
+
+    return (
+      <div
+        data-testid="mobile-controls"
+        className="fixed right-4 z-10 opacity-70 scale-90"
+        style={{ bottom: 'max(1rem, env(safe-area-inset-bottom, 1rem))' }}
+      >
+        <div className="flex justify-end gap-2 mb-2">
+          {quickActions.map((action) => (
+            <button
+              key={action.key}
+              data-testid={action.testId}
+              className="p-2 rounded-md bg-transparent border border-[#444444] hover:border-[#555555] text-[#dddddd]"
+              onClick={action.onUse}
+              aria-label={action.label}
+              title={action.title}
+            >
+              <ItemIcon src={action.icon} size={18} />
+            </button>
+          ))}
+        </div>
+        {renderDpad(desktopDpadClass, 'gap-1')}
       </div>
+    );
+  }
 
-      {/* D-pad grid */}
-      <div className={`grid grid-cols-3 gap-1`}>
-        {/* Empty space for top-left */}
-        <div></div>
-        {/* Up button */}
-        <button 
-          data-testid="mobile-control-up"
-          className={getButtonStyle('UP')}
-          onClick={() => onMove('UP')}
-          aria-label="Move Up"
-        >
-          ▲
-        </button>
-        {/* Empty space for top-right */}
-        <div></div>
-        
-        {/* Left button */}
-        <button 
-          data-testid="mobile-control-left"
-          className={getButtonStyle('LEFT')}
-          onClick={() => onMove('LEFT')}
-          aria-label="Move Left"
-        >
-          ◄
-        </button>
-        {/* Center placeholder */}
-        <div></div>
-        {/* Right button */}
-        <button 
-          data-testid="mobile-control-right"
-          className={getButtonStyle('RIGHT')}
-          onClick={() => onMove('RIGHT')}
-          aria-label="Move Right"
-        >
-          ►
-        </button>
-        
-        {/* Empty space for bottom-left */}
-        <div></div>
-        {/* Down button */}
-        <button 
-          data-testid="mobile-control-down"
-          className={getButtonStyle('DOWN')}
-          onClick={() => onMove('DOWN')}
-          aria-label="Move Down"
-        >
-          ▼
-        </button>
-        {/* Empty space for bottom-right */}
-        <div></div>
+  // Mobile: full-width control bar. All usable items sit in a strip above the
+  // d-pad, filling from the right edge (nearest the thumb) and wrapping to a
+  // second row when they run out of space.
+  const mobileDpadClass = (direction: string) =>
+    `flex h-14 w-14 items-center justify-center rounded-xl border border-white/10 shadow-md text-gray-200 transition-colors ${
+      activeKeys[direction] ? 'bg-[#555555]' : 'bg-[#333333] active:bg-[#555555]'
+    }`;
+
+  const stripItems = inventoryItems.filter((item) => item.onUse);
+  // Rock/rune/bomb keep their long-standing action testids
+  const stripTestId = (key: string) =>
+    ['rock', 'rune', 'bomb'].includes(key)
+      ? `mobile-action-${key}`
+      : `mobile-inventory-item-${key}`;
+
+  const renderStripButton = (item: MobileInventoryItem) => (
+    <button
+      key={item.key}
+      data-testid={stripTestId(item.key)}
+      className="relative flex h-14 w-14 items-center justify-center rounded-xl border border-white/10 bg-[#333333] shadow-md transition-colors active:bg-[#555555]"
+      onClick={item.onUse}
+      aria-label={item.label}
+      title={(item.count ?? 0) > 0 ? `${item.label} (${item.count})` : item.label}
+    >
+      {item.icon ? (
+        <ItemIcon src={item.icon} size={26} />
+      ) : (
+        <span className="text-xl leading-none" aria-hidden="true">
+          {item.emoji}
+        </span>
+      )}
+      {(item.count ?? 0) > 0 && (
+        <span className="absolute bottom-0.5 right-1 text-[10px] font-medium text-white/90">
+          {item.count}
+        </span>
+      )}
+    </button>
+  );
+
+  // Serpentine fill: the first row starts at the right edge (nearest the
+  // thumb) and runs left; overflow drops to a second row that comes back
+  // from the left. Buttons are 56px wide with an 8px gap inside px-3 padding.
+  const perRow = Math.max(1, Math.floor((viewportWidth - 24 + 8) / 64));
+  const firstRowItems = stripItems.slice(0, perRow);
+  const overflowItems = stripItems.slice(perRow);
+
+  return (
+    <div data-testid="mobile-controls" className="fixed inset-x-0 bottom-0 z-30 pointer-events-none">
+      <div
+        className="pointer-events-auto bg-gradient-to-t from-black/85 via-black/55 to-transparent px-3 pt-4"
+        style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom, 0.75rem))' }}
+      >
+        {stripItems.length > 0 && (
+          <div className="mb-2 flex flex-col gap-2">
+            <div className="flex flex-row-reverse gap-2">
+              {firstRowItems.map(renderStripButton)}
+            </div>
+            {overflowItems.length > 0 && (
+              <div className="flex flex-wrap gap-2">
+                {overflowItems.map(renderStripButton)}
+              </div>
+            )}
+          </div>
+        )}
+        <div className="flex items-end justify-end">
+          {renderDpad(mobileDpadClass, 'gap-1.5')}
+        </div>
       </div>
     </div>
   );

--- a/components/TilemapGrid.module.css
+++ b/components/TilemapGrid.module.css
@@ -44,16 +44,21 @@
   width: 100%;
 }
 
+/* On small screens the HUD scales down; widen it so the scaled result still
+   spans the full bar (left-2/right-2 insets = 16px) instead of leaving a gap
+   on the right. */
 @media (max-width: 600px) {
   .hudBar {
     transform: scale(0.9);
     transform-origin: top left;
+    width: calc((100% - 16px) / 0.9);
   }
 }
 
 @media (max-width: 480px) {
   .hudBar {
     transform: scale(0.82);
+    width: calc((100% - 16px) / 0.82);
   }
 }
 

--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -17,7 +17,7 @@ import {
   serializeNPCs,
   type RoomSnapshot,
 } from "../lib/map";
-import { removePlayerFromMapData } from "../lib/map/player";
+import { findPlayerPosition, removePlayerFromMapData } from "../lib/map/player";
 import type { Enemy } from "../lib/enemy";
 import { rehydrateEnemies } from "../lib/enemy";
 import type { NPC, NPCInteractionEvent } from "../lib/npc";
@@ -1675,6 +1675,13 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
   const latestMoveInputRef = useRef<(d: Direction) => void>(() => {});
   const playerPositionRef = useRef<[number, number] | null>(null);
   playerPositionRef.current = playerPosition;
+  // Current map dimensions in tiles, for clamping the camera at map edges.
+  const mapRows = gameState.mapData.tiles.length;
+  const mapCols = gameState.mapData.tiles[0]?.length ?? 0;
+  const mapDimsRef = useRef<[number, number]>([mapRows, mapCols]);
+  mapDimsRef.current = [mapRows, mapCols];
+  // Smooth-mode light overlay anchor; the rAF loop drags it with the hero.
+  const smoothLightAnchorRef = useRef<HTMLDivElement | null>(null);
 
   // --- Phase 2: enemies/NPCs slide one tile per turn ---
   // id -> [y, x] as of the previously diffed gameState.
@@ -2133,12 +2140,24 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
       const nextFloorState = advanceToNextFloor(gameState, dailySeed);
       nextFloorState.needsFloorTransition = false;
 
-      // Player is always centered in the 600×600 viewport
-      const viewportCenter = { x: 300, y: 300 };
+      // Close on the hero's actual viewport position (off-center when the
+      // camera is clamped at a map edge), and open on his next-floor spawn.
+      const closeCenter = playerPosition
+        ? heroViewportPosition(playerPosition, mapRows, mapCols)
+        : { x: 300, y: 300 };
+      const nextTiles = nextFloorState.mapData.tiles;
+      const nextSpawn = findPlayerPosition(nextFloorState.mapData);
+      const openCenter = nextSpawn
+        ? heroViewportPosition(
+            nextSpawn,
+            nextTiles.length,
+            nextTiles[0]?.length ?? 0
+          )
+        : { x: 300, y: 300 };
 
       setFloorTransition({
-        closeCenter: viewportCenter,
-        openCenter: viewportCenter,
+        closeCenter,
+        openCenter,
         pendingGameState: nextFloorState,
       });
     }
@@ -2778,9 +2797,21 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
         }
         setTimeout(() => {
           setWarpFlicker(true);
+          const closeCenter = playerPosition
+            ? heroViewportPosition(playerPosition, mapRows, mapCols)
+            : { x: 300, y: 300 };
+          const warpTiles = newGameState.mapData.tiles;
+          const warpSpawn = findPlayerPosition(newGameState.mapData);
+          const openCenter = warpSpawn
+            ? heroViewportPosition(
+                warpSpawn,
+                warpTiles.length,
+                warpTiles[0]?.length ?? 0
+              )
+            : { x: 300, y: 300 };
           setFloorTransition({
-            closeCenter: { x: 300, y: 300 },
-            openCenter: { x: 300, y: 300 },
+            closeCenter,
+            openCenter,
             pendingGameState: newGameState,
           });
         }, 160);
@@ -3125,9 +3156,20 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
 
       const v = smoothVisualRef.current;
       if (v && smoothMapNodeRef.current) {
+        const [rows, cols] = mapDimsRef.current;
         smoothMapNodeRef.current.style.transform = `translate(${calculateMapTransform(
-          [v[0], v[1]]
+          [v[0], v[1]],
+          rows,
+          cols
         )})`;
+        // Keep the torch/vignette glued to the hero: he leaves viewport
+        // center whenever the camera is clamped at a map edge.
+        if (smoothLightAnchorRef.current) {
+          const hero = heroViewportPosition([v[0], v[1]], rows, cols);
+          smoothLightAnchorRef.current.style.transform = `translate3d(${
+            hero.x - LIGHT_BOX_CENTER
+          }px, ${hero.y - LIGHT_BOX_CENTER}px, 0)`;
+        }
       }
       // Hero anchor rides the same visual position, so camera + hero cancel
       // out and he stays pinned at the viewport center.
@@ -3423,7 +3465,7 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
             </div>
           )}
         {/* Vertically center the entire game UI within the viewport */}
-        <div className="w-full mt-12 flex items-center justify-center">
+        <div className="w-full mt-12 max-[600px]:mt-1 flex items-center justify-center">
           <div className="game-scale relative" data-testid="game-scale">
             {/* Responsive HUD top bar: wraps on small screens. Each panel takes 1/2 width. */}
             <div
@@ -4027,12 +4069,12 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
                   // mid-tween don't snap the camera. Legacy: CSS transition.
                   transform: smoothEnabled
                     ? smoothVisualRef.current
-                      ? `translate(${calculateMapTransform(smoothVisualRef.current)})`
+                      ? `translate(${calculateMapTransform(smoothVisualRef.current, mapRows, mapCols)})`
                       : playerPosition
-                      ? `translate(${calculateMapTransform(playerPosition)})`
+                      ? `translate(${calculateMapTransform(playerPosition, mapRows, mapCols)})`
                       : "none"
                     : playerPosition
-                    ? `translate(${calculateMapTransform(playerPosition)})`
+                    ? `translate(${calculateMapTransform(playerPosition, mapRows, mapCols)})`
                     : "none",
                   transition: smoothEnabled ? "none" : undefined,
                 }}
@@ -4556,6 +4598,7 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
                     inset: 0,
                     pointerEvents: "none",
                     isolation: "isolate",
+                    overflow: "hidden",
                   }}
                   aria-hidden="true"
                 >
@@ -4564,9 +4607,32 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
                     heroTorchLitState &&
                     !inNightmare &&
                     (() => {
-                      const g = buildHeroLightGradients(300, 300, true);
+                      // Gradients bake centered into an oversized box that
+                      // follows the hero (the rAF loop updates the transform
+                      // mid-step), so the light stays on him even when the
+                      // clamped camera parks him off-center at map edges.
+                      const v = smoothVisualRef.current ?? playerPosition;
+                      const hero = heroViewportPosition(v, mapRows, mapCols);
+                      const g = buildHeroLightGradients(
+                        LIGHT_BOX_CENTER,
+                        LIGHT_BOX_CENTER,
+                        true
+                      );
                       return (
-                        <>
+                        <div
+                          ref={smoothLightAnchorRef}
+                          style={{
+                            position: "absolute",
+                            left: 0,
+                            top: 0,
+                            width: LIGHT_BOX_SIZE,
+                            height: LIGHT_BOX_SIZE,
+                            willChange: "transform",
+                            transform: `translate3d(${
+                              hero.x - LIGHT_BOX_CENTER
+                            }px, ${hero.y - LIGHT_BOX_CENTER}px, 0)`,
+                          }}
+                        >
                           <div
                             className={styles.torchGlow}
                             style={{
@@ -4581,7 +4647,7 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
                               zIndex: 10000,
                             }}
                           />
-                        </>
+                        </div>
                       );
                     })()}
                 </div>
@@ -4724,6 +4790,99 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
         runeCount={gameState.runeCount ?? 0}
         onThrowBomb={handleThrowBomb}
         bombCount={gameState.bombCount ?? 0}
+        inventoryItems={[
+          ...((gameState.rockCount ?? 0) > 0
+            ? [{
+                key: "rock",
+                label: "Rock",
+                icon: "/images/items/rock-1.png",
+                count: gameState.rockCount,
+                onUse: handleThrowRock,
+              }]
+            : []),
+          ...((gameState.runeCount ?? 0) > 0
+            ? [{
+                key: "rune",
+                label: "Rune",
+                icon: "/images/items/rune1.png",
+                count: gameState.runeCount,
+                onUse: handleThrowRune,
+              }]
+            : []),
+          ...((gameState.bombCount ?? 0) > 0
+            ? [{
+                key: "bomb",
+                label: "Bomb",
+                icon: "/images/items/bomb-black.png",
+                count: gameState.bombCount,
+                onUse: handleThrowBomb,
+              }]
+            : []),
+          ...((gameState.foodCount ?? 0) > 0
+            ? [{
+                key: "food",
+                label: "Food",
+                icon: "/images/items/food-1.png",
+                count: gameState.foodCount,
+                onUse: handleUseFood,
+              }]
+            : []),
+          ...((gameState.potionCount ?? 0) > 0
+            ? [{
+                key: "potion",
+                label: "Potion",
+                icon: "/images/items/meds-1.png",
+                count: gameState.potionCount,
+                onUse: handleUsePotion,
+              }]
+            : []),
+          ...((gameState.berryCount ?? 0) > 0
+            ? [{
+                key: "berry",
+                label: "Berry",
+                icon: "/images/items/berry.png",
+                count: gameState.berryCount,
+                onUse: handleUseBerry,
+              }]
+            : []),
+          ...((gameState.pinkHeartCount ?? 0) > 0
+            ? [{
+                key: "pink-heart",
+                label: "Pink Heart",
+                icon: "/images/items/pink-heart.png",
+                count: gameState.pinkHeartCount,
+                onUse: handleUsePinkHeart,
+              }]
+            : []),
+          ...(gameState.hasSnakeMedallion
+            ? [{
+                key: "medallion",
+                label: "Medallion",
+                icon: "/images/items/snake-medalion.png",
+                onUse: handleSnakeMedallionClick,
+              }]
+            : []),
+          ...(diaryEntries.length > 0
+            ? [{ key: "diary", label: "Diary", emoji: "📖", onUse: () => setHeroDiaryOpen(true) }]
+            : []),
+          ...(gameState.hasKey || (gameState.chestKeyCount ?? 0) > 0
+            ? [{
+                key: "key",
+                label: (gameState.chestKeyCount ?? 0) > 1 ? "Keys" : "Key",
+                icon: "/images/items/key.png",
+                count: (gameState.chestKeyCount ?? 0) > 0 ? gameState.chestKeyCount : undefined,
+              }]
+            : []),
+          ...(gameState.hasExitKey
+            ? [{ key: "exit-key", label: "Exit Key", icon: "/images/items/exit-key.png" }]
+            : []),
+          ...(gameState.hasSword
+            ? [{ key: "sword", label: "Sword", icon: "/images/items/sword.png" }]
+            : []),
+          ...(gameState.hasShield
+            ? [{ key: "shield", label: "Shield", icon: "/images/items/shield.png" }]
+            : []),
+        ]}
       />
     </div>
   );
@@ -5212,10 +5371,15 @@ function buildHeroLightGradients(
   return { torchGradient, vignetteGradient };
 }
 
-// Calculate the transform to center the map on the player
-function calculateMapTransform(playerPosition: [number, number]): string {
-  if (!playerPosition) return "0px, 0px";
-
+// Camera offsets that center the player where possible, clamped so the
+// 600px viewport never slides past the map edges (which would show the page
+// background through the empty part of the viewport). Maps smaller than the
+// viewport stay centered.
+function calculateMapOffsets(
+  playerPosition: [number, number],
+  mapRows?: number,
+  mapCols?: number
+): { tx: number; ty: number } {
   const tileSize = 40; // px
   const viewportWidth = 600; // px (from CSS)
   const viewportHeight = 600; // px (from CSS)
@@ -5225,8 +5389,57 @@ function calculateMapTransform(playerPosition: [number, number]): string {
   const playerY = (playerPosition[0] + 0.5) * tileSize;
 
   // Calculate the transform to center the player in the viewport
-  const translateX = viewportWidth / 2 - playerX;
-  const translateY = viewportHeight / 2 - playerY;
+  let tx = viewportWidth / 2 - playerX;
+  let ty = viewportHeight / 2 - playerY;
 
-  return `${translateX}px, ${translateY}px`;
+  if (mapCols) {
+    const mapWidth = mapCols * tileSize;
+    tx =
+      mapWidth <= viewportWidth
+        ? (viewportWidth - mapWidth) / 2
+        : Math.min(0, Math.max(viewportWidth - mapWidth, tx));
+  }
+  if (mapRows) {
+    const mapHeight = mapRows * tileSize;
+    ty =
+      mapHeight <= viewportHeight
+        ? (viewportHeight - mapHeight) / 2
+        : Math.min(0, Math.max(viewportHeight - mapHeight, ty));
+  }
+
+  return { tx, ty };
 }
+
+// Calculate the transform to center the map on the player
+export function calculateMapTransform(
+  playerPosition: [number, number],
+  mapRows?: number,
+  mapCols?: number
+): string {
+  if (!playerPosition) return "0px, 0px";
+  const { tx, ty } = calculateMapOffsets(playerPosition, mapRows, mapCols);
+  return `${tx}px, ${ty}px`;
+}
+
+// Where the hero lands inside the 600px viewport under the clamped camera:
+// dead center normally, off-center when the camera is pinned at a map edge.
+export function heroViewportPosition(
+  playerPosition: [number, number],
+  mapRows?: number,
+  mapCols?: number
+): { x: number; y: number } {
+  const { tx, ty } = calculateMapOffsets(playerPosition, mapRows, mapCols);
+  return {
+    x: tx + (playerPosition[1] + 0.5) * 40,
+    y: ty + (playerPosition[0] + 0.5) * 40,
+  };
+}
+
+// Oversized backing box for the smooth-mode torch/vignette overlay: the
+// gradients are baked centered in this box and the box itself is translated
+// to follow the hero, so per-frame updates are transform-only. Past the
+// gradient's last stop the vignette continues as solid black, so the extra
+// 320px margin keeps the viewport covered even when the clamped camera lets
+// the hero drift up to ~300px from center.
+const LIGHT_BOX_SIZE = 1240;
+const LIGHT_BOX_CENTER = LIGHT_BOX_SIZE / 2;


### PR DESCRIPTION
Mobile presentation pass toward the shareable MVP.

## What changed
- **Mobile control panel**: all usable items render as 56px buttons in a strip above the d-pad — fills right-to-left from the thumb, wraps serpentine to a second row. D-pad rebuilt as uniform squares with SVG arrows. Passive items (sword/shield/keys) stay in the top HUD.
- **Camera clamping**: the camera stops at map edges instead of always centering the hero, so the viewport never shows page background past the map boundary (the "map sits so low" bug near the top edge). Smooth-mode torch/vignette follows the hero off-center; floor/warp iris wipes use his real viewport position.
- **Layout viewport fix**: horizontal overflow clipped at html/body so the 600px game boxes can't widen the mobile layout viewport (which pushed the fixed bottom controls off-screen).
- **HUD/sizing**: HUD spans full width on mobile, title gap collapsed, desktop game unit capped at ~550px via zoom so it fits shorter windows.
- **Removed** the global feedback + how-to-play floating buttons (daily completion poll remains the feedback channel).

## Testing
- `npm run build` passes, full Jest suite green (590 passed), lint clean for touched files
- Verified live in browser at mobile + desktop viewports: d-pad movement, rock throw from the strip, camera clamp at map corners in both smooth and legacy modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)