### PR TITLE
Add /stats endgame dashboard backed by PostHog

### DIFF
--- a/__tests__/lib/daily_chest_stats.test.ts
+++ b/__tests__/lib/daily_chest_stats.test.ts
@@ -1,0 +1,50 @@
+import { level2ChestStatusForDate } from "../../lib/stats/daily_chest";
+import { initializeGameStateForMultiTier } from "../../lib/map/game-state";
+import { hashStringToSeed, mulberry32, withPatchedMathRandom } from "../../lib/rng";
+import { TileSubtype } from "../../lib/map/constants";
+
+const L2_POOL = new Set([
+  TileSubtype.SNAKE_MEDALLION,
+  TileSubtype.EXTRA_HEART,
+  TileSubtype.BOMB,
+]);
+
+describe("level2ChestStatusForDate", () => {
+  const dates = ["2026-07-24", "2026-07-23", "2026-01-01", "2025-12-31", "2026-06-15"];
+
+  it("is deterministic for a given date", () => {
+    for (const d of dates) {
+      expect(level2ChestStatusForDate(d)).toEqual(level2ChestStatusForDate(d));
+    }
+  });
+
+  it("always draws exactly two distinct items from the L2 pool", () => {
+    for (const d of dates) {
+      const { items } = level2ChestStatusForDate(d);
+      expect(items).toHaveLength(2);
+      const subtypes = items.map((i) => i.subtype);
+      expect(new Set(subtypes).size).toBe(2); // distinct
+      subtypes.forEach((s) => expect(L2_POOL.has(s)).toBe(true));
+    }
+  });
+
+  it("bombAvailable reflects whether a bomb is among the items", () => {
+    for (const d of dates) {
+      const status = level2ChestStatusForDate(d);
+      const hasBomb = status.items.some((i) => i.key === "bomb");
+      expect(status.bombAvailable).toBe(hasBomb);
+    }
+  });
+
+  it("matches what the real daily generator places in the Level 2 chests", () => {
+    // The single source of truth: reproduce the exact seeded path the game uses
+    // to build a daily run and compare its floor-2 chest contents to our helper.
+    for (const d of dates) {
+      const rng = mulberry32(hashStringToSeed(d));
+      const state = withPatchedMathRandom(rng, () => initializeGameStateForMultiTier(1));
+      const gameL2 = state.floorChestAllocation?.[2]?.chestContents ?? [];
+      const helperL2 = level2ChestStatusForDate(d).items.map((i) => i.subtype);
+      expect(helperL2).toEqual(gameL2);
+    }
+  });
+});

--- a/__tests__/lib/endgame_stats.test.ts
+++ b/__tests__/lib/endgame_stats.test.ts
@@ -1,0 +1,163 @@
+import {
+  toGameCompleteRow,
+  parseHogQLRows,
+  summarizeDay,
+  groupRowsByDay,
+  type GameCompleteRow,
+} from "../../lib/stats/endgame_stats";
+
+function makeRow(overrides: Partial<GameCompleteRow> = {}): GameCompleteRow {
+  return {
+    day: "2026-07-24",
+    timestamp: "2026-07-24T12:00:00.000Z",
+    distinctId: "user_1",
+    outcome: "win",
+    levelReached: 3,
+    heroHealth: 4,
+    steps: 100,
+    enemiesDefeated: 10,
+    damageDealt: 20,
+    damageTaken: 5,
+    chestsOpened: 2,
+    totalChests: 4,
+    hasSword: true,
+    hasShield: false,
+    treesDestroyed: 0,
+    wallsDestroyed: 0,
+    reachedOutsideWorld: false,
+    reachedPinkRealm: false,
+    collectedChestItems: [],
+    deathCause: null,
+    deathCauseEnemyKind: null,
+    ...overrides,
+  };
+}
+
+describe("toGameCompleteRow coercion", () => {
+  it("coerces mixed-typed PostHog values", () => {
+    const row = toGameCompleteRow({
+      day: "2026-07-24",
+      timestamp: "2026-07-24T00:00:00Z",
+      distinct_id: "user_abc",
+      outcome: "WIN",
+      level_reached: "2", // string floor
+      hero_health: "3",
+      steps: 250,
+      enemies_defeated: "12",
+      damage_dealt: null,
+      damage_taken: undefined,
+      chests_opened: 1,
+      total_chests: 4,
+      has_sword: "true", // string boolean
+      has_shield: false,
+      trees_destroyed: "1", // string number
+      walls_destroyed: 2,
+      reached_outside_world: 1, // numeric truthy
+      reached_pink_realm: "false",
+      death_cause: null,
+      death_cause_enemy_kind: null,
+    });
+
+    expect(row.outcome).toBe("win");
+    expect(row.levelReached).toBe(2);
+    expect(row.heroHealth).toBe(3);
+    expect(row.enemiesDefeated).toBe(12);
+    expect(row.damageDealt).toBeNull();
+    expect(row.damageTaken).toBeNull();
+    expect(row.hasSword).toBe(true);
+    expect(row.hasShield).toBe(false);
+    expect(row.treesDestroyed).toBe(1);
+    expect(row.wallsDestroyed).toBe(2);
+    expect(row.reachedOutsideWorld).toBe(true);
+    expect(row.reachedPinkRealm).toBe(false);
+  });
+
+  it("treats a non-win outcome as 'dead' and missing counts as safe defaults", () => {
+    const row = toGameCompleteRow({ day: "2026-07-24", outcome: "dead" });
+    expect(row.outcome).toBe("dead");
+    expect(row.treesDestroyed).toBe(0);
+    expect(row.wallsDestroyed).toBe(0);
+    expect(row.reachedPinkRealm).toBe(false);
+    expect(row.levelReached).toBeNull();
+    expect(row.collectedChestItems).toEqual([]);
+  });
+
+  it("parses collected_chest_items as an array or a JSON string, else []", () => {
+    expect(
+      toGameCompleteRow({ day: "d", collected_chest_items: ["sword", "extra_heart"] })
+        .collectedChestItems
+    ).toEqual(["sword", "extra_heart"]);
+    expect(
+      toGameCompleteRow({ day: "d", collected_chest_items: '["shield","bomb"]' })
+        .collectedChestItems
+    ).toEqual(["shield", "bomb"]);
+    expect(
+      toGameCompleteRow({ day: "d", collected_chest_items: null }).collectedChestItems
+    ).toEqual([]);
+  });
+});
+
+describe("parseHogQLRows", () => {
+  it("maps rows-as-arrays to objects by column position", () => {
+    const columns = ["day", "outcome", "level_reached", "reached_pink_realm"];
+    const results: unknown[][] = [
+      ["2026-07-24", "win", "3", true],
+      ["2026-07-24", "dead", "1", false],
+    ];
+    const rows = parseHogQLRows(columns, results);
+    expect(rows).toHaveLength(2);
+    expect(rows[0].outcome).toBe("win");
+    expect(rows[0].levelReached).toBe(3);
+    expect(rows[0].reachedPinkRealm).toBe(true);
+    expect(rows[1].outcome).toBe("dead");
+  });
+});
+
+describe("summarizeDay", () => {
+  it("computes wins, win rate, objective tallies, and avg floor", () => {
+    const games = [
+      makeRow({ outcome: "win", levelReached: 3, reachedPinkRealm: true, reachedOutsideWorld: true, treesDestroyed: 2 }),
+      makeRow({ outcome: "dead", levelReached: 1 }),
+      makeRow({ outcome: "dead", levelReached: 2, reachedOutsideWorld: true }),
+      makeRow({ outcome: "win", levelReached: 3, treesDestroyed: 0 }),
+    ];
+    const s = summarizeDay(games);
+    expect(s.total).toBe(4);
+    expect(s.wins).toBe(2);
+    expect(s.losses).toBe(2);
+    expect(s.winRate).toBe(50);
+    expect(s.reachedPinkRealm).toBe(1);
+    expect(s.reachedOutsideWorld).toBe(2);
+    expect(s.blewUpTree).toBe(1);
+    expect(s.avgLevelReached).toBe(2.3); // (3+1+2+3)/4 = 2.25 -> 2.3
+  });
+
+  it("handles an empty day", () => {
+    const s = summarizeDay([]);
+    expect(s.total).toBe(0);
+    expect(s.winRate).toBe(0);
+    expect(s.avgLevelReached).toBeNull();
+  });
+});
+
+describe("groupRowsByDay", () => {
+  it("groups by date_seed, newest day first, newest game first within a day", () => {
+    const rows = [
+      makeRow({ day: "2026-07-22", timestamp: "2026-07-22T08:00:00Z" }),
+      makeRow({ day: "2026-07-24", timestamp: "2026-07-24T08:00:00Z" }),
+      makeRow({ day: "2026-07-24", timestamp: "2026-07-24T10:00:00Z" }),
+      makeRow({ day: "2026-07-23", timestamp: "2026-07-23T08:00:00Z" }),
+    ];
+    const grouped = groupRowsByDay(rows);
+    expect(grouped.map((g) => g.date)).toEqual(["2026-07-24", "2026-07-23", "2026-07-22"]);
+    // within the busiest day, the later timestamp comes first
+    expect(grouped[0].games[0].timestamp).toBe("2026-07-24T10:00:00Z");
+    expect(grouped[0].summary.total).toBe(2);
+  });
+
+  it("drops rows with an empty day", () => {
+    const grouped = groupRowsByDay([makeRow({ day: "" }), makeRow({ day: "2026-07-24" })]);
+    expect(grouped).toHaveLength(1);
+    expect(grouped[0].date).toBe("2026-07-24");
+  });
+});

--- a/app/api/endgame-stats/route.ts
+++ b/app/api/endgame-stats/route.ts
@@ -1,0 +1,238 @@
+import { NextRequest, NextResponse } from "next/server";
+import {
+  parseHogQLRows,
+  groupRowsByDay,
+  type EndgameStatsResponse,
+  type StatsDayPayload,
+} from "../../../lib/stats/endgame_stats";
+import { level2ChestStatusForDate } from "../../../lib/stats/daily_chest";
+
+// Reads historical daily runs out of PostHog for the endgame stats dashboard.
+// This is a read path (PostHog Query / HogQL) and needs a *personal* API key +
+// numeric project id — the public `phc_` ingest key used by the browser cannot
+// read data. Configure on the server (never NEXT_PUBLIC_*):
+//   POSTHOG_PERSONAL_API_KEY  (or POSTHOG_API_KEY)
+//   POSTHOG_PROJECT_ID        (numeric, from Project Settings)
+//   POSTHOG_HOST              (optional, defaults to https://us.posthog.com)
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const DEFAULT_DAYS = 3;
+const MAX_DAYS = 14;
+const MAX_ROWS = 10000;
+
+// Fixed select order for the rows query. We map results by POSITION using these
+// names (rather than trusting PostHog's returned column labels), so the shape is
+// stable regardless of how the API echoes aliases.
+const ROW_COLUMNS = [
+  "day",
+  "timestamp",
+  "distinct_id",
+  "outcome",
+  "level_reached",
+  "hero_health",
+  "steps",
+  "enemies_defeated",
+  "damage_dealt",
+  "damage_taken",
+  "chests_opened",
+  "total_chests",
+  "has_sword",
+  "has_shield",
+  "trees_destroyed",
+  "walls_destroyed",
+  "reached_outside_world",
+  "reached_pink_realm",
+  "collected_chest_items",
+  "death_cause",
+  "death_cause_enemy_kind",
+] as const;
+
+// PostHog type-infers `date_seed` as a DateTime (it looks like a date), so
+// `properties.date_seed` comes back as "2026-07-24T00:00:00Z". We need the raw
+// stored "2026-07-24" string — both to page/group cleanly and because it is the
+// exact value that seeded the chest generation. JSONExtractString reads it
+// straight out of the properties JSON with no date parsing (no timezone shift).
+const DAY_EXPR = "JSONExtractString(properties, 'date_seed')";
+
+const ROW_SELECT = `
+  ${DAY_EXPR} AS day,
+  timestamp AS timestamp,
+  distinct_id AS distinct_id,
+  properties.outcome AS outcome,
+  properties.level_reached AS level_reached,
+  properties.hero_health AS hero_health,
+  properties.steps AS steps,
+  properties.enemies_defeated AS enemies_defeated,
+  properties.damage_dealt AS damage_dealt,
+  properties.damage_taken AS damage_taken,
+  properties.chests_opened AS chests_opened,
+  properties.total_chests AS total_chests,
+  properties.has_sword AS has_sword,
+  properties.has_shield AS has_shield,
+  properties.trees_destroyed AS trees_destroyed,
+  properties.walls_destroyed AS walls_destroyed,
+  properties.reached_outside_world AS reached_outside_world,
+  properties.reached_pink_realm AS reached_pink_realm,
+  properties.collected_chest_items AS collected_chest_items,
+  properties.death_cause AS death_cause,
+  properties.death_cause_enemy_kind AS death_cause_enemy_kind
+`;
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+interface HogQLResult {
+  columns: string[];
+  results: unknown[][];
+}
+
+function getConfig() {
+  const apiKey =
+    process.env.POSTHOG_PERSONAL_API_KEY || process.env.POSTHOG_API_KEY || "";
+  const projectId = process.env.POSTHOG_PROJECT_ID || "";
+  const host = (process.env.POSTHOG_HOST || "https://us.posthog.com").replace(
+    /\/$/,
+    ""
+  );
+  return { apiKey, projectId, host };
+}
+
+async function runHogQL(
+  query: string,
+  cfg: { apiKey: string; projectId: string; host: string }
+): Promise<HogQLResult> {
+  const res = await fetch(`${cfg.host}/api/projects/${cfg.projectId}/query/`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${cfg.apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query: { kind: "HogQLQuery", query } }),
+    cache: "no-store",
+  });
+  if (!res.ok) {
+    const text = await res.text().catch(() => "");
+    throw new Error(`PostHog query failed (${res.status}): ${text.slice(0, 400)}`);
+  }
+  return (await res.json()) as HogQLResult;
+}
+
+export async function GET(req: NextRequest) {
+  const cfg = getConfig();
+
+  // Not-configured state: return 200 with configured:false so the page can show
+  // a friendly setup notice instead of erroring.
+  if (!cfg.apiKey || !cfg.projectId) {
+    const body: EndgameStatsResponse = {
+      days: [],
+      nextCursor: null,
+      hasMore: false,
+      configured: false,
+      message:
+        "PostHog read credentials are not set. Add POSTHOG_PERSONAL_API_KEY and POSTHOG_PROJECT_ID (server env) to load stats.",
+    };
+    return NextResponse.json(body);
+  }
+
+  // --- params ---
+  const beforeDayParam = req.nextUrl.searchParams.get("beforeDay");
+  const beforeDay =
+    beforeDayParam && DATE_RE.test(beforeDayParam) ? beforeDayParam : null;
+  const daysParam = Number(req.nextUrl.searchParams.get("days"));
+  const days = Number.isFinite(daysParam)
+    ? Math.min(MAX_DAYS, Math.max(1, Math.trunc(daysParam)))
+    : DEFAULT_DAYS;
+
+  try {
+    // Query 1: pick the page of distinct daily-challenge days (newest first).
+    // Fetch one extra to detect whether older days remain.
+    const beforeClause = beforeDay ? `AND ${DAY_EXPR} < '${beforeDay}'` : "";
+    const daysQuery = `
+      SELECT DISTINCT ${DAY_EXPR} AS day
+      FROM events
+      WHERE event = 'game_complete'
+        AND properties.game_mode = 'daily'
+        AND ${DAY_EXPR} != ''
+        ${beforeClause}
+      ORDER BY day DESC
+      LIMIT ${days + 1}
+    `;
+    const daysRes = await runHogQL(daysQuery, cfg);
+    const allDays = daysRes.results
+      .map((r) => String(r[0] ?? ""))
+      .filter((d) => DATE_RE.test(d));
+
+    const hasMore = allDays.length > days;
+    const pageDays = allDays.slice(0, days);
+
+    if (pageDays.length === 0) {
+      const body: EndgameStatsResponse = {
+        days: [],
+        nextCursor: null,
+        hasMore: false,
+        configured: true,
+      };
+      return NextResponse.json(body);
+    }
+
+    // Query 2: all game_complete rows for those days.
+    const inList = pageDays.map((d) => `'${d}'`).join(", ");
+    const rowsQuery = `
+      SELECT ${ROW_SELECT}
+      FROM events
+      WHERE event = 'game_complete'
+        AND properties.game_mode = 'daily'
+        AND ${DAY_EXPR} IN (${inList})
+      ORDER BY day DESC, timestamp DESC
+      LIMIT ${MAX_ROWS}
+    `;
+    const rowsRes = await runHogQL(rowsQuery, cfg);
+    const rows = parseHogQLRows([...ROW_COLUMNS], rowsRes.results);
+    const grouped = groupRowsByDay(rows);
+    const groupedByDate = new Map(grouped.map((g) => [g.date, g]));
+
+    // Preserve the newest-first order from query 1, and attach the deterministic
+    // Level 2 chest status for each day.
+    const payloadDays: StatsDayPayload[] = pageDays.map((date) => {
+      const g = groupedByDate.get(date);
+      const chestStatus = level2ChestStatusForDate(date);
+      return {
+        date,
+        chests: {
+          items: chestStatus.items.map((it) => ({
+            key: it.key,
+            label: it.label,
+            icon: it.icon,
+          })),
+          bombAvailable: chestStatus.bombAvailable,
+        },
+        summary: g?.summary ?? {
+          total: 0,
+          wins: 0,
+          losses: 0,
+          winRate: 0,
+          reachedPinkRealm: 0,
+          reachedOutsideWorld: 0,
+          blewUpTree: 0,
+          avgLevelReached: null,
+        },
+        games: g?.games ?? [],
+      };
+    });
+
+    const body: EndgameStatsResponse = {
+      days: payloadDays,
+      nextCursor: hasMore ? pageDays[pageDays.length - 1] : null,
+      hasMore,
+      configured: true,
+    };
+    return NextResponse.json(body);
+  } catch (err) {
+    console.error("[endgame-stats]", err);
+    return NextResponse.json(
+      { error: "Failed to load endgame stats from PostHog." },
+      { status: 502 }
+    );
+  }
+}

--- a/app/stats/page.tsx
+++ b/app/stats/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import EndgameStats from "../../components/stats/EndgameStats";
+
+// Internal analytics view — keep it out of search indexes.
+export const metadata: Metadata = {
+  title: "Endgame Stats",
+  robots: { index: false, follow: false },
+};
+
+export default function StatsPage() {
+  return <EndgameStats />;
+}

--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -204,6 +204,7 @@ function runProgressProps(gs: GameState) {
     wallsDestroyed: gs.stats?.wallsDestroyed ?? 0,
     reachedOutsideWorld: !!gs.reachedOutsideWorld,
     reachedPinkRealm: !!gs.reachedPinkRealm,
+    collectedChestItems: gs.stats?.chestItemsCollected ?? [],
   };
 }
 
@@ -2885,6 +2886,7 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
         deathCause: gameState.deathCause?.type,
         deathCauseEnemyKind: gameState.deathCause?.enemyKind,
         currentFloor: gameState.currentFloor,
+        ...runProgressProps(gameState),
       });
     } catch {}
 

--- a/components/stats/EndgameStats.tsx
+++ b/components/stats/EndgameStats.tsx
@@ -1,0 +1,583 @@
+/* eslint-disable @next/next/no-img-element */
+"use client";
+
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import type {
+  EndgameStatsResponse,
+  StatsDayPayload,
+  GameCompleteRow,
+} from "../../lib/stats/endgame_stats";
+
+// Retro palette, borrowed from the in-game .pixel-* styles so the dashboard
+// reads like part of the game rather than an admin panel.
+const C = {
+  bg: "#161225",
+  panel: "#1f1d2d",
+  panel2: "#2b2540",
+  border: "#8b7fe0",
+  borderDark: "#0d0b1a",
+  text: "#f5f3ff",
+  muted: "#a79fce",
+  gold: "#f9d65c",
+  win: "#7ce7a3",
+  loss: "#ff8080",
+  bomb: "#ff9f43",
+};
+
+const ICON = {
+  closedChest: "/images/items/closed-chest.png",
+  heart: "/images/items/heart.png",
+  pinkHeart: "/images/items/pink-heart.png",
+  sword: "/images/items/sword.png",
+  shield: "/images/items/shield.png",
+  medallion: "/images/items/snake-medalion.png",
+  portal: "/images/items/portal-static.png",
+  tree: "/images/trees/tree-1.png",
+  bomb: "/images/items/bomb-black.png",
+};
+
+// Maps a recorded chest-item key (from analytics `collected_chest_items`) to its
+// icon + label, so the loot row can show exactly what a run pulled from chests.
+const LOOT_META: Record<string, { icon: string; label: string }> = {
+  sword: { icon: ICON.sword, label: "Sword" },
+  shield: { icon: ICON.shield, label: "Shield" },
+  snake_medallion: { icon: ICON.medallion, label: "Snake Medallion" },
+  extra_heart: { icon: ICON.heart, label: "Extra Heart" },
+  bomb: { icon: ICON.bomb, label: "Bomb" },
+  pink_heart: { icon: ICON.pinkHeart, label: "Pink Heart" },
+};
+
+const DAYS_PER_PAGE = 3;
+
+function PixelImg({
+  src,
+  alt,
+  size = 20,
+  dim = false,
+  title,
+}: {
+  src: string;
+  alt: string;
+  size?: number;
+  dim?: boolean;
+  title?: string;
+}) {
+  return (
+    <img
+      src={src}
+      alt={alt}
+      title={title ?? alt}
+      width={size}
+      height={size}
+      style={{
+        width: size,
+        height: size,
+        imageRendering: "pixelated",
+        opacity: dim ? 0.25 : 1,
+        objectFit: "contain",
+        flexShrink: 0,
+      }}
+    />
+  );
+}
+
+function formatDay(dateStr: string): { weekday: string; rest: string } {
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+  if (!m) return { weekday: "", rest: dateStr };
+  const d = new Date(Number(m[1]), Number(m[2]) - 1, Number(m[3]));
+  const weekday = d.toLocaleDateString(undefined, { weekday: "short" });
+  const rest = d.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+  return { weekday, rest };
+}
+
+/** Small labelled stat chip used in the day-summary strip. */
+function StatChip({
+  icon,
+  emoji,
+  value,
+  label,
+  accent,
+}: {
+  icon?: string;
+  emoji?: string;
+  value: React.ReactNode;
+  label: string;
+  accent?: string;
+}) {
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        gap: 6,
+        background: C.panel2,
+        border: `2px solid ${C.borderDark}`,
+        borderRadius: 4,
+        padding: "4px 8px",
+        minWidth: 0,
+      }}
+    >
+      {icon ? <PixelImg src={icon} alt={label} size={18} /> : null}
+      {emoji ? <span style={{ fontSize: 14 }}>{emoji}</span> : null}
+      <span
+        className="pixel-text"
+        style={{ color: accent ?? C.text, fontSize: 12, lineHeight: 1 }}
+      >
+        {value}
+      </span>
+      <span style={{ color: C.muted, fontSize: 11, lineHeight: 1 }}>{label}</span>
+    </div>
+  );
+}
+
+type LootItem = { icon: string; label: string };
+
+/**
+ * Reconstruct the chest loot a run collected. We don't store per-item chest
+ * contents, but we can infer them: the two Floor-1 chests are always sword +
+ * shield (known via has_sword/has_shield), the two Floor-2 chests hold that
+ * day's seed-derived items (l2Items), and chests_opened tells us the total.
+ * So when someone opened everything, we can name every item; when they opened
+ * only one of the two L2 chests we can't tell which, so it becomes a "?" pip.
+ * Returns null when the run predates chest tracking (value genuinely unknown).
+ */
+function deriveLoot(
+  g: GameCompleteRow,
+  l2Items: LootItem[]
+): { items: LootItem[]; mystery: number } | null {
+  // Exact data (newer runs record the actual items collected). Preferred — it
+  // even resolves the "opened only one L2 chest" case the inference can't.
+  if (g.collectedChestItems && g.collectedChestItems.length > 0) {
+    const items = g.collectedChestItems.map(
+      (k) => LOOT_META[k] ?? { icon: ICON.closedChest, label: k }
+    );
+    return { items, mystery: 0 };
+  }
+  // Fall back to seed-based inference for runs recorded before that telemetry.
+  if (g.chestsOpened == null) return null;
+  const items: LootItem[] = [];
+  if (g.hasSword) items.push({ icon: ICON.sword, label: "Sword" });
+  if (g.hasShield) items.push({ icon: ICON.shield, label: "Shield" });
+  const f2Opened = Math.max(0, Math.min(g.chestsOpened - items.length, l2Items.length));
+  let mystery = 0;
+  if (f2Opened >= l2Items.length) {
+    l2Items.forEach((it) => items.push(it));
+  } else {
+    mystery = f2Opened; // opened some L2 chest(s) but which item is ambiguous
+  }
+  return { items, mystery };
+}
+
+function GameRow({ g, l2Items }: { g: GameCompleteRow; l2Items: LootItem[] }) {
+  const win = g.outcome === "win";
+  const loot = deriveLoot(g, l2Items);
+  const emptyChest = loot != null && loot.items.length === 0 && loot.mystery === 0;
+  return (
+    <div
+      style={{
+        display: "flex",
+        alignItems: "center",
+        flexWrap: "wrap",
+        gap: 10,
+        padding: "8px 10px",
+        background: C.panel,
+        border: `2px solid ${C.borderDark}`,
+        borderRadius: 4,
+      }}
+    >
+      {/* outcome */}
+      <div
+        className="pixel-text"
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          color: win ? C.win : C.loss,
+          fontSize: 12,
+          minWidth: 92,
+        }}
+      >
+        <span style={{ fontSize: 15 }}>{win ? "🏆" : "💀"}</span>
+        {win ? "ESCAPED" : "FELL"}
+      </div>
+
+      {/* floor reached */}
+      <div
+        className="pixel-text"
+        style={{
+          color: C.gold,
+          fontSize: 12,
+          background: C.borderDark,
+          borderRadius: 3,
+          padding: "2px 6px",
+        }}
+        title="Deepest floor reached"
+      >
+        {g.levelReached != null ? `F${g.levelReached}` : "F?"}
+      </div>
+
+      {/* health — only shown for escapes; a fall is always 0 so the icon is just noise */}
+      {win ? (
+        <div style={{ display: "flex", alignItems: "center", gap: 3 }} title="Health remaining">
+          <PixelImg src={ICON.heart} alt="health" size={16} />
+          <span style={{ color: C.text, fontSize: 13 }}>{g.heroHealth ?? 0}</span>
+        </div>
+      ) : null}
+
+      {/* enemies defeated */}
+      <div style={{ display: "flex", alignItems: "center", gap: 4 }} title="Enemies defeated">
+        <span style={{ fontSize: 13 }}>⚔️</span>
+        <span style={{ color: C.text, fontSize: 13 }}>{g.enemiesDefeated ?? 0}</span>
+      </div>
+
+      {/* steps */}
+      <div style={{ display: "flex", alignItems: "center", gap: 4 }} title="Steps taken">
+        <span style={{ fontSize: 13 }}>👣</span>
+        <span style={{ color: C.text, fontSize: 13 }}>{g.steps ?? 0}</span>
+      </div>
+
+      {/* chest + collected loot (chest icon, then an icon per item they got) */}
+      <div
+        style={{ display: "flex", alignItems: "center", gap: 4 }}
+        title={
+          loot == null
+            ? "Chest loot not recorded for this run"
+            : "Chest, then the items collected from chests"
+        }
+      >
+        <PixelImg src={ICON.closedChest} alt="chest loot" size={16} dim={loot == null || emptyChest} />
+        {loot == null ? (
+          <span style={{ color: C.muted, fontSize: 13 }}>—</span>
+        ) : emptyChest ? (
+          <span style={{ color: C.muted, fontSize: 13 }}>0</span>
+        ) : (
+          <>
+            {loot.items.map((it, i) => (
+              <PixelImg key={`it-${i}`} src={it.icon} alt={it.label} size={16} />
+            ))}
+            {Array.from({ length: loot.mystery }).map((_, i) => (
+              <span
+                key={`myst-${i}`}
+                title="Opened a Level 2 chest (item not recorded)"
+                style={{
+                  width: 16,
+                  height: 16,
+                  display: "inline-flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  fontSize: 11,
+                  color: C.muted,
+                  border: `1px solid ${C.borderDark}`,
+                  borderRadius: 3,
+                }}
+              >
+                ?
+              </span>
+            ))}
+          </>
+        )}
+      </div>
+
+      {/* secret-progress flags: only lit when achieved */}
+      <div style={{ display: "flex", alignItems: "center", gap: 4, marginLeft: "auto" }}>
+        {g.reachedPinkRealm ? (
+          <PixelImg src={ICON.pinkHeart} alt="Reached pink realm" size={16} title="Reached the pink realm" />
+        ) : null}
+        {g.reachedOutsideWorld ? (
+          <PixelImg src={ICON.portal} alt="Reached outside world" size={16} title="Reached the outside world" />
+        ) : null}
+        {g.treesDestroyed > 0 ? (
+          <PixelImg src={ICON.tree} alt="Blew up a tree" size={16} title={`Blew up ${g.treesDestroyed} tree(s)`} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function DayCard({ day }: { day: StatsDayPayload }) {
+  const { weekday, rest } = formatDay(day.date);
+  const s = day.summary;
+  return (
+    <section
+      style={{
+        background: `linear-gradient(${C.panel}, ${C.bg})`,
+        border: `3px solid ${C.border}`,
+        boxShadow: `0 0 0 3px ${C.borderDark}`,
+        borderRadius: 6,
+        padding: 14,
+        marginBottom: 22,
+      }}
+    >
+      {/* header: date + chest status */}
+      <header
+        style={{
+          display: "flex",
+          alignItems: "flex-start",
+          justifyContent: "space-between",
+          flexWrap: "wrap",
+          gap: 12,
+          borderBottom: `2px solid ${C.borderDark}`,
+          paddingBottom: 10,
+          marginBottom: 10,
+        }}
+      >
+        <div>
+          <div className="pixel-text" style={{ color: C.gold, fontSize: 16, lineHeight: 1.4 }}>
+            {rest}
+          </div>
+          <div style={{ color: C.muted, fontSize: 12 }}>
+            {weekday} · {s.total} game{s.total === 1 ? "" : "s"}
+          </div>
+        </div>
+
+        {/* Level 2 chest status — same for everyone on this date */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: 10,
+            background: C.panel2,
+            border: `2px solid ${C.borderDark}`,
+            borderRadius: 5,
+            padding: "6px 10px",
+          }}
+        >
+          <span style={{ color: C.muted, fontSize: 11, maxWidth: 78, lineHeight: 1.2 }}>
+            Level 2 chests
+          </span>
+          {day.chests.items.length > 0 ? (
+            day.chests.items.map((it, i) => (
+              <div
+                key={`${it.key}-${i}`}
+                style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 2 }}
+                title={it.label}
+              >
+                <div
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                    width: 34,
+                    height: 34,
+                    background: C.bg,
+                    border: `2px solid ${it.key === "bomb" ? C.bomb : C.border}`,
+                    borderRadius: 4,
+                  }}
+                >
+                  <PixelImg src={it.icon} alt={it.label} size={24} />
+                </div>
+                <span style={{ color: C.muted, fontSize: 9 }}>{it.label}</span>
+              </div>
+            ))
+          ) : (
+            <span style={{ color: C.muted, fontSize: 11 }}>—</span>
+          )}
+          <span
+            className="pixel-text"
+            style={{
+              fontSize: 10,
+              padding: "3px 6px",
+              borderRadius: 3,
+              color: day.chests.bombAvailable ? C.borderDark : C.muted,
+              background: day.chests.bombAvailable ? C.bomb : "transparent",
+              border: `1px solid ${day.chests.bombAvailable ? C.bomb : C.borderDark}`,
+            }}
+            title="Whether a bomb was available in the Level 2 chests (gates outside world + pink realm)"
+          >
+            {day.chests.bombAvailable ? "BOMB DAY" : "NO BOMB"}
+          </span>
+        </div>
+      </header>
+
+      {/* objective summary strip */}
+      <div style={{ display: "flex", flexWrap: "wrap", gap: 8, marginBottom: 12 }}>
+        <StatChip emoji="🏆" value={`${s.winRate}%`} label={`${s.wins}/${s.total} win`} accent={C.win} />
+        <StatChip
+          value={s.avgLevelReached != null ? `F${s.avgLevelReached}` : "—"}
+          label="avg floor"
+          accent={C.gold}
+        />
+        <StatChip icon={ICON.pinkHeart} value={s.reachedPinkRealm} label="pink realm" accent={C.text} />
+        <StatChip icon={ICON.portal} value={s.reachedOutsideWorld} label="outside" accent={C.text} />
+        <StatChip icon={ICON.tree} value={s.blewUpTree} label="tree" accent={C.text} />
+      </div>
+
+      {/* per-game rows */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+        {day.games.length === 0 ? (
+          <div style={{ color: C.muted, fontSize: 12, fontStyle: "italic" }}>
+            No completed games recorded for this day.
+          </div>
+        ) : (
+          day.games.map((g, i) => (
+            <GameRow key={`${g.distinctId}-${g.timestamp}-${i}`} g={g} l2Items={day.chests.items} />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default function EndgameStats() {
+  const [days, setDays] = useState<StatsDayPayload[]>([]);
+  const [cursor, setCursor] = useState<string | null>(null);
+  const [hasMore, setHasMore] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [configured, setConfigured] = useState(true);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [initialized, setInitialized] = useState(false);
+
+  const loadingRef = useRef(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const loadMore = useCallback(async () => {
+    if (loadingRef.current || !hasMore) return;
+    loadingRef.current = true;
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({ days: String(DAYS_PER_PAGE) });
+      if (cursor) params.set("beforeDay", cursor);
+      const res = await fetch(`/api/endgame-stats?${params.toString()}`);
+      if (!res.ok) throw new Error(`Request failed (${res.status})`);
+      const data = (await res.json()) as EndgameStatsResponse;
+      setConfigured(data.configured);
+      if (data.message) setNotice(data.message);
+      setDays((prev) => [...prev, ...data.days]);
+      setCursor(data.nextCursor);
+      setHasMore(data.hasMore);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load stats.");
+      setHasMore(false);
+    } finally {
+      loadingRef.current = false;
+      setLoading(false);
+      setInitialized(true);
+    }
+  }, [cursor, hasMore]);
+
+  // Initial load.
+  useEffect(() => {
+    loadMore();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Infinite scroll: load the next page when the sentinel scrolls into view.
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const obs = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { rootMargin: "400px 0px" }
+    );
+    obs.observe(el);
+    return () => obs.disconnect();
+  }, [loadMore]);
+
+  return (
+    <div style={{ minHeight: "100vh", background: C.bg, color: C.text, padding: "24px 16px 80px" }}>
+      <div style={{ maxWidth: 860, margin: "0 auto" }}>
+        <h1 className="pixel-text" style={{ color: C.gold, fontSize: 20, marginBottom: 6 }}>
+          Endgame Stats
+        </h1>
+        <p style={{ color: C.muted, fontSize: 13, marginBottom: 22, lineHeight: 1.5 }}>
+          Every completed daily run, grouped by day. Each day shows its Level 2 chest draw (the
+          bomb-gated slot) plus how many players reached the pink realm, breached the outside world,
+          and blew up a tree.
+        </p>
+
+        {!configured && initialized ? (
+          <div
+            className="pixel-text"
+            style={{
+              background: C.panel,
+              border: `3px solid ${C.bomb}`,
+              boxShadow: `0 0 0 3px ${C.borderDark}`,
+              borderRadius: 6,
+              padding: 16,
+              color: C.text,
+              fontSize: 12,
+              lineHeight: 1.7,
+            }}
+          >
+            <div style={{ color: C.bomb, marginBottom: 8 }}>PostHog read access not configured</div>
+            <div style={{ color: C.muted }}>
+              {notice ??
+                "Set POSTHOG_PERSONAL_API_KEY and POSTHOG_PROJECT_ID on the server to load stats."}
+            </div>
+            <ul style={{ color: C.muted, marginTop: 10, paddingLeft: 18, listStyle: "square" }}>
+              <li>POSTHOG_PERSONAL_API_KEY — a personal API key (Settings → Personal API keys)</li>
+              <li>POSTHOG_PROJECT_ID — numeric project id (Project settings)</li>
+              <li>POSTHOG_HOST — optional, defaults to https://us.posthog.com</li>
+            </ul>
+          </div>
+        ) : null}
+
+        {configured &&
+          days.map((day, i) => <DayCard key={`${day.date}-${i}`} day={day} />)}
+
+        {configured && initialized && days.length === 0 && !error ? (
+          <div style={{ color: C.muted, fontSize: 13, fontStyle: "italic" }}>
+            No completed daily runs found in PostHog yet.
+          </div>
+        ) : null}
+
+        {error ? (
+          <div
+            style={{
+              color: C.loss,
+              fontSize: 13,
+              border: `2px solid ${C.loss}`,
+              borderRadius: 4,
+              padding: 12,
+              marginBottom: 16,
+            }}
+          >
+            {error}
+          </div>
+        ) : null}
+
+        {loading ? (
+          <div className="pixel-text" style={{ color: C.muted, fontSize: 12, padding: "12px 0" }}>
+            Loading…
+          </div>
+        ) : null}
+
+        {configured && hasMore && !loading ? (
+          <button
+            onClick={loadMore}
+            className="pixel-text"
+            style={{
+              background: C.panel2,
+              color: C.text,
+              border: `2px solid ${C.border}`,
+              boxShadow: `0 0 0 2px ${C.borderDark}`,
+              borderRadius: 4,
+              padding: "10px 16px",
+              fontSize: 12,
+              cursor: "pointer",
+            }}
+          >
+            Load more days
+          </button>
+        ) : null}
+
+        {/* infinite-scroll sentinel */}
+        <div ref={sentinelRef} style={{ height: 1 }} aria-hidden />
+
+        {configured && !hasMore && initialized && days.length > 0 ? (
+          <div style={{ color: C.muted, fontSize: 12, textAlign: "center", marginTop: 16 }}>
+            — end of history —
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -35,6 +35,7 @@ export function trackGameComplete(params: {
   wallsDestroyed?: number;
   reachedOutsideWorld?: boolean;
   reachedPinkRealm?: boolean;
+  collectedChestItems?: string[];
 }) {
   posthogAnalytics.trackGameComplete(params);
 }

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -1557,6 +1557,10 @@ export interface GameState {
     enemiesKilledByRock?: number;
     enemiesKilledByRune?: number;
     chestsOpened?: number;
+    // Item keys revealed from chests and actually picked up, in pickup order
+    // (e.g. ["sword","shield","extra_heart"]). Lets analytics report exactly
+    // which variable Level 2 items a run collected, not just a count.
+    chestItemsCollected?: string[];
     itemsCollected?: number; // Total items picked up
     maxHealth?: number; // Highest health reached
     poisonSteps?: number; // Steps taken while poisoned
@@ -3484,6 +3488,20 @@ function movePlayerCore(
         subtype.includes(TileSubtype.BOMB)) &&
       !subtype.includes(TileSubtype.CHEST)
     ) {
+      // Record exactly which chest item this was (in pickup order) for analytics.
+      const collectedNow: string[] = [];
+      if (subtype.includes(TileSubtype.BOMB)) collectedNow.push("bomb");
+      if (subtype.includes(TileSubtype.SWORD)) collectedNow.push("sword");
+      if (subtype.includes(TileSubtype.SHIELD)) collectedNow.push("shield");
+      if (subtype.includes(TileSubtype.SNAKE_MEDALLION)) collectedNow.push("snake_medallion");
+      if (subtype.includes(TileSubtype.EXTRA_HEART)) collectedNow.push("extra_heart");
+      if (subtype.includes(TileSubtype.PINK_HEART)) collectedNow.push("pink_heart");
+      if (collectedNow.length > 0) {
+        newGameState.stats.chestItemsCollected = [
+          ...(newGameState.stats.chestItemsCollected ?? []),
+          ...collectedNow,
+        ];
+      }
       if (subtype.includes(TileSubtype.BOMB)) {
         newGameState.bombCount = (newGameState.bombCount ?? 0) + BOMB_PACK_SIZE;
         newGameState.stats.itemsCollected = (newGameState.stats.itemsCollected ?? 0) + 1;

--- a/lib/posthog_analytics.ts
+++ b/lib/posthog_analytics.ts
@@ -124,6 +124,8 @@ export function trackGameComplete(params: {
   wallsDestroyed?: number;
   reachedOutsideWorld?: boolean;
   reachedPinkRealm?: boolean;
+  // Exact chest items collected this run (e.g. ["sword","shield","extra_heart"]).
+  collectedChestItems?: string[];
 }) {
   captureEvent('game_complete', {
     outcome: params.outcome,
@@ -152,6 +154,7 @@ export function trackGameComplete(params: {
     walls_destroyed: params.wallsDestroyed,
     reached_outside_world: params.reachedOutsideWorld,
     reached_pink_realm: params.reachedPinkRealm,
+    collected_chest_items: params.collectedChestItems,
   });
 }
 

--- a/lib/stats/daily_chest.ts
+++ b/lib/stats/daily_chest.ts
@@ -1,0 +1,85 @@
+// Reproduce the Level 2 treasure-chest contents for any daily-challenge date.
+//
+// The two L2 chests are the run's only variable loot slot, and one of the three
+// possible items is the BOMB — the key that unlocks wall-breaking, the outside
+// world, and (via bombing a pink goblin) the pink realm. Whether a bomb was
+// even available on a given day is therefore essential context for reading the
+// "reached pink realm / outside world / blew up the tree" numbers.
+//
+// The contents are fully deterministic from the date: the daily run is built by
+//   withPatchedMathRandom(mulberry32(hashStringToSeed(YYYY-MM-DD)),
+//                         () => initializeGameStateForMultiTier(1))
+// and `allocateChestsAndKeys()` is that function's FIRST RNG consumer. Calling
+// it here inside the identical seeded block replays the exact same draws, so the
+// items we compute match what every player saw that day — no need to store chest
+// contents in analytics.
+
+import { allocateChestsAndKeys } from "../map/map-features";
+import { TileSubtype } from "../map/constants";
+import { hashStringToSeed, mulberry32, withPatchedMathRandom } from "../rng";
+
+export interface ChestItemMeta {
+  subtype: TileSubtype;
+  /** Stable machine key for the item (used in JSON payloads / analytics joins). */
+  key: "bomb" | "snake_medallion" | "extra_heart" | "sword" | "shield" | "unknown";
+  label: string;
+  /** Public path to the in-game icon so the stats UI matches the game. */
+  icon: string;
+}
+
+const ITEM_META: Partial<Record<TileSubtype, Omit<ChestItemMeta, "subtype">>> = {
+  [TileSubtype.BOMB]: {
+    key: "bomb",
+    label: "Bomb",
+    icon: "/images/items/bomb-black.png",
+  },
+  [TileSubtype.SNAKE_MEDALLION]: {
+    key: "snake_medallion",
+    label: "Snake Medallion",
+    icon: "/images/items/snake-medalion.png",
+  },
+  [TileSubtype.EXTRA_HEART]: {
+    key: "extra_heart",
+    label: "Extra Heart",
+    icon: "/images/items/heart.png",
+  },
+  [TileSubtype.SWORD]: {
+    key: "sword",
+    label: "Sword",
+    icon: "/images/items/sword.png",
+  },
+  [TileSubtype.SHIELD]: {
+    key: "shield",
+    label: "Shield",
+    icon: "/images/items/shield.png",
+  },
+};
+
+export function chestItemMeta(subtype: TileSubtype): ChestItemMeta {
+  const meta = ITEM_META[subtype];
+  if (meta) return { subtype, ...meta };
+  return { subtype, key: "unknown", label: `Item ${subtype}`, icon: "/images/items/closed-chest.png" };
+}
+
+export interface Level2ChestStatus {
+  /** The two items drawn into the L2 chests, in generation order. */
+  items: ChestItemMeta[];
+  /** Whether one of the chests contained a bomb (bomb-gated content reachable). */
+  bombAvailable: boolean;
+}
+
+/**
+ * Compute the two Level 2 chest items for a daily run identified by its local
+ * date string (YYYY-MM-DD, the same value stored on analytics as `date_seed`).
+ */
+export function level2ChestStatusForDate(dateStr: string): Level2ChestStatus {
+  const seed = hashStringToSeed(dateStr);
+  const rng = mulberry32(seed);
+  const allocation = withPatchedMathRandom(rng, () => allocateChestsAndKeys());
+  const contents = allocation.get(2)?.chestContents ?? [];
+  const items = contents.map((subtype) => chestItemMeta(subtype));
+  return {
+    items,
+    bombAvailable: contents.includes(TileSubtype.BOMB),
+  };
+}

--- a/lib/stats/endgame_stats.ts
+++ b/lib/stats/endgame_stats.ts
@@ -1,0 +1,212 @@
+// Shaping + aggregation for the endgame stats dashboard.
+//
+// Source of truth is the `game_complete` PostHog event fired at the end of every
+// daily run (win or death). Each event carries the full run summary, so a single
+// event type answers all four reporting questions:
+//   1. Level 2 chest status  -> computed from `date_seed` (see daily_chest.ts)
+//   2. reached pink realm     -> reached_pink_realm
+//   3. reached outside world  -> reached_outside_world
+//   4. blew up the tree       -> trees_destroyed > 0
+//
+// These functions are pure (no network) so the route can stay thin and the
+// coercion / grouping logic is unit-testable against fixture rows.
+
+import type { ChestItemMeta } from "./daily_chest";
+
+/** One completed daily game, normalized from a PostHog `game_complete` row. */
+export interface GameCompleteRow {
+  day: string; // date_seed, YYYY-MM-DD (the daily-challenge identity)
+  timestamp: string; // ISO string of when the run ended
+  distinctId: string;
+  outcome: "win" | "dead";
+  levelReached: number | null;
+  heroHealth: number | null;
+  steps: number | null;
+  enemiesDefeated: number | null;
+  damageDealt: number | null;
+  damageTaken: number | null;
+  chestsOpened: number | null;
+  totalChests: number | null;
+  hasSword: boolean;
+  hasShield: boolean;
+  treesDestroyed: number;
+  wallsDestroyed: number;
+  reachedOutsideWorld: boolean;
+  reachedPinkRealm: boolean;
+  /** Exact chest items collected, e.g. ["sword","shield","extra_heart"]; [] if unrecorded. */
+  collectedChestItems: string[];
+  deathCause: string | null;
+  deathCauseEnemyKind: string | null;
+}
+
+export interface DaySummary {
+  total: number;
+  wins: number;
+  losses: number;
+  winRate: number; // 0-100, integer
+  reachedPinkRealm: number; // # of games that reached the pink realm
+  reachedOutsideWorld: number; // # of games that breached into the outside world
+  blewUpTree: number; // # of games that destroyed >=1 tree
+  avgLevelReached: number | null; // mean floor reached, 1 decimal
+}
+
+/** Level 2 chest status as sent to the client (icon paths + bomb flag). */
+export interface ChestStatusPayload {
+  items: Pick<ChestItemMeta, "key" | "label" | "icon">[];
+  bombAvailable: boolean;
+}
+
+export interface StatsDayPayload {
+  date: string; // YYYY-MM-DD
+  chests: ChestStatusPayload;
+  summary: DaySummary;
+  games: GameCompleteRow[];
+}
+
+export interface EndgameStatsResponse {
+  days: StatsDayPayload[];
+  /** Pass as `beforeDay` to load the next (older) page; null when no more. */
+  nextCursor: string | null;
+  hasMore: boolean;
+  /** False when PostHog read credentials are not configured on the server. */
+  configured: boolean;
+  message?: string;
+}
+
+// --- coercion helpers --------------------------------------------------------
+
+function toNumberOrNull(v: unknown): number | null {
+  if (v === null || v === undefined || v === "") return null;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+function toIntOr(v: unknown, fallback: number): number {
+  const n = toNumberOrNull(v);
+  return n === null ? fallback : Math.trunc(n);
+}
+
+/**
+ * PostHog stores booleans as real JSON booleans, but older/mixed events can
+ * surface them as the strings "true"/"false" (or 0/1). Treat all of those.
+ */
+function toBool(v: unknown): boolean {
+  if (v === true) return true;
+  if (typeof v === "string") return v.toLowerCase() === "true";
+  if (typeof v === "number") return v !== 0;
+  return false;
+}
+
+/**
+ * Array-valued PostHog properties come back as a real array, but can also
+ * surface as a JSON string. Normalize either into a string[].
+ */
+function toStringArray(v: unknown): string[] {
+  if (Array.isArray(v)) return v.map((x) => String(x));
+  if (typeof v === "string" && v.trim().startsWith("[")) {
+    try {
+      const parsed = JSON.parse(v);
+      if (Array.isArray(parsed)) return parsed.map((x) => String(x));
+    } catch {
+      // fall through
+    }
+  }
+  return [];
+}
+
+/**
+ * Normalize a single plain-object record (column name -> value) into a
+ * GameCompleteRow. Column names are the aliases used by the HogQL query below.
+ */
+export function toGameCompleteRow(rec: Record<string, unknown>): GameCompleteRow {
+  const outcome = String(rec.outcome ?? "").toLowerCase() === "win" ? "win" : "dead";
+  return {
+    day: String(rec.day ?? ""),
+    timestamp: String(rec.timestamp ?? ""),
+    distinctId: String(rec.distinct_id ?? ""),
+    outcome,
+    levelReached: toNumberOrNull(rec.level_reached),
+    heroHealth: toNumberOrNull(rec.hero_health),
+    steps: toNumberOrNull(rec.steps),
+    enemiesDefeated: toNumberOrNull(rec.enemies_defeated),
+    damageDealt: toNumberOrNull(rec.damage_dealt),
+    damageTaken: toNumberOrNull(rec.damage_taken),
+    chestsOpened: toNumberOrNull(rec.chests_opened),
+    totalChests: toNumberOrNull(rec.total_chests),
+    hasSword: toBool(rec.has_sword),
+    hasShield: toBool(rec.has_shield),
+    treesDestroyed: toIntOr(rec.trees_destroyed, 0),
+    wallsDestroyed: toIntOr(rec.walls_destroyed, 0),
+    reachedOutsideWorld: toBool(rec.reached_outside_world),
+    reachedPinkRealm: toBool(rec.reached_pink_realm),
+    collectedChestItems: toStringArray(rec.collected_chest_items),
+    deathCause: rec.death_cause == null ? null : String(rec.death_cause),
+    deathCauseEnemyKind:
+      rec.death_cause_enemy_kind == null ? null : String(rec.death_cause_enemy_kind),
+  };
+}
+
+/**
+ * Map PostHog HogQL query output (`columns` + `results` rows-as-arrays) into
+ * normalized GameCompleteRow objects.
+ */
+export function parseHogQLRows(
+  columns: string[],
+  results: unknown[][]
+): GameCompleteRow[] {
+  return results.map((row) => {
+    const rec: Record<string, unknown> = {};
+    columns.forEach((col, i) => {
+      rec[col] = row[i];
+    });
+    return toGameCompleteRow(rec);
+  });
+}
+
+// --- aggregation -------------------------------------------------------------
+
+export function summarizeDay(games: GameCompleteRow[]): DaySummary {
+  const total = games.length;
+  const wins = games.filter((g) => g.outcome === "win").length;
+  const levels = games
+    .map((g) => g.levelReached)
+    .filter((n): n is number => n !== null);
+  const avgLevelReached =
+    levels.length > 0
+      ? Math.round((levels.reduce((s, n) => s + n, 0) / levels.length) * 10) / 10
+      : null;
+  return {
+    total,
+    wins,
+    losses: total - wins,
+    winRate: total > 0 ? Math.round((wins / total) * 100) : 0,
+    reachedPinkRealm: games.filter((g) => g.reachedPinkRealm).length,
+    reachedOutsideWorld: games.filter((g) => g.reachedOutsideWorld).length,
+    blewUpTree: games.filter((g) => g.treesDestroyed > 0).length,
+    avgLevelReached,
+  };
+}
+
+/**
+ * Group normalized rows by their daily `date_seed`, newest day first and newest
+ * game first within each day. Rows with an empty day are dropped.
+ */
+export function groupRowsByDay(
+  rows: GameCompleteRow[]
+): { date: string; summary: DaySummary; games: GameCompleteRow[] }[] {
+  const byDay = new Map<string, GameCompleteRow[]>();
+  for (const row of rows) {
+    if (!row.day) continue;
+    const list = byDay.get(row.day);
+    if (list) list.push(row);
+    else byDay.set(row.day, [row]);
+  }
+  return Array.from(byDay.entries())
+    .sort((a, b) => (a[0] < b[0] ? 1 : a[0] > b[0] ? -1 : 0)) // date desc
+    .map(([date, games]) => {
+      const sorted = [...games].sort((a, b) =>
+        a.timestamp < b.timestamp ? 1 : a.timestamp > b.timestamp ? -1 : 0
+      );
+      return { date, summary: summarizeDay(sorted), games: sorted };
+    });
+}


### PR DESCRIPTION
## What

A new internal, noindex **`/stats`** dashboard that scrolls through every completed daily run, grouped by day (a few days per page, infinite scroll), styled like the game with its item icons.

Per day it reports the four things we wanted:
1. **Level 2 chest draw** + whether a **bomb** was available (the slot that gates the outside world / pink realm).
2. **Pink realm** reaches.
3. **Outside world** reaches.
4. **Tree** blow-ups.

Per game (compact rows): outcome, floor reached, health (wins only), enemies, steps (👣), and the **chest loot** collected.

## How
- **`app/api/endgame-stats`** — HogQL query over `game_complete` (daily), paged by `date_seed`. Extracts `date_seed` with `JSONExtractString` because PostHog type-infers it as a DateTime. Server-only creds; returns `configured:false` with a setup notice if unset.
- **L2 chest contents** are recomputed deterministically from the daily seed (`allocateChestsAndKeys`) — no analytics storage needed. Cross-checked against the real generator in tests.

## Telemetry fixes (needed for the dashboard to have data)
- Added the missing `runProgressProps` spread to the **non-story permanent-death path** (daily/endless) — previously only *wins* recorded chests/loadout/pink/outside/tree.
- Records the **exact chest items collected** (`collected_chest_items`) so the loot row shows real items (extra heart / snake medallion / bomb), not just a seed inference. Populates for runs played after this deploys; older runs fall back to the seed reconstruction.

## ⚠️ Deploy requirement
The deployed page needs these **server** env vars in Vercel (reads use a *personal* API key, not the public `phc_` key):
- `POSTHOG_PERSONAL_API_KEY`
- `POSTHOG_PROJECT_ID`
- `POSTHOG_HOST` (optional, defaults to `https://us.posthog.com`)

## Verification
`npm run typecheck`, `npm run lint`, full Jest suite (721 passed), and a clean `npm run build` all pass. Route verified end-to-end against live PostHog (returns real data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
