### PR TITLE
Pink heart: layer chest prize on top of chest, not the tile below

### DIFF
--- a/components/Tile.tsx
+++ b/components/Tile.tsx
@@ -984,7 +984,7 @@ export const Tile: React.FC<TileProps> = ({
             <div
               key="pink-heart"
               data-testid={`subtype-icon-${TileSubtype.PINK_HEART}`}
-              className={`${styles.assetIcon} ${styles.pinkHeartIcon}`}
+              className={`${styles.assetIcon} ${styles.overlayIcon} ${styles.pinkHeartIcon}`}
             />
           </>
         )}


### PR DESCRIPTION
The pink flaming heart was the only opened-chest prize rendered without the overlayIcon class, so it stayed a normal flex child in the tile's subtypeContainer and wrapped to a second row below the chest sprite - spilling into the tile underneath, where a wall-top clipped it. Add overlayIcon (absolute, centered, z-index 5000) to match every other prize so the heart sits centered on the chest.