### PR TITLE
Fix missing death cause on throw/use turns; swap rune emoji

### DIFF
--- a/__tests__/lib/rock_throwing.test.ts
+++ b/__tests__/lib/rock_throwing.test.ts
@@ -349,6 +349,60 @@ describe('Rock Throwing - rune-killed stone-goblin is frozen (no jump)', () => {
 });
 });
 
+describe('Rock Throwing - killed by a ranged pink goblin records the death cause', () => {
+  it('sets deathCause to the pink goblin when its laser kills the hero on the throw turn', () => {
+    const base = generateMapWithSubtypes();
+    for (let y = 0; y < base.tiles.length; y++) {
+      for (let x = 0; x < base.tiles[y].length; x++) {
+        base.tiles[y][x] = 1; // wall everywhere
+        base.subtypes[y][x] = [];
+      }
+    }
+    const py = 5, px = 5;
+    // Clear a row to the RIGHT so the goblin has line of sight to laser the hero.
+    for (let d = 0; d <= 4; d++) {
+      base.tiles[py][px + d] = 0;
+      base.subtypes[py][px + d] = [];
+    }
+    base.subtypes[py][px] = [TileSubtype.PLAYER];
+    // (py, px-1) stays a wall: the hero throws LEFT, so the rock is harmless and
+    // never touches the goblin — the death must come purely from the ranged laser.
+
+    // Pink goblin 4 tiles right (manhattan 4): it always lasers at that distance,
+    // for 1 damage, and is never adjacent — the old adjacency search missed it.
+    const goblin = new Enemy({ y: py, x: px + 4 });
+    goblin.kind = 'pink-goblin';
+    goblin.behaviorMemory.aware = true;
+
+    const gameState: GameState = {
+      hasKey: false,
+      hasExitKey: false,
+      hasSword: false,
+      hasShield: false,
+      mapData: base,
+      showFullMap: false,
+      win: false,
+      playerDirection: Direction.LEFT,
+      enemies: [goblin],
+      heroHealth: 1,
+      heroMaxHealth: 5,
+      heroAttack: 1,
+      rockCount: 1,
+      heroTorchLit: true,
+      combatRng: () => 0.5,
+      stats: { damageDealt: 0, damageTaken: 0, enemiesDefeated: 0, steps: 0 },
+      recentDeaths: [],
+    };
+
+    const after = performThrowRock(gameState);
+
+    // The laser killed the hero...
+    expect(after.heroHealth).toBe(0);
+    // ...and the killer is recorded even though it never came adjacent.
+    expect(after.deathCause).toEqual({ type: 'enemy', enemyKind: 'pink-goblin' });
+  });
+});
+
 describe('Rock Throwing - lands on an open abyss: falls in, nothing sits on it', () => {
   it('a rock that comes to rest on an OPEN_ABYSS is consumed, not placed', () => {
     const base = generateMapWithSubtypes();

--- a/app/end/page.tsx
+++ b/app/end/page.tsx
@@ -189,7 +189,7 @@ export default function EndPage() {
   if (last.hasShield) items.push('🛡️');
   if (last.hasSnakeMedallion) items.push('🌀');
   if ((last.rockCount ?? 0) > 0) items.push(`🪨×${last.rockCount}`);
-  if ((last.runeCount ?? 0) > 0) items.push(`🪄×${last.runeCount}`);
+  if ((last.runeCount ?? 0) > 0) items.push(`💠×${last.runeCount}`);
   if ((last.bombCount ?? 0) > 0) items.push(`💣×${last.bombCount}`);
   if ((last.foodCount ?? 0) > 0) items.push(`🧀×${last.foodCount}`);
   if ((last.potionCount ?? 0) > 0) items.push(`🧪×${last.potionCount}`);
@@ -361,7 +361,7 @@ export default function EndPage() {
             if (last.hasShield) inv.push({ emoji: '🛡️', label: 'Shield' });
             if (last.hasSnakeMedallion) inv.push({ emoji: '🌀', label: 'Travel Medallion' });
             if ((last.rockCount ?? 0) > 0) inv.push({ emoji: '🪨', label: `Rock x${last.rockCount}` });
-            if ((last.runeCount ?? 0) > 0) inv.push({ emoji: '🪄', label: `Rune x${last.runeCount}` });
+            if ((last.runeCount ?? 0) > 0) inv.push({ emoji: '💠', label: `Rune x${last.runeCount}` });
             if ((last.bombCount ?? 0) > 0) inv.push({ emoji: '💣', label: `Bomb x${last.bombCount}` });
             if ((last.foodCount ?? 0) > 0) inv.push({ emoji: '🧀', label: `Food x${last.foodCount}` });
             if ((last.potionCount ?? 0) > 0) inv.push({ emoji: '🧪', label: `Potion x${last.potionCount}` });

--- a/components/daily/DailyCompleted.tsx
+++ b/components/daily/DailyCompleted.tsx
@@ -115,7 +115,7 @@ export function buildInventoryEntries(
   if ((game.rockCount ?? 0) > 0)
     inv.push({ key: "rock", asset: "/images/items/rock-1.png", emoji: "🪨", alt: "Rock", count: game.rockCount });
   if ((game.runeCount ?? 0) > 0)
-    inv.push({ key: "rune", asset: "/images/items/rune1.png", emoji: "🪄", alt: "Rune", count: game.runeCount });
+    inv.push({ key: "rune", asset: "/images/items/rune1.png", emoji: "💠", alt: "Rune", count: game.runeCount });
   if ((game.bombCount ?? 0) > 0)
     inv.push({ key: "bomb", asset: "/images/items/bomb-black.png", emoji: "💣", alt: "Bomb", count: game.bombCount });
   if ((game.foodCount ?? 0) > 0)

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -221,6 +221,24 @@ function perTurnDamageCap(state: { inPinkRealm?: boolean }): number {
   return state.inPinkRealm ? PINK_REALM_DAMAGE_CAP : 4;
 }
 
+/**
+ * Record which enemy killed the hero on an action turn (throw/use-item). Ranged
+ * attackers like pink goblins fire from a distance and then move, so an adjacency
+ * search after the enemy turn misses them — read the killer straight from the
+ * attack result instead, matching the movement-turn logic. No-op unless the hero
+ * just died and no death cause has been set yet.
+ */
+function recordEnemyDeathCause(
+  state: GameState,
+  attackingEnemies: EnemyAttackInfo[]
+): void {
+  if (state.heroHealth !== 0 || state.deathCause) return;
+  const killer = attackingEnemies[0];
+  if (killer) {
+    state.deathCause = { type: "enemy", enemyKind: killer.kind };
+  }
+}
+
 export function performUseFood(gameState: GameState): GameState {
   gameState = detonateLiveBombs(gameState);
   if (gameState.heroHealth <= 0) return gameState;
@@ -259,17 +277,7 @@ export function performUseFood(gameState: GameState): GameState {
         preTickState.stats.damageTaken += applied;
 
         // If player dies from enemy damage, track which enemy killed them
-        if (preTickState.heroHealth === 0) {
-          const killerEnemy = preTickState.enemies.find(
-            (e) => Math.abs(e.y - py) + Math.abs(e.x - px) === 1
-          );
-          if (killerEnemy) {
-            preTickState.deathCause = {
-              type: "enemy",
-              enemyKind: killerEnemy.kind,
-            };
-          }
-        }
+        recordEnemyDeathCause(preTickState, result.attackingEnemies);
       }
     }
   }
@@ -334,17 +342,7 @@ export function performUsePotion(gameState: GameState): GameState {
         applyHeroDamage(preTickState, applied);
         preTickState.stats.damageTaken += applied;
 
-        if (preTickState.heroHealth === 0) {
-          const killerEnemy = preTickState.enemies.find(
-            (e) => Math.abs(e.y - py) + Math.abs(e.x - px) === 1
-          );
-          if (killerEnemy) {
-            preTickState.deathCause = {
-              type: "enemy",
-              enemyKind: killerEnemy.kind,
-            };
-          }
-        }
+        recordEnemyDeathCause(preTickState, result.attackingEnemies);
       }
     }
   }
@@ -419,17 +417,7 @@ export function performUsePinkHeart(gameState: GameState): GameState {
         applyHeroDamage(preTickState, applied);
         preTickState.stats.damageTaken += applied;
 
-        if (preTickState.heroHealth === 0) {
-          const killerEnemy = preTickState.enemies.find(
-            (e) => Math.abs(e.y - py) + Math.abs(e.x - px) === 1
-          );
-          if (killerEnemy) {
-            preTickState.deathCause = {
-              type: "enemy",
-              enemyKind: killerEnemy.kind,
-            };
-          }
-        }
+        recordEnemyDeathCause(preTickState, result.attackingEnemies);
       }
     }
   }
@@ -494,17 +482,7 @@ export function performUseBerry(gameState: GameState): GameState {
         applyHeroDamage(preTickState, applied);
         preTickState.stats.damageTaken += applied;
 
-        if (preTickState.heroHealth === 0) {
-          const killerEnemy = preTickState.enemies.find(
-            (e) => Math.abs(e.y - py) + Math.abs(e.x - px) === 1
-          );
-          if (killerEnemy) {
-            preTickState.deathCause = {
-              type: "enemy",
-              enemyKind: killerEnemy.kind,
-            };
-          }
-        }
+        recordEnemyDeathCause(preTickState, result.attackingEnemies);
       }
     }
   }
@@ -627,6 +605,9 @@ export function performThrowRock(gameState: GameState): GameState {
         ...preTickState.stats,
         damageTaken: preTickState.stats.damageTaken + applied,
       };
+      // Record the killer (e.g. a pink goblin's ranged laser) so the end screen
+      // can show how the hero died instead of a bare "You died".
+      recordEnemyDeathCause(preTickState, result.attackingEnemies);
     }
     // Note: Do NOT apply adjacent ghost vanish on rock-throw turns; only move enemies.
   }
@@ -903,6 +884,9 @@ export function performThrowRune(gameState: GameState): GameState {
         ...preTickState.stats,
         damageTaken: preTickState.stats.damageTaken + applied,
       };
+      // Record the killer (e.g. a pink goblin's ranged laser) so the end screen
+      // can show how the hero died instead of a bare "You died".
+      recordEnemyDeathCause(preTickState, result.attackingEnemies);
     }
   }
 
@@ -1373,6 +1357,9 @@ export function performThrowBomb(gameState: GameState): GameState {
         ...preTickState.stats,
         damageTaken: preTickState.stats.damageTaken + applied,
       };
+      // Record the killer (e.g. a pink goblin's ranged laser) so the end screen
+      // can show how the hero died instead of a bare "You died".
+      recordEnemyDeathCause(preTickState, result.attackingEnemies);
     }
   }
 


### PR DESCRIPTION
Ranged killers (e.g. pink goblins laser the hero from 2-5 tiles away and
never come adjacent. The movement path records the killer from the attack
result, but the throw-rock/rune/bomb paths never set deathCause at all and
the use-food/potion/pink-heart/berry paths searched only for an adjacent
enemy - so a ranged kill on an action turn left deathCause empty and the
end screen showed a bare "You died" with no cause (and PostHog logged a
null death_cause).

Add recordEnemyDeathCause() helper that reads the killer from
attackingEnemies (matching the movement-turn logic) and wire it into all
seven action paths. Add a regression test covering the pink-goblin laser
kill on a rock-throw turn.

Also swap the rune inventory emoji from a magic wand to a blue rune symbol
to match the rune tile art.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MYbU6xVM1jiAe85iGiuf5j