### PR TITLE
Shrink hand-smashed pot bang to a small ping

### DIFF
--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -1885,6 +1885,7 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
     y: number;
     x: number;
     src: string;
+    size?: number;
   }>(null);
   // Transient heart effect (petting dogs)
   const [heartEffect, setHeartEffect] = useState<null | {
@@ -2976,9 +2977,10 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
         ).includes(TileSubtype.POT);
         if (preHadPot && !postHasPot) {
           const bamIdx = 1 + Math.floor(Math.random() * 3);
-          setBamEffect({ y: ty, x: tx, src: `/images/items/bam${bamIdx}.png` });
+          // A hand-smashed pot should read as a small ping on the pot itself,
+          // not an explosion: keep the bam compact and skip the screen shake.
+          setBamEffect({ y: ty, x: tx, src: `/images/items/bam${bamIdx}.png`, size: 20 });
           setTimeout(() => setBamEffect(null), 300);
-          triggerScreenShake();
         }
       }
 
@@ -4404,7 +4406,7 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
                     // Use tile centers: add 0.5 to grid coords before converting to pixels
                     const pxLeft = (bamEffect.x + 0.5) * tileSize;
                     const pxTop = (bamEffect.y + 0.5) * tileSize;
-                    const size = 48; // effect image size in px
+                    const size = bamEffect.size ?? 48; // effect image size in px
                     return (
                       <div
                         data-testid="bam-effect"


### PR DESCRIPTION
The bam flashed when smashing a pot by hand rendered at the full 48px
impact size with a screen shake, reading like an explosion. Add an
optional size to the bam effect state and render the pot-smash bam at
20px with no screen shake so it looks like a small ping on the pot.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013XDfyEBVCUqmYpFij2qHhu