### PR TITLE
Make daily water generation semi-random with sized pools

### DIFF
--- a/__tests__/lib/water_behavior.test.ts
+++ b/__tests__/lib/water_behavior.test.ts
@@ -7,8 +7,15 @@ import {
   detonateLiveBombs,
 } from "../../lib/map/game-state";
 import type { GameState } from "../../lib/map/game-state";
-import { generateCompleteMapForFloor } from "../../lib/map/map-features";
+import {
+  generateCompleteMapForFloor,
+  addWaterPoolsToMap,
+  rollWaterPlan,
+  WATER_FLOOR_CHANCE,
+  type WaterPlan,
+} from "../../lib/map/map-features";
 import { areAllFloorsConnected } from "../../lib/map/map-generation";
+import { mulberry32, withPatchedMathRandom } from "../../lib/rng";
 
 function baseState(
   tiles: number[][],
@@ -360,5 +367,179 @@ describe("Water terrain (v2)", () => {
     // Pools cut their shore on 0-2 sides, so a rare pool can be all hard banks —
     // but the majority should still carry some shallow shoreline.
     expect(sawShallow).toBeGreaterThanOrEqual(Math.floor(sawDeep * 0.6));
+  });
+});
+
+describe("Water terrain — sized daily generation", () => {
+  type Map = { tiles: number[][]; subtypes: number[][][] };
+
+  // Mirror advanceToNextFloor's seeded path: floorSeed = seed + floor, one mulberry32
+  // stream, generation inside withPatchedMathRandom.
+  function buildSeededFloor(
+    seed: number,
+    floor: number,
+    opts: { includeLava?: boolean; waterPlan?: WaterPlan }
+  ): Map {
+    const alloc =
+      floor === 2
+        ? {
+            chests: 2,
+            keys: 2,
+            chestContents: [TileSubtype.SWORD, TileSubtype.SHIELD],
+          }
+        : { chests: 0, keys: 0, chestContents: [] };
+    return withPatchedMathRandom(mulberry32(seed + floor), () =>
+      generateCompleteMapForFloor(alloc, floor, opts)
+    );
+  }
+
+  const countSub = (map: Map, sub: TileSubtype): number =>
+    map.subtypes.flat().filter((s) => s.includes(sub)).length;
+
+  // The dry-path guarantee: with every hazard (deep water, lava, faulty, abyss) walled,
+  // the remaining dry floor must still be one connected region reaching the key/exit.
+  const dryPathHolds = (map: Map): boolean => {
+    const testGrid = map.tiles.map((row) => [...row]);
+    for (let y = 0; y < map.tiles.length; y++) {
+      for (let x = 0; x < map.tiles[0].length; x++) {
+        const subs = map.subtypes[y][x];
+        if (
+          subs.includes(TileSubtype.DEEP_WATER) ||
+          subs.includes(TileSubtype.LAVA) ||
+          subs.includes(TileSubtype.FAULTY_FLOOR) ||
+          subs.includes(TileSubtype.OPEN_ABYSS)
+        ) {
+          testGrid[y][x] = 1; // WALL
+        }
+      }
+    }
+    return areAllFloorsConnected(testGrid);
+  };
+
+  test("largest (flood ~50%) water + lava never strands the key/exit — 25 seeds, F2 and F3", () => {
+    for (const floor of [2, 3]) {
+      const plan: WaterPlan = { tier: "flood", poolCount: 1, coverage: 0.5 };
+      let sawSizablePool = 0;
+      for (let seed = 0; seed < 25; seed++) {
+        const map = buildSeededFloor(seed, floor, {
+          includeLava: true,
+          waterPlan: plan,
+        });
+        // HARD invariant: a dry, swim-free, lava-free route always survives.
+        expect(dryPathHolds(map)).toBe(true);
+        // Water never overwrites objectives or lava.
+        for (let y = 0; y < map.tiles.length; y++) {
+          for (let x = 0; x < map.tiles[0].length; x++) {
+            const subs = map.subtypes[y][x];
+            if (
+              subs.includes(TileSubtype.DEEP_WATER) ||
+              subs.includes(TileSubtype.SHALLOW_WATER)
+            ) {
+              expect(subs).not.toContain(TileSubtype.EXIT);
+              expect(subs).not.toContain(TileSubtype.EXITKEY);
+              expect(subs).not.toContain(TileSubtype.LAVA);
+            }
+          }
+        }
+        if (countSub(map, TileSubtype.DEEP_WATER) >= 8) sawSizablePool++;
+      }
+      // Flood coverage should usually grow a large pool (connectivity may cap it, so
+      // allow a couple of tightly-roomed seeds to fall short).
+      expect(sawSizablePool).toBeGreaterThanOrEqual(20);
+    }
+  });
+
+  test("higher coverage produces more deep water on average", () => {
+    const meanDeep = (coverage: number): number => {
+      let total = 0;
+      const N = 15;
+      for (let s = 0; s < N; s++) {
+        const map = buildSeededFloor(s, 2, {
+          waterPlan: { tier: "pond", poolCount: 1, coverage },
+        });
+        total += countSub(map, TileSubtype.DEEP_WATER);
+      }
+      return total / N;
+    };
+    // A big-lake coverage should clearly out-fill a puddle coverage.
+    expect(meanDeep(0.4)).toBeGreaterThan(meanDeep(0.04) + 5);
+  });
+
+  test("rock count scales up when a floor carries deep water", () => {
+    const meanRocks = (waterPlan?: WaterPlan): number => {
+      let total = 0;
+      const N = 15;
+      for (let s = 0; s < N; s++) {
+        const map = buildSeededFloor(s, 2, waterPlan ? { waterPlan } : {});
+        total += countSub(map, TileSubtype.ROCK);
+      }
+      return total / N;
+    };
+    const dry = meanRocks();
+    const flooded = meanRocks({ tier: "flood", poolCount: 1, coverage: 0.4 });
+    // Rocks are the only dry-crossing tool, so a big pool should hand out clearly more.
+    expect(flooded).toBeGreaterThan(dry + 3);
+  });
+
+  test("rollWaterPlan: F1 never rolls, candidate floors enable ~half the time, flood is rare", () => {
+    expect(WATER_FLOOR_CHANCE).toBeCloseTo(0.5);
+
+    const N = 4000;
+
+    // Floor 1 (and 4+) are never water candidates, whatever the stream.
+    let f1Null = 0;
+    let f4Null = 0;
+    withPatchedMathRandom(mulberry32(4242), () => {
+      for (let i = 0; i < N; i++) {
+        if (rollWaterPlan(1) === null) f1Null++;
+        if (rollWaterPlan(4) === null) f4Null++;
+      }
+    });
+    expect(f1Null).toBe(N);
+    expect(f4Null).toBe(N);
+
+    // Candidate floors: ~half enable; enabled plans are weighted toward small pools.
+    let enabled = 0;
+    const tierCounts: Record<string, number> = {};
+    withPatchedMathRandom(mulberry32(1337), () => {
+      for (let i = 0; i < N; i++) {
+        const p = rollWaterPlan(2);
+        if (!p) continue;
+        enabled++;
+        tierCounts[p.tier] = (tierCounts[p.tier] ?? 0) + 1;
+        expect(p.coverage).toBeGreaterThan(0);
+        expect(p.poolCount).toBeGreaterThanOrEqual(1);
+        if (p.tier === "flood") {
+          expect(p.coverage).toBeGreaterThanOrEqual(0.4);
+          expect(p.coverage).toBeLessThanOrEqual(0.5);
+        }
+      }
+    });
+    const enableRate = enabled / N;
+    expect(enableRate).toBeGreaterThan(0.44);
+    expect(enableRate).toBeLessThan(0.56);
+
+    // Puddles are the plurality; flood is genuinely rare (~5% of watered floors).
+    expect(tierCounts.puddles).toBeGreaterThan(tierCounts.flood);
+    const floodFrac = (tierCounts.flood ?? 0) / enabled;
+    expect(floodFrac).toBeGreaterThan(0.01);
+    expect(floodFrac).toBeLessThan(0.12);
+  });
+
+  test("addWaterPoolsToMap with no opts keeps the legacy small pool", () => {
+    // Back-compat: the includeWater boolean path (test-lava-gen, older callers) should
+    // still yield a modest 2-4 tile deep core.
+    let maxDeep = 0;
+    for (let s = 0; s < 20; s++) {
+      const map = withPatchedMathRandom(mulberry32(s + 2), () =>
+        generateCompleteMapForFloor(
+          { chests: 2, keys: 2, chestContents: [TileSubtype.SWORD, TileSubtype.SHIELD] },
+          2,
+          { includeWater: true }
+        )
+      );
+      maxDeep = Math.max(maxDeep, countSub(map, TileSubtype.DEEP_WATER));
+    }
+    expect(maxDeep).toBeLessThanOrEqual(4);
   });
 });

--- a/app/test-water-daily/page.tsx
+++ b/app/test-water-daily/page.tsx
@@ -1,0 +1,280 @@
+"use client";
+
+import React, { Suspense, useMemo, useState } from "react";
+import { TilemapGrid } from "../../components/TilemapGrid";
+import {
+  tileTypes,
+  TileSubtype,
+  Direction,
+  initializeGameStateForMultiTier,
+  advanceToNextFloor,
+  type GameState,
+} from "../../lib/map";
+import { rollWaterPlan, type WaterPlan } from "../../lib/map/map-features";
+import { hashStringToSeed, mulberry32, withPatchedMathRandom } from "../../lib/rng";
+import { DateUtils } from "../../lib/date_utils";
+
+/**
+ * Daily WATER generation browser, keyed by DATE. Pick a past date and this rebuilds
+ * that day's real 3-floor daily run through the exact seeded path the game uses
+ * (withPatchedMathRandom(mulberry32(seed)) → initializeGameStateForMultiTier(1), then
+ * advanceToNextFloor for floors 2-3), so you see precisely how water (semi-random,
+ * ~1-in-3 floors, weighted size tiers) would land that day — and how the rock count
+ * scales with it. Floor 1 is the element-free teaching floor.
+ *
+ * The rolled water plan (tier / pool count / target coverage) is shown per floor by
+ * re-running the same seeded roll in an isolated stream — it matches what the map
+ * builder rolled because the water roll is the first RNG draw for each floor.
+ *
+ * Only past-or-today dates are allowed (future dates would spoil upcoming dailies).
+ */
+
+function shiftDate(dateStr: string, delta: number): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  const dt = new Date(y, m - 1, d + delta);
+  const yy = dt.getFullYear();
+  const mm = String(dt.getMonth() + 1).padStart(2, "0");
+  const dd = String(dt.getDate()).padStart(2, "0");
+  return `${yy}-${mm}-${dd}`;
+}
+
+function countSub(state: GameState, sub: TileSubtype): number {
+  return state.mapData.subtypes.flat().filter((s) => s.includes(sub)).length;
+}
+
+type FloorData = {
+  floor: number;
+  state: GameState;
+  plan: WaterPlan | null;
+  deep: number;
+  shallow: number;
+  lava: number;
+  rocks: number;
+};
+
+function buildDay(dateStr: string): FloorData[] {
+  const seed = hashStringToSeed(dateStr);
+  const f1 = withPatchedMathRandom(mulberry32(seed), () =>
+    initializeGameStateForMultiTier(1)
+  );
+  const f2 = advanceToNextFloor(f1, seed);
+  const f3 = advanceToNextFloor(f2, seed);
+  const states = [f1, f2, f3];
+  // Re-run the water roll in an isolated stream per floor — the roll is the first RNG
+  // draw inside advanceToNextFloor's mulberry32(seed + floor) stream, so this matches.
+  const plans: (WaterPlan | null)[] = [
+    null,
+    withPatchedMathRandom(mulberry32(seed + 2), () => rollWaterPlan(2)),
+    withPatchedMathRandom(mulberry32(seed + 3), () => rollWaterPlan(3)),
+  ];
+  return states.map((state, i) => ({
+    floor: i + 1,
+    state,
+    plan: plans[i],
+    deep: countSub(state, TileSubtype.DEEP_WATER),
+    shallow: countSub(state, TileSubtype.SHALLOW_WATER),
+    lava: countSub(state, TileSubtype.LAVA),
+    rocks: countSub(state, TileSubtype.ROCK),
+  }));
+}
+
+/** Full-floor minimap: one colored cell per tile (the game camera only shows a small
+ *  window, useless for judging generation). */
+function MiniMap({ state, cell = 8 }: { state: GameState; cell?: number }) {
+  const { tiles, subtypes } = state.mapData;
+  const cellFor = (y: number, x: number): { bg: string; title: string } => {
+    const subs = subtypes[y][x] ?? [];
+    if (subs.includes(TileSubtype.LAVA)) return { bg: "#ff5a1e", title: "lava" };
+    if (subs.includes(TileSubtype.OBSIDIAN)) return { bg: "#4a3040", title: "obsidian" };
+    if (subs.includes(TileSubtype.DEEP_WATER)) return { bg: "#1e4e7a", title: "deep water" };
+    if (subs.includes(TileSubtype.SHALLOW_WATER)) return { bg: "#4a7f9c", title: "shallow water" };
+    if (subs.includes(TileSubtype.STEPPING_STONE)) return { bg: "#8a8f94", title: "stepping stone" };
+    if (subs.includes(TileSubtype.PLAYER)) return { bg: "#ffffff", title: "hero" };
+    if (subs.includes(TileSubtype.EXIT)) return { bg: "#34d399", title: "exit" };
+    if (subs.includes(TileSubtype.EXITKEY)) return { bg: "#fde047", title: "exit key" };
+    if (subs.includes(TileSubtype.KEY)) return { bg: "#eab308", title: "chest key" };
+    if (subs.includes(TileSubtype.CHEST)) return { bg: "#a16207", title: "chest" };
+    if (subs.includes(TileSubtype.FAULTY_FLOOR)) return { bg: "#111111", title: "faulty" };
+    if (subs.includes(TileSubtype.POT)) return { bg: "#8d7350", title: "pot" };
+    if (subs.includes(TileSubtype.ROCK)) return { bg: "#9ca3af", title: "rock" };
+    if (tiles[y][x] === 1) return { bg: "#3f4a3f", title: "wall" };
+    return { bg: "#6b7a5e", title: "floor" };
+  };
+  return (
+    <div
+      style={{
+        display: "grid",
+        gridTemplateColumns: `repeat(${tiles[0].length}, ${cell}px)`,
+        gap: 1,
+        background: "#222",
+        padding: 3,
+        width: "fit-content",
+      }}
+    >
+      {tiles.map((row, y) =>
+        row.map((_, x) => {
+          const { bg, title } = cellFor(y, x);
+          return (
+            <div
+              key={`${y}-${x}`}
+              title={`${title} (${y},${x})`}
+              style={{ width: cell, height: cell, background: bg }}
+            />
+          );
+        })
+      )}
+    </div>
+  );
+}
+
+function planLabel(fd: FloorData): string {
+  if (fd.floor === 1) return "teaching floor — no elements";
+  if (!fd.plan) return "dry (no water rolled)";
+  const cov = Math.round(fd.plan.coverage * 100);
+  const pools = fd.plan.poolCount === 1 ? "1 pool" : `${fd.plan.poolCount} pools`;
+  return `${fd.plan.tier} · ${pools} · target ${cov}%`;
+}
+
+function FloorColumn({
+  fd,
+  selected,
+  onSelect,
+}: {
+  fd: FloorData;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  const watered = fd.deep > 0 || fd.shallow > 0;
+  return (
+    <div
+      className="flex flex-col items-center gap-2 rounded-lg p-2"
+      style={{
+        background: selected ? "rgba(59,130,246,0.18)" : "rgba(0,0,0,0.5)",
+        border: selected ? "1px solid #3b82f6" : "1px solid #333",
+      }}
+    >
+      <button
+        onClick={onSelect}
+        className="text-sm font-bold underline-offset-2 hover:underline"
+      >
+        Floor {fd.floor} {selected ? "◂ viewing" : ""}
+      </button>
+      <div className="text-[11px] text-gray-300 text-center leading-tight">
+        <div className={watered ? "text-sky-300" : "text-gray-400"}>{planLabel(fd)}</div>
+        <div className="mt-1">
+          deep <b>{fd.deep}</b> · shallow <b>{fd.shallow}</b>
+        </div>
+        <div>
+          lava <b>{fd.lava}</b> · rocks <b>{fd.rocks}</b>
+        </div>
+      </div>
+      <MiniMap state={fd.state} cell={7} />
+    </div>
+  );
+}
+
+function TestWaterDailyInner() {
+  const today = DateUtils.getTodayString();
+  const params =
+    typeof window !== "undefined" ? new URLSearchParams(window.location.search) : null;
+  const initialDate = (() => {
+    const q = params?.get("date");
+    if (q && /^\d{4}-\d{2}-\d{2}$/.test(q) && q <= today) return q;
+    return today;
+  })();
+
+  const [date, setDate] = useState(initialDate);
+  const [selectedFloor, setSelectedFloor] = useState(2); // F2 is the first water candidate
+
+  const day = useMemo(() => buildDay(date), [date]);
+
+  const clampPast = (d: string) => (d > today ? today : d);
+  const wateredFloors = day.filter((f) => f.deep > 0 || f.shallow > 0).length;
+  const totalDeep = day.reduce((n, f) => n + f.deep, 0);
+
+  const selected = day[selectedFloor - 1];
+  const gridState: GameState = {
+    ...selected.state,
+    enemies: [],
+    npcs: [],
+    showFullMap: true,
+    playerDirection: Direction.DOWN,
+    mode: "normal",
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center p-4 text-white bg-black/90 gap-4">
+      <div className="text-center bg-black/70 rounded-lg p-3 w-full max-w-3xl">
+        <h1 className="text-xl font-bold">Daily Water Generation Browser</h1>
+        <p className="text-xs text-gray-300 mt-1">
+          Rebuilds a past day&apos;s real 3-floor daily. Water is semi-random: ~1-in-3
+          floors, mostly small, rarely a ~50% flood. Rocks scale with water.
+        </p>
+        <div className="flex items-center justify-center gap-2 mt-3 flex-wrap">
+          <button
+            className="px-2 py-1 rounded bg-white/10 hover:bg-white/20 text-sm"
+            onClick={() => setDate((d) => shiftDate(d, -1))}
+          >
+            ← prev day
+          </button>
+          <input
+            type="date"
+            value={date}
+            max={today}
+            onChange={(e) => e.target.value && setDate(clampPast(e.target.value))}
+            className="bg-white/10 rounded px-2 py-1 text-sm"
+          />
+          <button
+            className="px-2 py-1 rounded bg-white/10 hover:bg-white/20 text-sm disabled:opacity-30"
+            disabled={date >= today}
+            onClick={() => setDate((d) => clampPast(shiftDate(d, 1)))}
+          >
+            next day →
+          </button>
+          <button
+            className="px-2 py-1 rounded bg-white/10 hover:bg-white/20 text-sm"
+            onClick={() => setDate(today)}
+          >
+            today
+          </button>
+        </div>
+        <p className="text-xs text-gray-300 mt-2">
+          <b>{date}</b>
+          {date === today ? " (today's daily)" : ""} · seed{" "}
+          <b>{hashStringToSeed(date)}</b> · watered floors <b>{wateredFloors}/3</b> · total
+          deep-water tiles <b>{totalDeep}</b>
+        </p>
+      </div>
+
+      <div className="flex gap-3 flex-wrap justify-center max-w-full overflow-x-auto">
+        {day.map((fd) => (
+          <FloorColumn
+            key={fd.floor}
+            fd={fd}
+            selected={fd.floor === selectedFloor}
+            onSelect={() => setSelectedFloor(fd.floor)}
+          />
+        ))}
+      </div>
+
+      <div className="flex flex-col items-center gap-2">
+        <div className="text-sm text-gray-300">
+          Full view — Floor {selectedFloor} ({planLabel(selected)})
+        </div>
+        <TilemapGrid
+          tileTypes={tileTypes}
+          initialGameState={gridState}
+          forceDaylight={true}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function TestWaterDailyPage() {
+  return (
+    <Suspense fallback={null}>
+      <TestWaterDailyInner />
+    </Suspense>
+  );
+}

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -48,7 +48,7 @@ import {
 } from "./utils";
 import { addPlayerToMap, findPlayerPosition, removePlayerFromMapData } from "./player";
 import { computeTorchGlow } from "../torch_glow";
-import { addRunePotsForStoneExciters, generateCompleteMap, generateCompleteMapForFloor, allocateChestsAndKeys } from "./map-features";
+import { addRunePotsForStoneExciters, generateCompleteMap, generateCompleteMapForFloor, allocateChestsAndKeys, rollWaterPlan } from "./map-features";
 import { addSnakesPerRules, addStaticGuardNearKey } from "./enemy-features";
 import { buildOutsideWorld, buildNightmareRoom, innerEdgeForDirection } from "./outside-world";
 import { buildPinkRealm } from "./pink-realm";
@@ -2103,20 +2103,23 @@ export function advanceToNextFloor(currentState: GameState, dailySeed: number): 
   // Get the pre-computed chest/key allocation for this floor
   const allocation = currentState.floorChestAllocation?.[nextFloor];
   
-  // Daily floors 2 and 3 carry elemental terrain: instant-death lava pools and a
-  // deep-water pool with a shallow shoreline. Floor 1 is built elsewhere and stays
-  // element-free as the teaching floor.
+  // Daily floors 2 and 3 carry elemental terrain. Lava is always present on those
+  // floors; water is SEMI-RANDOM — each floor independently rolls whether it gets a
+  // pool and how big (rollWaterPlan: ~1/2 per candidate floor, weighted size tiers,
+  // ~50%-coverage flood is rare). Lava and water can coexist on the same floor. Floor 1
+  // is built elsewhere and stays element-free as the teaching floor.
   const includeLava = nextFloor === 2 || nextFloor === 3;
-  const includeWater = nextFloor === 2 || nextFloor === 3;
 
-  // Generate new map with floor-specific seed
+  // Generate new map with floor-specific seed. The water roll MUST happen inside this
+  // seeded block (before map generation) so daily maps stay deterministic.
   const newMapData = withPatchedMathRandom(rng, () => {
+    const waterPlan = rollWaterPlan(nextFloor) ?? undefined;
     let mapData: MapData;
     if (allocation && (allocation.chests > 0 || allocation.keys > 0)) {
-      mapData = generateCompleteMapForFloor(allocation, nextFloor, { includeLava, includeWater });
+      mapData = generateCompleteMapForFloor(allocation, nextFloor, { includeLava, waterPlan });
     } else {
       // Floors 5+: no chests or keys, just a standard map without chests/keys
-      mapData = generateCompleteMapForFloor({ chests: 0, keys: 0, chestContents: [] }, nextFloor, { includeLava, includeWater });
+      mapData = generateCompleteMapForFloor({ chests: 0, keys: 0, chestContents: [] }, nextFloor, { includeLava, waterPlan });
     }
     return mapData;
   });

--- a/lib/map/map-features.ts
+++ b/lib/map/map-features.ts
@@ -390,26 +390,104 @@ export function addLavaPoolsToMap(mapData: MapData, floor?: number): MapData {
 }
 
 /**
- * Carve one water pool into a floor: a DEEP_WATER core with a SHALLOW_WATER shore
- * on most — not necessarily all — sides (each pool cuts the shore on 0-2 sides, so
- * some banks drop straight from dry floor into deep water).
+ * A daily floor's water "size tier". Deep-water coverage is expressed as a fraction of
+ * the floor's eligible interior floor tiles, so it scales with grid size. Mostly small
+ * (puddles/pond); a lake is uncommon; a floor-flooding ~50% pool is genuinely rare.
+ */
+export type WaterTier = "puddles" | "pond" | "lake" | "flood";
+
+/**
+ * A resolved water plan for one floor: which size tier, how many separate pools, and
+ * the target deep-water coverage (fraction of eligible floor). Produced by rollWaterPlan
+ * (a seeded roll) and consumed by addWaterPoolsToMap.
+ */
+export type WaterPlan = {
+  tier: WaterTier;
+  poolCount: number;
+  coverage: number;
+};
+
+// Weighted size table. `coverage` is the fraction of eligible interior floor that
+// becomes DEEP water (the shallow shore is extra, on top). "Mostly small-to-medium,
+// rarely up to ~50%." Weights sum to 1.
+const WATER_TIERS: ReadonlyArray<{
+  tier: WaterTier;
+  weight: number;
+  poolCount: [number, number]; // inclusive range
+  coverage: [number, number]; // inclusive range, fraction of eligible floor
+}> = [
+  { tier: "puddles", weight: 0.45, poolCount: [3, 4], coverage: [0.02, 0.05] },
+  { tier: "pond", weight: 0.33, poolCount: [1, 1], coverage: [0.06, 0.11] },
+  { tier: "lake", weight: 0.17, poolCount: [1, 2], coverage: [0.16, 0.28] },
+  { tier: "flood", weight: 0.05, poolCount: [1, 1], coverage: [0.4, 0.5] },
+];
+
+/**
+ * Per-candidate-floor chance that the floor rolls any water at all. Only daily floors
+ * 2-3 are candidates (floor 1 stays element-free as the teaching floor), so two floors
+ * at 0.5 average one watered floor per three-floor day — "about 1 in 3 daily floors".
+ */
+export const WATER_FLOOR_CHANCE = 0.5;
+
+function pickWaterTier(): (typeof WATER_TIERS)[number] {
+  const r = Math.random();
+  let acc = 0;
+  for (const t of WATER_TIERS) {
+    acc += t.weight;
+    if (r < acc) return t;
+  }
+  return WATER_TIERS[WATER_TIERS.length - 1];
+}
+
+/**
+ * Seeded roll for a floor's water plan. Only daily floors 2-3 are candidates; every
+ * other floor (including the floor-1 teaching floor) returns null. A candidate floor
+ * rolls dry (null) at rate 1 - WATER_FLOOR_CHANCE; otherwise it draws a weighted size
+ * tier and a coverage/pool-count within that tier.
+ *
+ * MUST be called inside the seeded withPatchedMathRandom block so daily maps stay
+ * deterministic (see the daily-determinism gotcha: land generation shifts in one deploy).
+ */
+export function rollWaterPlan(floor: number): WaterPlan | null {
+  if (floor !== 2 && floor !== 3) return null;
+  if (Math.random() >= WATER_FLOOR_CHANCE) return null;
+  const t = pickWaterTier();
+  const [pcLo, pcHi] = t.poolCount;
+  const [covLo, covHi] = t.coverage;
+  const poolCount = pcLo + Math.floor(Math.random() * (pcHi - pcLo + 1));
+  const coverage = covLo + Math.random() * (covHi - covLo);
+  return { tier: t.tier, poolCount, coverage };
+}
+
+/**
+ * Carve one or more water pools into a floor: each a DEEP_WATER core with a
+ * SHALLOW_WATER shore on most — not necessarily all — sides (each pool cuts the shore
+ * on 0-2 sides, so some banks drop straight from dry floor into deep water).
  * Shallow water is free to wade (torch stays lit); deep water is swum — the torch
  * snuffs — or bridged with thrown rocks (STEPPING_STONE). Only the deep core counts
- * against connectivity: it is walled in the test grid (together with any lava already
- * placed) so a dry, swim-free path to the key/exit always exists. The shallow ring is
- * ordinary walkable floor and needs no guarantee.
+ * against connectivity: it is walled in the test grid (together with any lava/faulty
+ * already placed) so a dry, swim-free path to the key/exit always exists. The shallow
+ * ring is ordinary walkable floor and needs no guarantee.
+ *
+ * Size/count come from `opts` (from a seeded rollWaterPlan): `coverage` is the fraction
+ * of eligible interior floor that becomes DEEP water, split across `poolCount` pools.
+ * With no opts it falls back to the legacy single 2-4 tile pool. Pools grow by
+ * INCREMENTAL connectivity-safe accretion — a candidate tile is added only if the floor
+ * stays one connected region with it (and all prior water/lava) walled — so a large
+ * target degrades gracefully to the biggest safe pool rather than being rejected whole.
  *
  * Same placement rules as lava: interior tiles only, empty FLOOR only (so downstream
  * item/spawn scans avoid the water automatically), and never within Chebyshev radius 2
  * of the exit or exit key. Must run inside the seeded withPatchedMathRandom block.
  */
-export function addWaterPoolsToMap(mapData: MapData): MapData {
+export function addWaterPoolsToMap(
+  mapData: MapData,
+  opts?: { poolCount?: number; coverage?: number }
+): MapData {
   const newMapData: MapData = JSON.parse(JSON.stringify(mapData));
   const grid = newMapData.tiles;
   const h = grid.length;
   const w = grid[0]?.length ?? 0;
-
-  const deepTarget = 2 + Math.floor(Math.random() * 3); // 2..4 deep tiles
 
   const protectedTiles = new Set<string>();
   for (let y = 0; y < h; y++) {
@@ -425,6 +503,8 @@ export function addWaterPoolsToMap(mapData: MapData): MapData {
     }
   }
 
+  // Eligible = interior, empty FLOOR, not in the exit/key halo, and not already water
+  // (deep or shallow, so pools placed earlier in this call are never overwritten).
   const isEligible = (y: number, x: number): boolean => {
     if (y < 1 || y >= h - 1 || x < 1 || x >= w - 1) return false; // interior only
     if (grid[y][x] !== FLOOR) return false;
@@ -434,9 +514,33 @@ export function addWaterPoolsToMap(mapData: MapData): MapData {
     return true;
   };
 
-  // Whole-pool connectivity: wall the deep candidate plus every hazard already on the
-  // map (lava, faulty) and require one connected floor region — the dry-path rule.
-  const keepsConnectivity = (candidate: Set<string>): boolean => {
+  // Coverage denominator: eligible interior floor at placement time.
+  let eligibleCount = 0;
+  for (let y = 0; y < h; y++) {
+    for (let x = 0; x < w; x++) {
+      if (isEligible(y, x)) eligibleCount++;
+    }
+  }
+  if (eligibleCount === 0) return newMapData;
+
+  const poolCount = Math.max(1, opts?.poolCount ?? 1);
+  // Total deep-water budget across all pools. With a coverage fraction, scale to the
+  // floor; without, keep the legacy small 2-4 tile pool.
+  const deepBudget =
+    opts?.coverage !== undefined
+      ? Math.max(1, Math.round(opts.coverage * eligibleCount))
+      : 2 + Math.floor(Math.random() * 3);
+  const perPool = Math.max(1, Math.ceil(deepBudget / poolCount));
+
+  // Deep tiles committed so far (across all pools) — walled in every connectivity test.
+  const placedDeep = new Set<string>();
+  // Tiles that broke connectivity once. Walling more tiles only ever makes connectivity
+  // harder, and placedDeep only grows, so a rejection is permanent — cache it globally.
+  const rejected = new Set<string>();
+
+  // Does the floor stay one connected region if `placedDeep` ∪ `extra` (this pool's
+  // tentative tiles) ∪ every hazard already on the map are all walls?
+  const keepsConnectivity = (extra: Iterable<string>): boolean => {
     const testGrid = grid.map((row) => [...row]);
     for (let yy = 0; yy < h; yy++) {
       for (let xx = 0; xx < w; xx++) {
@@ -449,60 +553,86 @@ export function addWaterPoolsToMap(mapData: MapData): MapData {
         }
       }
     }
-    for (const key of candidate) {
+    for (const key of placedDeep) {
+      const [yy, xx] = key.split(",").map(Number);
+      testGrid[yy][xx] = WALL;
+    }
+    for (const key of extra) {
       const [yy, xx] = key.split(",").map(Number);
       testGrid[yy][xx] = WALL;
     }
     return areAllFloorsConnected(testGrid);
   };
 
-  // Try a handful of seeds; commit the first pool whose deep core keeps the floor connected.
-  for (let attempt = 0; attempt < 8; attempt++) {
+  for (let p = 0; p < poolCount; p++) {
+    // Fresh seed list each pool (previously placed water is no longer eligible).
     const seeds: Array<[number, number]> = [];
     for (let y = 0; y < h; y++) {
       for (let x = 0; x < w; x++) {
-        if (isEligible(y, x)) seeds.push([y, x]);
+        if (isEligible(y, x) && !rejected.has(`${y},${x}`)) seeds.push([y, x]);
       }
     }
-    if (seeds.length === 0) return newMapData;
-    const [sy, sx] = seeds[Math.floor(Math.random() * seeds.length)];
+    if (seeds.length === 0) break;
 
-    // Grow the deep core by random 4-neighbour accretion.
-    const candidate = new Set<string>([`${sy},${sx}`]);
-    const frontier: Array<[number, number]> = [[sy, sx]];
-    while (candidate.size < deepTarget && frontier.length > 0) {
+    // Find a seed tile that is itself connectivity-safe.
+    let seed: [number, number] | null = null;
+    for (let tries = 0; tries < 8 && seeds.length > 0; tries++) {
+      const idx = Math.floor(Math.random() * seeds.length);
+      const [sy, sx] = seeds[idx];
+      const key = `${sy},${sx}`;
+      if (keepsConnectivity([key])) {
+        seed = [sy, sx];
+        break;
+      }
+      rejected.add(key);
+      seeds.splice(idx, 1);
+    }
+    if (!seed) continue;
+
+    // Grow the deep core by connectivity-safe 4-neighbour accretion: a tile joins only
+    // if the whole floor stays connected with it (and all prior water) walled.
+    const core = new Set<string>([`${seed[0]},${seed[1]}`]);
+    const frontier: Array<[number, number]> = [seed];
+    while (core.size < perPool && frontier.length > 0) {
       const fi = Math.floor(Math.random() * frontier.length);
       const [cy, cx] = frontier[fi];
-      const neighbors: Array<[number, number]> = [
+      const open = ([
         [cy - 1, cx],
         [cy + 1, cx],
         [cy, cx - 1],
         [cy, cx + 1],
-      ];
-      const open = neighbors.filter(
-        ([ny, nx]) => isEligible(ny, nx) && !candidate.has(`${ny},${nx}`)
+      ] as Array<[number, number]>).filter(
+        ([ny, nx]) =>
+          isEligible(ny, nx) &&
+          !core.has(`${ny},${nx}`) &&
+          !placedDeep.has(`${ny},${nx}`) &&
+          !rejected.has(`${ny},${nx}`)
       );
       if (open.length === 0) {
         frontier.splice(fi, 1);
         continue;
       }
       const [ny, nx] = open[Math.floor(Math.random() * open.length)];
-      candidate.add(`${ny},${nx}`);
-      frontier.push([ny, nx]);
+      const key = `${ny},${nx}`;
+      if (keepsConnectivity([...core, key])) {
+        core.add(key);
+        frontier.push([ny, nx]);
+      } else {
+        rejected.add(key);
+      }
     }
 
-    if (!keepsConnectivity(candidate)) continue;
-
-    // Commit the deep core...
-    for (const key of candidate) {
+    // Commit the deep core.
+    for (const key of core) {
       const [yy, xx] = key.split(",").map(Number);
       newMapData.subtypes[yy][xx] = [TileSubtype.DEEP_WATER];
+      placedDeep.add(key);
     }
-    // ...then ring it with a shallow shoreline — but not necessarily all the way
-    // around. Each pool picks 0-2 "cut" sides (N/E/S/W) where the shore is omitted,
-    // so some banks drop straight from dry floor into deep water. Ring tiles whose
-    // offset from a deep tile points into a cut side are skipped (diagonals are
-    // skipped if either component points at a cut, keeping the bank edge clean).
+
+    // Ring it with a shallow shoreline — but not necessarily all the way around. Each
+    // pool cuts 0-2 sides (N/E/S/W) where the shore is omitted, so some banks drop
+    // straight from dry floor into deep water. A ring tile whose offset points into a
+    // cut side is skipped (diagonals skip if either component points at a cut).
     const cutRoll = Math.random();
     const cutCount = cutRoll < 0.25 ? 0 : cutRoll < 0.75 ? 1 : 2;
     const sides: Array<[number, number]> = [
@@ -518,7 +648,7 @@ export function addWaterPoolsToMap(mapData: MapData): MapData {
     const cutSides = sides.slice(0, cutCount);
     const pointsIntoCut = (dy: number, dx: number): boolean =>
       cutSides.some(([cy, cx]) => (cy !== 0 && dy === cy) || (cx !== 0 && dx === cx));
-    for (const key of candidate) {
+    for (const key of core) {
       const [yy, xx] = key.split(",").map(Number);
       for (let dy = -1; dy <= 1; dy++) {
         for (let dx = -1; dx <= 1; dx++) {
@@ -532,7 +662,6 @@ export function addWaterPoolsToMap(mapData: MapData): MapData {
         }
       }
     }
-    return newMapData;
   }
 
   return newMapData;
@@ -567,7 +696,21 @@ export function addRocksToMap(mapData: MapData, floor?: number): MapData {
   if (floor === 1) toPlace = 5;
   else if (floor === 2) toPlace = 4;
   else if (floor === 3) toPlace = 3;
-  
+
+  // Scale rocks up with deep water on this floor. Rocks are the ONLY way to build a
+  // dry stepping-stone crossing (they land at throw range and no longer convert on
+  // contact), so a big pool needs enough ammo to actually bridge it. Bonus is
+  // proportional to deep-water tiles, capped so a rare ~50% flood doesn't dump an
+  // absurd pile of rocks. Deterministic (reads the already-placed map, no new RNG).
+  let deepWaterTiles = 0;
+  for (let y = 0; y < gridHeight; y++) {
+    for (let x = 0; x < gridWidth; x++) {
+      if (newMapData.subtypes[y][x].includes(TileSubtype.DEEP_WATER)) deepWaterTiles++;
+    }
+  }
+  const waterRockBonus = Math.min(12, Math.floor(deepWaterTiles / 5));
+  toPlace += waterRockBonus;
+
   toPlace = Math.min(toPlace, eligible.length);
   for (let i = 0; i < toPlace; i++) {
     const [ry, rx] = eligible[i];
@@ -920,7 +1063,8 @@ export function generateCompleteMapForFloor(
     wallTorches?: number; // override the default wall torch count (endless dark floor)
     includeFaultyFloors?: boolean; // set false to guarantee no abyss holes (endless dark floor)
     includeLava?: boolean; // set true to carve instant-death lava pools (daily floors 2-3)
-    includeWater?: boolean; // set true to carve a deep-water pool with a shallow ring (daily floors 2-3)
+    includeWater?: boolean; // legacy: carve one small default deep-water pool + shallow ring
+    waterPlan?: WaterPlan; // sized water plan from a seeded rollWaterPlan (daily floors 2-3)
   },
 ): MapData {
   const [gridW, gridH] = opts?.gridSize ?? (floor !== undefined ? gridSizeForFloor(floor) : [GRID_SIZE, GRID_SIZE]);
@@ -938,7 +1082,14 @@ export function generateCompleteMapForFloor(
   // Lava first, then water: each pass walls the other's hazard tiles in its
   // connectivity test, so together they can never sever the dry path.
   const withLava = opts?.includeLava ? addLavaPoolsToMap(withKeys, floor) : withKeys;
-  const withWater = opts?.includeWater ? addWaterPoolsToMap(withLava) : withLava;
+  const withWater = opts?.waterPlan
+    ? addWaterPoolsToMap(withLava, {
+        poolCount: opts.waterPlan.poolCount,
+        coverage: opts.waterPlan.coverage,
+      })
+    : opts?.includeWater
+      ? addWaterPoolsToMap(withLava)
+      : withLava;
 
   const withPots = addPotsToMap(withWater);
   const withRocks = addRocksToMap(withPots, opts?.rocksFloor ?? floor);


### PR DESCRIPTION
## What

Water v2 already ships to every daily floor 2-3 as a fixed 2-4 tile pool. This makes it **semi-random** per Chris's ask:

- Each candidate floor (F2, F3) independently rolls whether it gets water — **~50% each**, so about **1 of the 3 daily floors** carries water on an average day (F1 stays element-free as the teaching floor).
- When a floor gets water, a **weighted size tier** decides how much:

  | Tier | Chance | Deep coverage |
  |---|---|---|
  | puddles (3-4 scattered) | 45% | 2-5% |
  | pond | 33% | 6-11% |
  | lake | 17% | 16-28% |
  | **flood** | **5%** | **40-50%** |

- Lava is unchanged (still always on F2/F3) and **coexists** with water.
- **Rocks scale with deep water** (`min(12, floor(deep/5))` bonus) — rocks are the only dry-crossing tool now that they land at throw range, so a big pool hands out enough to actually build a stepping-stone crossing.

## How

- `addWaterPoolsToMap` takes `{ poolCount, coverage }` and grows deep-water cores by **incremental connectivity-safe accretion** — a tile joins only if the floor stays one connected dry region with it (and all prior water/lava) walled — so a large target degrades to the biggest safe pool instead of being rejected whole.
- `rollWaterPlan` (seeded, called **inside** `withPatchedMathRandom`) picks the tier, keeping daily maps deterministic.

## Test plan

- `npm run typecheck` ✓
- `npm run test` ✓ (709 pass) — incl. a **25-seed sweep at the ~50% flood tier on F2 and F3** proving the dry-path-to-key/exit guarantee holds with every hazard walled; coverage monotonicity; rock scaling; and `rollWaterPlan` distribution (enable rate, flood rarity).
- `npm run build` ✓
- New `/test-water-daily` date-picker harness renders any past day's real 3-floor rolls.

## Deploy note (daily determinism)

Merging changes the RNG draw order, so today's daily layout shifts at deploy. Per the feature doc's gotcha #12, the clean window is **near/after local midnight** so today's daily isn't split between players who played before vs after the deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)