### PR TITLE
Flash a bang when a pot is smashed by hand

### DIFF
--- a/__tests__/components/BamEffect.test.tsx
+++ b/__tests__/components/BamEffect.test.tsx
@@ -56,4 +56,46 @@ describe('Bam effect UI', () => {
 
     jest.useRealTimers();
   });
+
+  it('shows a bam overlay on the pot when it is smashed by hand', async () => {
+    jest.useFakeTimers();
+    // Player at (1,1), a pot to the right at (1,2), no enemies.
+    const size = 25;
+    const tiles = Array.from({ length: size }, () => Array(size).fill(0));
+    const subtypes = Array.from({ length: size }, () =>
+      Array.from({ length: size }, () => [] as number[])
+    );
+    subtypes[1][1] = [TileSubtype.PLAYER];
+    subtypes[1][2] = [TileSubtype.POT];
+    const state: GameState = {
+      hasKey: false,
+      hasExitKey: false,
+      mapData: { tiles, subtypes },
+      showFullMap: true,
+      win: false,
+      playerDirection: Direction.RIGHT,
+      enemies: [],
+      heroHealth: 5,
+      heroAttack: 1,
+      stats: { damageDealt: 0, damageTaken: 0, enemiesDefeated: 0, steps: 0 },
+    };
+
+    render(<TilemapGrid tileTypes={{}} initialGameState={state} />);
+
+    act(() => {
+      fireEvent.keyDown(window, { key: 'ArrowRight' });
+    });
+
+    // Bam appears directly on the pot tile (1,2), not a midpoint.
+    const bam = await screen.findByTestId('bam-effect');
+    expect(bam).toHaveAttribute('data-bam-y', '1');
+    expect(bam).toHaveAttribute('data-bam-x', '2');
+
+    act(() => {
+      jest.advanceTimersByTime(600);
+    });
+    expect(screen.queryByTestId('bam-effect')).toBeNull();
+
+    jest.useRealTimers();
+  });
 });

--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -2754,6 +2754,42 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
       const preDamageDealt = gameState.stats?.damageDealt ?? 0;
       const newGameState = movePlayer(gameState, direction);
 
+      // Smashing a pot by hand should read as an impact, just like breaking it
+      // with a thrown rock: flash a "bam" over the pot as it shatters to reveal
+      // its contents, instead of the pot silently vanishing. Detect it by the pot
+      // tag disappearing from the tile the player moved into.
+      if (playerPosition) {
+        const [py, px] = playerPosition;
+        let ty = py;
+        let tx = px;
+        switch (direction) {
+          case Direction.UP:
+            ty = py - 1;
+            break;
+          case Direction.RIGHT:
+            tx = px + 1;
+            break;
+          case Direction.DOWN:
+            ty = py + 1;
+            break;
+          case Direction.LEFT:
+            tx = px - 1;
+            break;
+        }
+        const preHadPot = (gameState.mapData.subtypes?.[ty]?.[tx] || []).includes(
+          TileSubtype.POT
+        );
+        const postHasPot = (
+          newGameState.mapData.subtypes?.[ty]?.[tx] || []
+        ).includes(TileSubtype.POT);
+        if (preHadPot && !postHasPot) {
+          const bamIdx = 1 + Math.floor(Math.random() * 3);
+          setBamEffect({ y: ty, x: tx, src: `/images/items/bam${bamIdx}.png` });
+          setTimeout(() => setBamEffect(null), 300);
+          triggerScreenShake();
+        }
+      }
+
       // Pink-realm warp: first show the hero step ONTO the ring tile, then flicker
       // (dematerialize) and run the iris transition into the realm — rather than swapping
       // the map instantly (which made the hero flicker on the tile beside the ring).


### PR DESCRIPTION
## What

Opening a pot by walking into it made the pot **silently vanish**, leaving food/items sitting on the floor with no impact — it looked off. Throwing a rock at a pot already shows a "bam" impact flash; this makes the by-hand path match.

Now when a pot is broken by hand, the same bam VFX + screen shake used for a thrown-rock hit fires on the pot tile, so both paths read as smashing the pot.

## How

In `handlePlayerMove` (`components/TilemapGrid.tsx`), after `movePlayer`, detect the `POT` tag disappearing from the tile the player stepped into and trigger the existing `setBamEffect` + `triggerScreenShake` (300ms, same as the rock path).

## Tests

- New test in `__tests__/components/BamEffect.test.tsx`: smashing a pot by hand shows a `bam-effect` on the pot tile, then clears.
- Existing pot/rock suites (23 tests) still pass; typecheck and build clean.