### PR TITLE
Mobile d-pad: hold-to-run and remove the press highlight

### DIFF
--- a/__tests__/components/MobileControls.test.tsx
+++ b/__tests__/components/MobileControls.test.tsx
@@ -54,26 +54,48 @@ describe('MobileControls', () => {
     expect(upButton).toHaveClass('bg-[#333333]');
   });
   
-  it('should call onMove with correct direction when arrow buttons are clicked', () => {
+  it('calls onMove with the correct direction when arrow buttons are pressed', () => {
     // Mock window.innerWidth to be less than 600px
     global.innerWidth = 500;
     global.dispatchEvent(new Event('resize'));
-    
+
     const handleMove = jest.fn();
     render(<MobileControls onMove={handleMove} />);
-    
-    // Click each direction button and verify the callback is called with correct direction
-    fireEvent.click(screen.getByTestId('mobile-control-up'));
+
+    // Press each direction button and verify the callback fires on press
+    fireEvent.pointerDown(screen.getByTestId('mobile-control-up'));
     expect(handleMove).toHaveBeenCalledWith('UP');
-    
-    fireEvent.click(screen.getByTestId('mobile-control-down'));
+
+    fireEvent.pointerDown(screen.getByTestId('mobile-control-down'));
     expect(handleMove).toHaveBeenCalledWith('DOWN');
-    
-    fireEvent.click(screen.getByTestId('mobile-control-left'));
+
+    fireEvent.pointerDown(screen.getByTestId('mobile-control-left'));
     expect(handleMove).toHaveBeenCalledWith('LEFT');
-    
-    fireEvent.click(screen.getByTestId('mobile-control-right'));
+
+    fireEvent.pointerDown(screen.getByTestId('mobile-control-right'));
     expect(handleMove).toHaveBeenCalledWith('RIGHT');
+  });
+
+  it('fires onMove on press and onMoveEnd on release (for hold-to-run)', () => {
+    global.innerWidth = 500;
+    global.dispatchEvent(new Event('resize'));
+
+    const handleMove = jest.fn();
+    const handleMoveEnd = jest.fn();
+    render(<MobileControls onMove={handleMove} onMoveEnd={handleMoveEnd} />);
+
+    const up = screen.getByTestId('mobile-control-up');
+    fireEvent.pointerDown(up);
+    expect(handleMove).toHaveBeenCalledWith('UP');
+    expect(handleMoveEnd).not.toHaveBeenCalled();
+
+    fireEvent.pointerUp(up);
+    expect(handleMoveEnd).toHaveBeenCalledWith('UP');
+
+    // A cancelled touch (e.g. system gesture) also ends the hold
+    fireEvent.pointerDown(up);
+    fireEvent.pointerCancel(up);
+    expect(handleMoveEnd).toHaveBeenCalledTimes(2);
   });
 
   it('shows usable inventory items as buttons in the mobile strip', () => {
@@ -186,7 +208,7 @@ describe('MobileControls', () => {
     const { unmount } = render(<MobileControls onMove={jest.fn()} />);
     expect(screen.queryByTestId('keyboard-tip')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByTestId('mobile-control-up'));
+    fireEvent.pointerDown(screen.getByTestId('mobile-control-up'));
     expect(screen.getByTestId('keyboard-tip')).toBeInTheDocument();
     expect(window.localStorage.getItem('tb_kbd_tip_seen')).toBe('1');
 
@@ -194,7 +216,7 @@ describe('MobileControls', () => {
 
     // Already seen — a later session should not show the tip again
     render(<MobileControls onMove={jest.fn()} />);
-    fireEvent.click(screen.getByTestId('mobile-control-up'));
+    fireEvent.pointerDown(screen.getByTestId('mobile-control-up'));
     expect(screen.queryByTestId('keyboard-tip')).not.toBeInTheDocument();
   });
 
@@ -202,7 +224,7 @@ describe('MobileControls', () => {
     global.innerWidth = 500;
     global.dispatchEvent(new Event('resize'));
     render(<MobileControls onMove={jest.fn()} />);
-    fireEvent.click(screen.getByTestId('mobile-control-up'));
+    fireEvent.pointerDown(screen.getByTestId('mobile-control-up'));
     expect(screen.queryByTestId('keyboard-tip')).not.toBeInTheDocument();
   });
 });

--- a/components/MobileControls.tsx
+++ b/components/MobileControls.tsx
@@ -11,6 +11,9 @@ export interface MobileInventoryItem {
 
 interface MobileControlsProps {
   onMove: (direction: string) => void;
+  // Called when a direction button is released (or the touch is cancelled), so
+  // the game can stop a held-to-run repeat. onMove fires on press.
+  onMoveEnd?: (direction: string) => void;
   onThrowRock?: () => void;
   rockCount?: number;
   onUseRune?: () => void;
@@ -84,8 +87,21 @@ const DPAD_WIDTH = 3 * 56 + 2 * 6;
 const DRAG_TAP_THRESHOLD = 8; // px of travel below which a press counts as a tap (no-op)
 const DPAD_SNAP_MS = 160;
 
+// Suppress the mobile long-press artifacts on the controls: the blue text/element
+// selection highlight, the tap flash, and the iOS callout menu.
+const NO_SELECT: React.CSSProperties = {
+  userSelect: 'none',
+  WebkitUserSelect: 'none',
+  WebkitTapHighlightColor: 'transparent',
+  WebkitTouchCallout: 'none',
+};
+// Direction buttons additionally claim the touch so a press-and-hold never turns
+// into a scroll/zoom gesture.
+const NO_SELECT_TOUCH: React.CSSProperties = { ...NO_SELECT, touchAction: 'none' };
+
 const MobileControls: React.FC<MobileControlsProps> = ({
   onMove,
+  onMoveEnd,
   onThrowRock,
   rockCount,
   onUseRune,
@@ -182,12 +198,27 @@ const MobileControls: React.FC<MobileControlsProps> = ({
     tipTimer.current = window.setTimeout(() => setShowKbdTip(false), 6000);
   }, [isMobile]);
 
-  const move = useCallback(
-    (direction: string) => {
+  // Press a direction: fire the move now and (via onMove -> game) start the
+  // held-to-run repeat. Capturing the pointer keeps the hold alive even if the
+  // finger drifts off the button, so a slight wobble doesn't stop the run.
+  const pressDirection = useCallback(
+    (direction: string, target: HTMLElement, pointerId: number) => {
+      try {
+        target.setPointerCapture(pointerId);
+      } catch {
+        // pointer capture unsupported — hold still works while over the button
+      }
       onMove(direction);
       activateControl();
     },
     [onMove, activateControl]
+  );
+
+  const releaseDirection = useCallback(
+    (direction: string) => {
+      onMoveEnd?.(direction);
+    },
+    [onMoveEnd]
   );
 
   // Handle keyboard events to highlight the corresponding button
@@ -268,7 +299,11 @@ const MobileControls: React.FC<MobileControlsProps> = ({
             key={direction}
             data-testid={`mobile-control-${direction.toLowerCase()}`}
             className={buttonClass(direction)}
-            onClick={() => move(direction)}
+            style={NO_SELECT_TOUCH}
+            onPointerDown={(e) => pressDirection(direction, e.currentTarget, e.pointerId)}
+            onPointerUp={() => releaseDirection(direction)}
+            onPointerCancel={() => releaseDirection(direction)}
+            onContextMenu={(e) => e.preventDefault()}
             aria-label={`Move ${direction.charAt(0)}${direction.slice(1).toLowerCase()}`}
           >
             <DirectionArrow direction={direction} />
@@ -294,7 +329,7 @@ const MobileControls: React.FC<MobileControlsProps> = ({
         <div
           data-testid="mobile-controls"
           className="fixed right-4 z-10 opacity-70 scale-90"
-          style={{ bottom: 'max(1rem, env(safe-area-inset-bottom, 1rem))' }}
+          style={{ bottom: 'max(1rem, env(safe-area-inset-bottom, 1rem))', ...NO_SELECT }}
         >
           <div className="flex justify-end gap-2 mb-2">
             {quickActions.map((action) => (
@@ -372,8 +407,9 @@ const MobileControls: React.FC<MobileControlsProps> = ({
       key={item.key}
       data-testid={stripTestId(item.key)}
       className="relative flex items-center justify-center rounded-xl border border-white/10 bg-[#333333] shadow-md transition-colors active:bg-[#555555]"
-      style={{ width: btnSize, height: btnSize }}
+      style={{ width: btnSize, height: btnSize, ...NO_SELECT }}
       onClick={item.onUse}
+      onContextMenu={(e) => e.preventDefault()}
       aria-label={item.label}
       title={(item.count ?? 0) > 0 ? `${item.label} (${item.count})` : item.label}
     >
@@ -471,7 +507,8 @@ const MobileControls: React.FC<MobileControlsProps> = ({
       onPointerUp={(e) => endDrag(e.clientX)}
       onPointerCancel={() => endDrag(null)}
       className="flex h-14 w-14 cursor-grab items-center justify-center rounded-xl bg-transparent text-white/25 transition-colors active:cursor-grabbing active:text-white/50"
-      style={{ touchAction: 'none' }}
+      style={NO_SELECT_TOUCH}
+      onContextMenu={(e) => e.preventDefault()}
     >
       <svg width="16" height="16" viewBox="0 0 16 16" aria-hidden="true">
         <line x1="3" y1="5" x2="13" y2="5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
@@ -485,7 +522,7 @@ const MobileControls: React.FC<MobileControlsProps> = ({
     <div data-testid="mobile-controls" className="fixed inset-x-0 bottom-0 z-30 pointer-events-none">
       <div
         className="pointer-events-auto bg-gradient-to-t from-black/85 via-black/55 to-transparent px-3 pt-4"
-        style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom, 0.75rem))' }}
+        style={{ paddingBottom: 'max(0.75rem, env(safe-area-inset-bottom, 0.75rem))', ...NO_SELECT }}
       >
         {stripItems.length > 0 && (
           <div className={`mb-2 flex flex-wrap gap-2 ${stripFlowClass}`}>

--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -1800,6 +1800,10 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
   const smoothQueuedRef = useRef<Direction | null>(null);
   // Direction keys currently held (most recent last).
   const smoothHeldRef = useRef<Direction[]>([]);
+  // Held-to-run timers for the on-screen d-pad when smooth mode is off (smooth
+  // mode chains held inputs via the rAF loop instead).
+  const mobileHoldTimeoutRef = useRef<number | null>(null);
+  const mobileHoldIntervalRef = useRef<number | null>(null);
   const smoothMapNodeRef = useRef<HTMLDivElement | null>(null);
   // Map-space anchor for the hero (inside mapContainer so walls/trees occlude
   // him via the map's z-order); the rAF loop moves it with the camera.
@@ -3437,26 +3441,77 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
     return () => cancelAnimationFrame(raf);
   }, [smoothEnabled]);
 
-  // Handle mobile control button clicks
-  const handleMobileMove = useCallback(
+  // On-screen d-pad hold-to-run. Press fires a move immediately; holding keeps
+  // moving in that direction the same way a held keyboard arrow does.
+  const directionFromString = (directionStr: string): Direction | null => {
+    switch (directionStr) {
+      case "UP":
+        return Direction.UP;
+      case "RIGHT":
+        return Direction.RIGHT;
+      case "DOWN":
+        return Direction.DOWN;
+      case "LEFT":
+        return Direction.LEFT;
+      default:
+        return null;
+    }
+  };
+
+  const clearMobileHold = useCallback(() => {
+    if (mobileHoldTimeoutRef.current !== null) {
+      window.clearTimeout(mobileHoldTimeoutRef.current);
+      mobileHoldTimeoutRef.current = null;
+    }
+    if (mobileHoldIntervalRef.current !== null) {
+      window.clearInterval(mobileHoldIntervalRef.current);
+      mobileHoldIntervalRef.current = null;
+    }
+  }, []);
+
+  const handleMobileMoveStart = useCallback(
     (directionStr: string) => {
-      switch (directionStr) {
-        case "UP":
-          handleMoveInput(Direction.UP);
-          break;
-        case "RIGHT":
-          handleMoveInput(Direction.RIGHT);
-          break;
-        case "DOWN":
-          handleMoveInput(Direction.DOWN);
-          break;
-        case "LEFT":
-          handleMoveInput(Direction.LEFT);
-          break;
+      const direction = directionFromString(directionStr);
+      if (direction === null) return;
+      if (smoothEnabled) {
+        // Mirror a keyboard keydown: mark the direction held so the rAF loop
+        // chains steps into a run, then kick off the first step now.
+        smoothHeldRef.current = smoothHeldRef.current.filter(
+          (d) => d !== direction
+        );
+        smoothHeldRef.current.push(direction);
+        handleMoveInput(direction);
+      } else {
+        // No rAF chaining without smooth mode, so emulate keyboard key-repeat.
+        clearMobileHold();
+        handleMoveInput(direction);
+        mobileHoldTimeoutRef.current = window.setTimeout(() => {
+          mobileHoldIntervalRef.current = window.setInterval(() => {
+            handleMoveInput(direction);
+          }, 130);
+        }, 180);
       }
     },
-    [handleMoveInput]
+    [smoothEnabled, handleMoveInput, clearMobileHold]
   );
+
+  const handleMobileMoveEnd = useCallback(
+    (directionStr: string) => {
+      const direction = directionFromString(directionStr);
+      if (direction === null) return;
+      if (smoothEnabled) {
+        smoothHeldRef.current = smoothHeldRef.current.filter(
+          (d) => d !== direction
+        );
+      } else {
+        clearMobileHold();
+      }
+    },
+    [smoothEnabled, clearMobileHold]
+  );
+
+  // Stop any held-to-run repeat if the component unmounts mid-press.
+  useEffect(() => clearMobileHold, [clearMobileHold]);
 
   // Add keyboard event listener
   useEffect(() => {
@@ -5042,7 +5097,8 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
       
       {/* Mobile controls - Outside ScreenShake to prevent displacement */}
       <MobileControls
-        onMove={handleMobileMove}
+        onMove={handleMobileMoveStart}
+        onMoveEnd={handleMobileMoveEnd}
         onThrowRock={handleThrowRock}
         rockCount={gameState.rockCount ?? 0}
         onUseRune={handleThrowRune}


### PR DESCRIPTION
Follow-up to the mobile controls polish.

## What changed
- **Hold-to-run** — the on-screen direction buttons now respond to press/hold (pointer events) instead of a single tap. Holding a direction moves the hero continuously, exactly like holding a keyboard arrow: in smooth mode the press marks the direction "held" so the existing rAF loop chains steps into a run; in non-smooth mode (`?smooth=0`) a key-repeat timer drives it. A quick tap still moves one tile, and pointer capture keeps the run going if your thumb drifts off the button.
- **No more press highlight** — the controls set `user-select: none`, `-webkit-tap-highlight-color: transparent`, `-webkit-touch-callout: none`, and `touch-action: none` (plus context-menu prevention), so pressing and holding no longer paints a blue selection over the control panel.

## Verification
- Full Jest suite green (614 passed); typecheck clean; production build passes.
- Verified in-browser (smooth mode = prod default): held DOWN ran the hero 6 tiles in ~1.4s, held UP ran until the wall, a quick tap moved exactly 1 tile, and the no-select CSS is applied to the buttons and panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)