### PR TITLE
Stop client rate limiting from dropping analytics events

### DIFF
--- a/instrumentation-client.ts
+++ b/instrumentation-client.ts
@@ -11,6 +11,12 @@ posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
   // We track gameplay with explicit events, so autocapture only adds noise.
   autocapture: false,
   rageclick: false, // repeated same-spot taps are normal gameplay, not rage
+  // Session replay is disabled: a constantly-animating game (torch flames,
+  // camera, sprites) makes rrweb emit a massive $snapshot stream that drained
+  // posthog-js's client rate limiter and dropped real events (game_complete),
+  // while producing heavy, low-value replays that burn recording quota. We rely
+  // on explicit gameplay events instead. (Overrides the project-level setting.)
+  disable_session_recording: true,
   debug: process.env.NODE_ENV === "development",
 });
 

--- a/lib/posthog_analytics.ts
+++ b/lib/posthog_analytics.ts
@@ -74,12 +74,23 @@ export function markNewPlayer(opts?: { enteredViaTutorial?: boolean }) {
 // Safe PostHog event capture
 function captureEvent(eventName: string, properties?: EventParams) {
   if (typeof window === 'undefined') return;
-  
+
   try {
-    posthog.capture(eventName, {
-      ...properties,
-      timestamp: new Date().toISOString()
-    });
+    posthog.capture(
+      eventName,
+      {
+        ...properties,
+        timestamp: new Date().toISOString(),
+      },
+      // Bypass posthog-js's client-side rate limiter (default 10/sec, 100 burst)
+      // for our events. These are all deliberate, low-volume gameplay signals —
+      // but session replay's $snapshot stream (heavy for a constantly-animating
+      // game) drains the shared token bucket, after which captures get dropped,
+      // silently losing game_complete and other runs. skip_client_rate_limiting
+      // guarantees these always send; it does not weaken the limiter for
+      // autocapture/replay, which stay governed.
+      { skip_client_rate_limiting: true }
+    );
   } catch (error) {
     console.warn('PostHog capture failed:', error);
   }


### PR DESCRIPTION
## Problem
`[PostHog.js] This capture call is ignored due to client rate limiting` — real runs (and `game_complete`) were being silently dropped for users. Root cause: **session replay**. On a constantly-animating game, rrweb emits a massive `$snapshot` stream that drains posthog-js's client-side rate limiter (default 10/sec, 100 burst); once the token bucket empties, subsequent captures are dropped.

## Fix
- **`skip_client_rate_limiting: true`** on every deliberate gameplay event (in the shared `captureEvent` wrapper). These events are hand-picked and low-volume, and they all matter, so they bypass the client rate limiter and always send. This does **not** weaken the limiter for autocapture/replay.
- **`disable_session_recording: true`** — removes the flood at its source and stops spending PostHog recording quota on heavy, low-value replays of an animated DOM game. (Overrides the project-level recording setting for this client.)

## Notes
- The limiter is a self-refilling token bucket, not a persistent ban — so previously-affected users report normally again as soon as they load this build. Already-dropped events are unrecoverable.
- Verified: `typecheck`, `lint`, full Jest suite, and `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
