### PR TITLE
Add the Shaper terrain-shaping puzzle boss (isolated /test-shaper)

### DIFF
--- a/__tests__/lib/shaper.test.ts
+++ b/__tests__/lib/shaper.test.ts
@@ -1,0 +1,502 @@
+import { Enemy } from "../../lib/enemy";
+import { movePlayer, Direction, TileSubtype } from "../../lib/map";
+import type { GameState } from "../../lib/map/game-state";
+import {
+  planShaperAttack,
+  executeShaperAttack,
+  fireTargets,
+  shaperRevealTiles,
+  shaperPendingFire,
+  type ShaperMutation,
+} from "../../lib/bosses/shaper";
+
+function seqRng(): () => number {
+  let s = 0.123;
+  return () => {
+    s = (s * 9301 + 0.49297) % 1;
+    return s;
+  };
+}
+
+function openArena(
+  n: number,
+  heroPos: [number, number],
+  shaperPos: [number, number]
+): { state: GameState; shaper: Enemy } {
+  const tiles = Array.from({ length: n }, (_, y) =>
+    Array.from({ length: n }, (_, x) => (y === 0 || x === 0 || y === n - 1 || x === n - 1 ? 1 : 0))
+  );
+  const subtypes: number[][][] = Array.from({ length: n }, () =>
+    Array.from({ length: n }, () => [])
+  );
+  subtypes[heroPos[0]][heroPos[1]] = [TileSubtype.PLAYER];
+  const shaper = new Enemy({ y: shaperPos[0], x: shaperPos[1] });
+  shaper.kind = "shaper";
+  const state = {
+    hasKey: false, hasExitKey: false, hasSword: true, hasShield: false,
+    mapData: { tiles, subtypes }, showFullMap: true, win: false,
+    playerDirection: Direction.UP, enemies: [shaper], npcs: [],
+    heroHealth: 5, heroMaxHealth: 5, heroAttack: 1, heroTorchLit: true,
+    rockCount: 5, combatRng: () => 0.5,
+    stats: { damageDealt: 0, damageTaken: 0, enemiesDefeated: 0, steps: 0 },
+    recentDeaths: [],
+  } as unknown as GameState;
+  return { state, shaper };
+}
+
+const grid = (n: number) => Array.from({ length: n }, () => Array(n).fill(0));
+const emptySubs = (n: number) =>
+  Array.from({ length: n }, () => Array.from({ length: n }, () => [] as number[]));
+const at = (m: ShaperMutation[], y: number, x: number) => m.find((t) => t.y === y && t.x === x);
+
+describe("Shaper attacks respect walls", () => {
+  test("a lava PATH melts exactly ONE wall into charred floor and never passes through", () => {
+    // Boss above, hero below, a wall spanning the column between them at row 4.
+    const g = grid(11);
+    const s = emptySubs(11);
+    g[4][5] = 1; // wall directly on the straight path
+    const muts = planShaperAttack(
+      "path", "lava", { y: 1, x: 5 }, { y: 9, x: 5 }, { y: 9, x: 5 }, g, s, seqRng()
+    );
+    // The wall tile is melted to SINGED...
+    const wall = at(muts, 4, 5);
+    expect(wall?.sub).toBe(TileSubtype.SINGED);
+    // ...and NOTHING is reshaped beyond it (rows > 4 on the path column).
+    expect(muts.every((m) => !(m.x === 5 && m.y > 4))).toBe(true);
+    // Applying it opens the wall to floor.
+    executeShaperAttack(muts, g, s);
+    expect(g[4][5]).toBe(0);
+    expect(s[4][5]).toEqual([TileSubtype.SINGED]);
+  });
+
+  test("a water PATH stops at a wall (never touches it) and pools to the sides", () => {
+    const g = grid(11);
+    const s = emptySubs(11);
+    g[4][5] = 1;
+    const muts = planShaperAttack(
+      "path", "water", { y: 1, x: 5 }, { y: 9, x: 5 }, { y: 9, x: 5 }, g, s, seqRng()
+    );
+    expect(at(muts, 4, 5)).toBeUndefined(); // wall untouched
+    expect(muts.every((m) => !(m.x === 5 && m.y > 4))).toBe(true); // nothing beyond
+    // Puddles to the left and right of the last floor tile before the wall (row 3).
+    expect(at(muts, 3, 4)?.sub).toBe(TileSubtype.SHALLOW_WATER);
+    expect(at(muts, 3, 6)?.sub).toBe(TileSubtype.SHALLOW_WATER);
+    executeShaperAttack(muts, g, s);
+    expect(g[4][5]).toBe(1); // wall still a wall
+  });
+
+  test("neither element ever reshapes a tile on the far side of a wall (the bug)", () => {
+    for (const el of ["lava", "water"] as const) {
+      const g = grid(11);
+      const s = emptySubs(11);
+      g[4][5] = 1;
+      const muts = planShaperAttack(
+        "path", el, { y: 1, x: 5 }, { y: 9, x: 5 }, { y: 9, x: 5 }, g, s, seqRng()
+      );
+      // No mutation strictly beyond the wall along the corridor.
+      expect(muts.some((m) => m.y >= 6 && m.x === 5)).toBe(false);
+    }
+  });
+
+  test("lava won't melt the map border wall", () => {
+    // Bordered grid (walls on the edge), boss firing up into the top border.
+    const g = grid(11);
+    for (let i = 0; i < 11; i++) {
+      g[0][i] = 1; g[10][i] = 1; g[i][0] = 1; g[i][10] = 1;
+    }
+    const s = emptySubs(11);
+    const muts = planShaperAttack(
+      "path", "lava", { y: 3, x: 5 }, { y: 1, x: 5 }, { y: 1, x: 5 }, g, s, seqRng()
+    );
+    // The border wall at row 0 is never melted (out of the meltable set).
+    expect(muts.every((m) => m.y !== 0)).toBe(true);
+    executeShaperAttack(muts, g, s);
+    expect(g[0][5]).toBe(1); // still a wall
+  });
+});
+
+describe("Shaper element interaction (the weapon)", () => {
+  test("lava crossing water yields singed; water crossing lava yields singed", () => {
+    // Lava path down a column with a shallow tile in the way.
+    const g = grid(11);
+    const s = emptySubs(11);
+    s[4][5] = [TileSubtype.SHALLOW_WATER];
+    const lavaMuts = planShaperAttack(
+      "path", "lava", { y: 1, x: 5 }, { y: 8, x: 5 }, { y: 8, x: 5 }, g, s, seqRng()
+    );
+    expect(at(lavaMuts, 4, 5)?.sub).toBe(TileSubtype.SINGED);
+
+    const g2 = grid(11);
+    const s2 = emptySubs(11);
+    s2[4][5] = [TileSubtype.LAVA];
+    const waterMuts = planShaperAttack(
+      "path", "water", { y: 1, x: 5 }, { y: 8, x: 5 }, { y: 8, x: 5 }, g2, s2, seqRng()
+    );
+    expect(at(waterMuts, 4, 5)?.sub).toBe(TileSubtype.SINGED);
+  });
+
+  test("water deepens shallow; execute applies the given subtypes", () => {
+    const g = grid(9);
+    const s = emptySubs(9);
+    executeShaperAttack([{ y: 3, x: 3, sub: TileSubtype.DEEP_WATER }], g, s);
+    expect(s[3][3]).toEqual([TileSubtype.DEEP_WATER]);
+  });
+});
+
+describe("Shaper strategy: water slows, fire kills", () => {
+  test("UNALERTED (out of range) holds fire for several turns, then spews", () => {
+    const { state } = openArena(21, [19, 10], [1, 10]);
+    state.combatRng = seqRng();
+    let s = state;
+    for (let t = 0; t < 4; t++) {
+      s = movePlayer(s, t % 2 === 0 ? Direction.LEFT : Direction.RIGHT);
+      expect(shaperRevealTiles(s.enemies![0].behaviorMemory as Record<string, unknown>)).toBeNull();
+    }
+    let spewed = false;
+    for (let t = 0; t < 3 && !spewed; t++) {
+      s = movePlayer(s, t % 2 === 0 ? Direction.LEFT : Direction.RIGHT);
+      if (shaperRevealTiles(s.enemies![0].behaviorMemory as Record<string, unknown>)) spewed = true;
+    }
+    expect(spewed).toBe(true);
+  });
+
+  test("ALERTED opens with WATER (not fire)", () => {
+    const { state } = openArena(13, [6, 6], [2, 6]);
+    state.combatRng = seqRng();
+    forceStrat(state, "drowning");
+    const s = movePlayer(state, Direction.DOWN);
+    const atk = shaperRevealTiles(s.enemies![0].behaviorMemory as Record<string, unknown>);
+    expect(atk?.element).toBe("water");
+  });
+
+  test("two water squirts in a row create torch-snuffing DEEP water", () => {
+    const { state } = openArena(13, [6, 6], [2, 6]);
+    state.combatRng = seqRng();
+    forceStrat(state, "drowning");
+    let s = movePlayer(state, Direction.DOWN); // water #1: floor -> shallow
+    expect(countSubtype(s, TileSubtype.DEEP_WATER)).toBe(0);
+    s = movePlayer(s, Direction.DOWN); // water #2: shallow -> deep
+    expect(countSubtype(s, TileSubtype.DEEP_WATER)).toBeGreaterThan(0);
+  });
+
+  test("fire is telegraphed: it launches (glow, no lava), then rains down as lava", () => {
+    const { state } = openArena(13, [6, 6], [2, 6]);
+    state.combatRng = seqRng();
+    forceStrat(state, "drowning");
+    let s = movePlayer(state, Direction.DOWN); // water 1
+    s = movePlayer(s, Direction.DOWN); // water 2
+    const lavaBefore = countSubtype(s, TileSubtype.LAVA);
+    s = movePlayer(s, Direction.DOWN); // FIRE LAUNCH
+    const pending = shaperPendingFire(s.enemies![0].behaviorMemory as Record<string, unknown>);
+    expect(pending).toBeTruthy();
+    expect(pending!.length).toBeGreaterThan(0);
+    expect(countSubtype(s, TileSubtype.LAVA)).toBe(lavaBefore); // no lava yet — just a warning
+    s = movePlayer(s, Direction.DOWN); // FIRE RAINS DOWN
+    expect(shaperPendingFire(s.enemies![0].behaviorMemory as Record<string, unknown>)).toBeNull();
+    expect(countSubtype(s, TileSubtype.LAVA)).toBeGreaterThan(lavaBefore);
+  });
+
+  test("standing where the fire lands kills you (otherwise you die)", () => {
+    // Hero pinned against the west wall; bumping LEFT keeps it still, so the fire
+    // is aimed at its tile and then rains down onto it while it stays put.
+    const { state } = openArena(13, [6, 1], [2, 1]);
+    state.combatRng = seqRng();
+    forceStrat(state, "drowning");
+    let s = state;
+    for (let t = 0; t < 4; t++) s = movePlayer(s, Direction.LEFT); // water, water, launch, LAND
+    expect(s.heroHealth).toBe(0);
+    expect(s.deathCause?.type).toBe("lava");
+  });
+
+  test("stepping off the telegraphed tiles when the fire lands survives", () => {
+    const { state } = openArena(13, [6, 1], [2, 1]);
+    state.combatRng = seqRng();
+    forceStrat(state, "drowning");
+    let s = state;
+    for (let t = 0; t < 3; t++) s = movePlayer(s, Direction.LEFT); // water, water, launch (holding)
+    const pending = shaperPendingFire(s.enemies![0].behaviorMemory as Record<string, unknown>) ?? [];
+    const pend = new Set(pending.map(([y, x]) => `${y},${x}`));
+    const [hy, hx] = findHero(s);
+    const safe = ([[1, 0], [-1, 0], [0, 1]] as Array<[number, number]>).find(
+      ([dy, dx]) => s.mapData.tiles[hy + dy]?.[hx + dx] === 0 && !pend.has(`${hy + dy},${hx + dx}`)
+    );
+    expect(safe).toBeTruthy(); // there is an escape off the telegraph
+    const dir = safe![0] === 1 ? Direction.DOWN : safe![0] === -1 ? Direction.UP : Direction.RIGHT;
+    s = movePlayer(s, dir); // fire lands, hero steps clear
+    expect(s.heroHealth).toBeGreaterThan(0);
+    expect(s.deathCause?.type).not.toBe("lava");
+  });
+
+  test("fire mostly AVOIDS water tiles (it's a wasted kill)", () => {
+    // Flood a patch, then tally how many launched fire tiles land on water.
+    let waterHits = 0;
+    let total = 0;
+    for (let seed = 1; seed <= 25; seed++) {
+      const { state } = openArena(13, [6, 6], [2, 6]);
+      state.combatRng = mulberryish(seed);
+      forceStrat(state, "drowning");
+      // Pre-flood a 5x5 shallow patch around the hero (never the hero's own tile,
+      // which must keep its PLAYER marker).
+      for (let y = 4; y <= 8; y++)
+        for (let x = 4; x <= 8; x++)
+          if (!(y === 6 && x === 6)) state.mapData.subtypes[y][x] = [TileSubtype.SHALLOW_WATER];
+      let s: GameState = state;
+      s = movePlayer(s, Direction.LEFT); // water1 (hero holds? no wall — it moves; fine)
+      s = movePlayer(s, Direction.LEFT); // water2
+      s = movePlayer(s, Direction.LEFT); // fire launch
+      const pending = shaperPendingFire(s.enemies![0].behaviorMemory as Record<string, unknown>) ?? [];
+      for (const [y, x] of pending) {
+        total++;
+        const subs = s.mapData.subtypes[y][x] ?? [];
+        if (subs.includes(TileSubtype.SHALLOW_WATER) || subs.includes(TileSubtype.DEEP_WATER)) waterHits++;
+      }
+    }
+    expect(total).toBeGreaterThan(0);
+    expect(waterHits / total).toBeLessThan(0.4); // avoids water most of the time
+  });
+
+  test("reaching the Shaper and striking it kills it", () => {
+    const { state } = openArena(7, [3, 3], [3, 4]);
+    const hit1 = movePlayer(state, Direction.RIGHT);
+    expect(hit1.enemies![0].health).toBe(2);
+    const hit2 = movePlayer(hit1, Direction.RIGHT);
+    expect((hit2.enemies ?? []).length).toBe(0);
+  });
+});
+
+describe("Shaper WALL strategy", () => {
+  test("raises a wall between itself and the hero when alerted", () => {
+    const { state } = openArena(13, [6, 6], [2, 6]);
+    forceStrat(state, "wall");
+    state.combatRng = () => 0.5; // >= lava-mix -> it builds rather than lobs fire
+    const wallsBefore = countWalls(state);
+    const s = movePlayer(state, Direction.DOWN);
+    expect(countWalls(s)).toBe(wallsBefore + 1);
+  });
+
+  test("never builds a wall on the hero or the boss", () => {
+    for (let seed = 1; seed <= 20; seed++) {
+      let s = openArena(13, [9, 6], [6, 6]).state;
+      forceStrat(s, "wall");
+      s.combatRng = mulberryish(seed);
+      for (let t = 0; t < 12; t++) {
+        s = movePlayer(s, stepTowardBoss(s));
+        if ((s.enemies ?? []).length === 0 || s.heroHealth <= 0) break;
+        const boss = s.enemies![0];
+        expect(s.mapData.tiles[boss.y][boss.x]).toBe(0); // boss never entombed
+        const [hy, hx] = findHero(s);
+        expect(s.mapData.tiles[hy][hx]).toBe(0); // hero never walled over
+      }
+    }
+  });
+
+  test("NEVER seals the hero out — the boss stays reachable every turn (many fights)", () => {
+    for (let seed = 1; seed <= 60; seed++) {
+      let s = openArena(15, [11, 7], [7, 7]).state;
+      forceStrat(s, "wall");
+      s.combatRng = mulberryish(seed * 13 + 1);
+      for (let t = 0; t < 30; t++) {
+        if ((s.enemies ?? []).length === 0) break; // boss slain -> it was reachable
+        // The boss is never entombed (structural), and ignoring coolable lava
+        // the hero can always still reach a standable attack tile (path).
+        expect(bossHasStandableNeighbor(s)).toBe(true);
+        expect(canStillReachBoss(s)).toBe(true);
+        s = movePlayer(s, stepTowardBoss(s));
+        if (s.heroHealth <= 0) break;
+      }
+    }
+  });
+
+  test("does NOT entomb itself: won't build the 4th wall around a 3-walled boss", () => {
+    // Reproduction of the softlock the review caught: boss at (7,7) with N/S/W
+    // already walls. The last open neighbor (E=(7,8)) must never be walled, or
+    // the boss becomes permanently unreachable and the fight is unwinnable.
+    for (let seed = 0; seed < 8; seed++) {
+      let s = openArena(15, [7, 10], [7, 7]).state;
+      forceStrat(s, "wall");
+      s.mapData.tiles[6][7] = 1; // N
+      s.mapData.tiles[8][7] = 1; // S
+      s.mapData.tiles[7][6] = 1; // W
+      s.combatRng = seed === 0 ? () => 0.5 : mulberryish(seed);
+      for (let t = 0; t < 10; t++) {
+        s = movePlayer(s, stepTowardBoss(s));
+        if ((s.enemies ?? []).length === 0 || s.heroHealth <= 0) break;
+        expect(bossHasStandableNeighbor(s)).toBe(true);
+        expect(s.mapData.tiles[7][8]).toBe(0); // E never walled -> never entombed
+      }
+    }
+  });
+
+  test("when it can't wall you off it lobs a lava splatter instead", () => {
+    // Wall the boss into a spot where new walls would seal the hero out, forcing
+    // the fire fallback. Small arena, boss cornered.
+    let s = openArena(9, [5, 4], [3, 4]).state;
+    forceStrat(s, "wall");
+    s.combatRng = mulberryish(3);
+    let sawFire = false;
+    for (let t = 0; t < 16 && !sawFire; t++) {
+      s = movePlayer(s, stepTowardBoss(s));
+      if ((s.enemies ?? []).length === 0 || s.heroHealth <= 0) break;
+      if (shaperPendingFire(s.enemies![0].behaviorMemory as Record<string, unknown>) || countSubtype(s, TileSubtype.LAVA) > 0) {
+        sawFire = true;
+      }
+    }
+    expect(sawFire).toBe(true);
+  });
+
+  test("fire ALWAYS leaves an escape tile — no unavoidable death in a 1-wide corridor", () => {
+    // A dry 1-wide horizontal corridor (row 5 open, everything else wall). If
+    // the fire blob fills the aim tile AND both collinear neighbors, a hero
+    // standing on the aim tile has no survivable move. fireTargets must always
+    // spare one walkable neighbor.
+    const n = 13;
+    const g = Array.from({ length: n }, (_, y) =>
+      Array.from({ length: n }, (_, x) => (y === 5 && x >= 1 && x <= 11 ? 0 : 1))
+    );
+    const s = emptySubs(n);
+    const boss = { y: 5, x: 3 };
+    const aim = { y: 5, x: 7 };
+    for (let seed = 1; seed <= 200; seed++) {
+      const targets = fireTargets(boss, aim, g, s, mulberryish(seed));
+      const set = new Set(targets.map(([y, x]) => `${y},${x}`));
+      const walkableNeighbors = ([[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>)
+        .map(([dy, dx]) => [aim.y + dy, aim.x + dx] as [number, number])
+        .filter(([y, x]) => g[y][x] === 0);
+      const hasEscape = walkableNeighbors.some(([y, x]) => !set.has(`${y},${x}`));
+      expect(hasEscape).toBe(true);
+    }
+  });
+
+  test("the encounter rolls BOTH strategies across many fights", () => {
+    const seen = new Set<string>();
+    for (let seed = 1; seed <= 60; seed++) {
+      const s = openArena(11, [6, 5], [3, 5]).state;
+      s.combatRng = mulberryish(seed);
+      const after = movePlayer(s, Direction.DOWN);
+      const strat = (after.enemies![0].behaviorMemory as Record<string, unknown>).strategy;
+      if (typeof strat === "string") seen.add(strat);
+    }
+    expect(seen.has("drowning")).toBe(true);
+    expect(seen.has("wall")).toBe(true);
+  });
+});
+
+function forceStrat(s: GameState, strat: "drowning" | "wall"): void {
+  (s.enemies![0].behaviorMemory as Record<string, unknown>).strategy = strat;
+}
+function countWalls(s: GameState): number {
+  let c = 0;
+  for (const row of s.mapData.tiles) for (const t of row) if (t === 1) c++;
+  return c;
+}
+// Can the hero still reach a STANDABLE tile orthogonally adjacent to the boss,
+// treating WALLS and abyss as blockers but lava as passable (the hero can cool
+// it with a rock)? A walled boss-neighbor is NOT a valid attack tile, and the
+// hero must actually be able to stand on the goal tile — matches the production
+// heroCanReachBoss semantics so the test can actually detect entombment.
+function canStillReachBoss(s: GameState): boolean {
+  const tiles = s.mapData.tiles;
+  const boss = s.enemies![0];
+  const blocked = (y: number, x: number) => {
+    if (y < 0 || x < 0 || y >= tiles.length || x >= tiles[0].length) return true;
+    if (tiles[y][x] === 1) return true; // wall (permanent); lava is coolable so NOT blocked
+    return (s.mapData.subtypes[y]?.[x] ?? []).includes(TileSubtype.OPEN_ABYSS);
+  };
+  const goals = new Set<string>();
+  for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>) {
+    const gy = boss.y + dy;
+    const gx = boss.x + dx;
+    if (!blocked(gy, gx)) goals.add(`${gy},${gx}`); // only standable attack tiles
+  }
+  if (goals.size === 0) return false; // boss sealed in
+  const [hy, hx] = findHero(s);
+  if (goals.has(`${hy},${hx}`)) return true;
+  const seen = new Set([`${hy},${hx}`]);
+  const q: Array<[number, number]> = [[hy, hx]];
+  while (q.length) {
+    const [y, x] = q.shift()!;
+    for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>) {
+      const ny = y + dy;
+      const nx = x + dx;
+      const k = `${ny},${nx}`;
+      if (seen.has(k) || blocked(ny, nx)) continue;
+      if (goals.has(k)) return true; // reached a standable attack tile
+      seen.add(k);
+      q.push([ny, nx]);
+    }
+  }
+  return false;
+}
+// Structural backstop, independent of the BFS oracle: the boss must always have
+// at least one orthogonal neighbor that is not a wall and not an abyss, i.e. a
+// tile the hero could stand on to melee it. Fails loudly if the boss is entombed.
+function bossHasStandableNeighbor(s: GameState): boolean {
+  const b = s.enemies![0];
+  return ([[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>).some(([dy, dx]) => {
+    const ny = b.y + dy;
+    const nx = b.x + dx;
+    if (s.mapData.tiles[ny]?.[nx] === 1) return false;
+    return !(s.mapData.subtypes[ny]?.[nx] ?? []).includes(TileSubtype.OPEN_ABYSS);
+  });
+}
+// Move the hero one BFS step toward the boss, avoiding walls and lava; bump a
+// wall (no-op) if boxed for the moment.
+function stepTowardBoss(s: GameState): Direction {
+  const tiles = s.mapData.tiles;
+  const subs = s.mapData.subtypes;
+  const boss = s.enemies![0];
+  const [hy, hx] = findHero(s);
+  const passable = (y: number, x: number) => {
+    if (y < 0 || x < 0 || y >= tiles.length || x >= tiles[0].length) return false;
+    if (tiles[y][x] !== 0 && tiles[y][x] !== 5) return false;
+    const c = subs[y]?.[x] ?? [];
+    if (c.includes(TileSubtype.LAVA) && !c.includes(TileSubtype.OBSIDIAN)) return false;
+    if (c.includes(TileSubtype.OPEN_ABYSS)) return false;
+    return true;
+  };
+  const goals = new Set(
+    [[-1, 0], [1, 0], [0, -1], [0, 1]].map(([dy, dx]) => `${boss.y + dy},${boss.x + dx}`)
+  );
+  // BFS recording the first step taken from the hero.
+  const q: Array<{ y: number; x: number; first: Direction | null }> = [{ y: hy, x: hx, first: null }];
+  const seen = new Set([`${hy},${hx}`]);
+  const dirs: Array<[number, number, Direction]> = [
+    [-1, 0, Direction.UP], [1, 0, Direction.DOWN], [0, -1, Direction.LEFT], [0, 1, Direction.RIGHT],
+  ];
+  while (q.length) {
+    const cur = q.shift()!;
+    for (const [dy, dx, dir] of dirs) {
+      const ny = cur.y + dy;
+      const nx = cur.x + dx;
+      const first = cur.first ?? dir;
+      if (goals.has(`${ny},${nx}`)) return first; // step toward an adjacent-to-boss tile
+      if (seen.has(`${ny},${nx}`) || !passable(ny, nx)) continue;
+      seen.add(`${ny},${nx}`);
+      q.push({ y: ny, x: nx, first });
+    }
+  }
+  return Direction.UP; // boxed for now (bump)
+}
+
+function mulberryish(seed: number): () => number {
+  let s = seed >>> 0;
+  return () => {
+    s = (s + 0x6d2b79f5) >>> 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function countSubtype(s: GameState, sub: number): number {
+  let c = 0;
+  for (const row of s.mapData.subtypes) for (const cell of row) if (cell.includes(sub)) c++;
+  return c;
+}
+function findHero(s: GameState): [number, number] {
+  const subs = s.mapData.subtypes;
+  for (let y = 0; y < subs.length; y++)
+    for (let x = 0; x < subs[y].length; x++)
+      if (subs[y][x].includes(TileSubtype.PLAYER)) return [y, x];
+  throw new Error("hero not found");
+}

--- a/__tests__/lib/shaper_arena.test.ts
+++ b/__tests__/lib/shaper_arena.test.ts
@@ -1,0 +1,120 @@
+import { TileSubtype } from "../../lib/map";
+import type { GameState } from "../../lib/map/game-state";
+import {
+  SHAPER_LAYOUTS,
+  SHAPER_ENTRIES,
+  buildShaperArena,
+} from "../../lib/bosses/shaper_arena";
+
+function mulberry32(seed: number): () => number {
+  let s = seed;
+  return () => {
+    s |= 0;
+    s = (s + 0x6d2b79f5) | 0;
+    let t = Math.imul(s ^ (s >>> 15), 1 | s);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function reachable(state: GameState, from: [number, number]): Set<string> {
+  const tiles = state.mapData.tiles;
+  const subs = state.mapData.subtypes;
+  const H = tiles.length;
+  const W = tiles[0].length;
+  const walkable = (y: number, x: number) =>
+    y >= 0 && x >= 0 && y < H && x < W &&
+    tiles[y][x] === 0 &&
+    !(subs[y][x] ?? []).includes(TileSubtype.LAVA);
+  const seen = new Set<string>([`${from[0]},${from[1]}`]);
+  const q: Array<[number, number]> = [from];
+  while (q.length) {
+    const [y, x] = q.shift()!;
+    for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>) {
+      const k = `${y + dy},${x + dx}`;
+      if (!seen.has(k) && walkable(y + dy, x + dx)) {
+        seen.add(k);
+        q.push([y + dy, x + dx]);
+      }
+    }
+  }
+  return seen;
+}
+function findPlayer(state: GameState): [number, number] {
+  const subs = state.mapData.subtypes;
+  for (let y = 0; y < subs.length; y++)
+    for (let x = 0; x < subs[y].length; x++)
+      if (subs[y][x].includes(TileSubtype.PLAYER)) return [y, x];
+  throw new Error("no player");
+}
+function count(state: GameState, sub: number): number {
+  let c = 0;
+  for (const row of state.mapData.subtypes) for (const cell of row) if (cell.includes(sub)) c++;
+  return c;
+}
+function bossReachable(state: GameState): boolean {
+  const seen = reachable(state, findPlayer(state));
+  const b = state.enemies![0];
+  return [[-1, 0], [1, 0], [0, -1], [0, 1]].some(([dy, dx]) => seen.has(`${b.y + dy},${b.x + dx}`));
+}
+// Distance to the first wall going `dir` from center (12,12).
+function firstWallDist(state: GameState, dir: [number, number]): number {
+  let y = 12;
+  let x = 12;
+  for (let d = 1; d <= 12; d++) {
+    y += dir[0];
+    x += dir[1];
+    if (state.mapData.tiles[y]?.[x] === 1) return d;
+  }
+  return 99;
+}
+
+describe("Shaper randomized labyrinth", () => {
+  SHAPER_ENTRIES.forEach((entry) => {
+    test(`is always solvable from the ${entry} entry (40 random mazes)`, () => {
+      for (let seed = 1; seed <= 40; seed++) {
+        const state = buildShaperArena(SHAPER_LAYOUTS[0], entry, mulberry32(seed));
+        expect(bossReachable(state)).toBe(true);
+      }
+    });
+  });
+
+  test("the boss sees INTO the inner tiers (aligned inner gaps — no sneaking up)", () => {
+    // Inner rings are gapped on all four sides at the center lines, so every
+    // cardinal ray out of the center runs clear through both inner tiers before
+    // any wall (dist >= 7) — the boss spots you as you reach the inner halls.
+    for (let seed = 1; seed <= 40; seed++) {
+      const state = buildShaperArena(SHAPER_LAYOUTS[0], "south", mulberry32(seed));
+      for (const dir of [[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>) {
+        expect(firstWallDist(state, dir)).toBeGreaterThanOrEqual(7);
+      }
+    }
+  });
+
+  test("each maze genuinely winds (large reachable area from the entry)", () => {
+    for (let seed = 1; seed <= 20; seed++) {
+      const state = buildShaperArena(SHAPER_LAYOUTS[0], "south", mulberry32(seed));
+      expect(reachable(state, findPlayer(state)).size).toBeGreaterThan(80);
+    }
+  });
+
+  test("boss dead center on clean floor with a 7x7 roam box (both layouts)", () => {
+    for (const layout of SHAPER_LAYOUTS) {
+      const state = buildShaperArena(layout, "south", mulberry32(3));
+      const boss = state.enemies![0];
+      expect([boss.y, boss.x]).toEqual([12, 12]);
+      expect(state.mapData.tiles[12][12]).toBe(0);
+      const mem = boss.behaviorMemory as Record<string, unknown>;
+      expect(mem.roamMinY).toBe(9);
+      expect(mem.roamMaxY).toBe(15);
+    }
+  });
+
+  test("loot survives on the halls regardless of the gap rng", () => {
+    for (let seed = 1; seed <= 10; seed++) {
+      const state = buildShaperArena(SHAPER_LAYOUTS[0], "south", mulberry32(seed));
+      expect(count(state, TileSubtype.ROCK)).toBeGreaterThanOrEqual(8);
+      expect(count(state, TileSubtype.POT)).toBeGreaterThanOrEqual(3);
+    }
+  });
+});

--- a/app/globals.css
+++ b/app/globals.css
@@ -546,6 +546,52 @@ body {
   }
 }
 
+/* The Shaper's terrain reshape: each affected tile flashes in (staggered by
+   distance so the change sweeps outward), then fades to reveal the real
+   lava/water tile placed underneath. Fast, so it reads as a real-time spread. */
+@keyframes shaperReveal {
+  0% {
+    transform: scale(0.5);
+    opacity: 0;
+  }
+  45% {
+    transform: scale(1.12);
+    opacity: 0.95;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 0;
+  }
+}
+
+/* The Shaper's fire telegraph: a gentle warm pulse on tiles about to be hit. */
+@keyframes shaperFireGlow {
+  0%, 100% {
+    opacity: 0.35;
+    transform: scale(0.92);
+  }
+  50% {
+    opacity: 0.7;
+    transform: scale(1.04);
+  }
+}
+
+/* Lava rocketing up out of view the turn the Shaper launches fire. */
+@keyframes shaperFireLaunch {
+  0% {
+    opacity: 0;
+    transform: translateY(35%) scaleY(0.6);
+  }
+  30% {
+    opacity: 1;
+    transform: translateY(0) scaleY(1);
+  }
+  100% {
+    opacity: 0;
+    transform: translateY(-25%) scaleY(1.1);
+  }
+}
+
 /* Item pickup animation - center screen scale up and fade */
 @keyframes itemPickupCenter {
   0% {

--- a/app/test-shaper/page.tsx
+++ b/app/test-shaper/page.tsx
@@ -1,0 +1,142 @@
+"use client";
+
+import React, { Suspense, useState, useMemo } from "react";
+import { TilemapGrid } from "../../components/TilemapGrid";
+import { tileTypes } from "../../lib/map";
+import {
+  SHAPER_LAYOUTS,
+  SHAPER_ENTRIES,
+  buildShaperArena,
+  type ShaperEntry,
+} from "../../lib/bosses/shaper_arena";
+
+function TestShaperInner() {
+  const [layoutIndex, setLayoutIndex] = useState(0);
+  const [entry, setEntry] = useState<ShaperEntry>("south");
+  const [resetCount, setResetCount] = useState(0);
+  const [outcome, setOutcome] = useState<"none" | "won" | "lost">("none");
+
+  const layout = SHAPER_LAYOUTS[layoutIndex];
+  // Build the (randomized) labyrinth once per selection — not on every render,
+  // or the maze would reshuffle mid-play. Reset re-rolls a fresh one.
+  const initialState = useMemo(
+    () => buildShaperArena(layout, entry),
+    [layout, entry, resetCount]
+  );
+  const reset = () => {
+    setOutcome("none");
+    setResetCount((c) => c + 1);
+  };
+
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center justify-center p-4 text-white relative"
+      style={{
+        backgroundImage: "url(/images/presentational/wall-up-close.png)",
+        backgroundRepeat: "repeat",
+        backgroundSize: "auto",
+      }}
+    >
+      <div className="absolute inset-0 bg-black/40 pointer-events-none"></div>
+      <div className="relative z-10 flex flex-col items-center gap-4">
+        <div className="text-center bg-black/70 rounded-lg p-4 backdrop-blur-sm max-w-xl">
+          <h1 className="text-2xl font-bold mb-2">Boss Prototype: The Shaper</h1>
+          <p className="text-sm text-gray-300 mb-1">
+            Reach the Shaper across the marsh and strike it &mdash; the crossing
+            is the fight. It reshapes the terrain at you every few turns
+            (telegraphed a turn ahead):
+          </p>
+          <ul className="text-xs text-gray-400 text-left mx-auto inline-block mt-1 space-y-0.5">
+            <li>
+              <span className="text-orange-400">Ember wall</span> (red tiles)
+              &mdash; becomes LAVA (instant death). Throw a rock to cool it into a
+              stepping stone.
+            </li>
+            <li>
+              <span className="text-blue-400">Flood</span> (blue tiles) &mdash;
+              floods to water and deepens shallow&rarr;deep. Deep water snuffs
+              your torch &mdash; you swim blind.
+            </li>
+            <li>
+              Wade shallow water freely. Rock a deep tile into a dry stepping
+              stone. Stay lit; step near lava glow to relight.
+            </li>
+          </ul>
+        </div>
+
+        <div className="flex flex-wrap gap-2 justify-center bg-black/70 rounded-lg p-3 backdrop-blur-sm">
+          {SHAPER_LAYOUTS.map((l, i) => (
+            <button
+              key={l.name}
+              onClick={() => {
+                setLayoutIndex(i);
+                setOutcome("none");
+              }}
+              className={`px-3 py-1 rounded text-sm ${
+                layoutIndex === i
+                  ? "bg-amber-600 text-white"
+                  : "bg-gray-700 text-gray-300 hover:bg-gray-600"
+              }`}
+            >
+              {l.name}
+            </button>
+          ))}
+          <span className="w-px bg-gray-600 mx-1" />
+          <span className="text-xs text-gray-400 self-center">Enter from:</span>
+          {SHAPER_ENTRIES.map((e) => (
+            <button
+              key={e}
+              onClick={() => {
+                setEntry(e);
+                setOutcome("none");
+              }}
+              className={`px-3 py-1 rounded text-sm capitalize ${
+                entry === e
+                  ? "bg-sky-700 text-white"
+                  : "bg-gray-700 text-gray-300 hover:bg-gray-600"
+              }`}
+            >
+              {e}
+            </button>
+          ))}
+          <span className="w-px bg-gray-600 mx-1" />
+          <button
+            onClick={reset}
+            className="px-3 py-1 rounded text-sm bg-red-700 text-white hover:bg-red-600"
+          >
+            Reset
+          </button>
+        </div>
+
+        {outcome === "lost" && (
+          <div className="bg-red-900/90 rounded-lg px-4 py-2 text-sm font-bold backdrop-blur-sm">
+            The terrain claimed you. Hit Reset to try again.
+          </div>
+        )}
+        {outcome === "won" && (
+          <div className="bg-green-900/90 rounded-lg px-4 py-2 text-sm font-bold backdrop-blur-sm">
+            You reached the Shaper and broke it. Hit Reset to duel again.
+          </div>
+        )}
+
+        <TilemapGrid
+          key={`${layoutIndex}-${entry}-${resetCount}`}
+          tileTypes={tileTypes}
+          initialGameState={initialState}
+          forceDaylight={true}
+          storageSlot="test"
+          onWin={() => setOutcome("won")}
+          onDeath={() => setOutcome("lost")}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function TestShaperPage() {
+  return (
+    <Suspense fallback={null}>
+      <TestShaperInner />
+    </Suspense>
+  );
+}

--- a/components/Tile.tsx
+++ b/components/Tile.tsx
@@ -183,7 +183,7 @@ interface TileProps {
   hasEnemy?: boolean; // Whether this tile contains an enemy
   enemyVisible?: boolean; // Whether enemy is in player's FOV
   enemyFacing?: 'UP' | 'RIGHT' | 'DOWN' | 'LEFT';
-  enemyKind?: 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin';
+  enemyKind?: 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin' | 'shaper';
   enemyMoved?: boolean; // did the enemy move last tick (for snakes: choose moving vs coiled)
   enemySwarmCount?: number; // for white-goblin: how many swarm members share this tile (1-4)
   enemyAura?: boolean; // show eerie green glow when close to hero

--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -37,6 +37,12 @@ import {
   EnemyRegistry,
   type EnemyKind,
 } from "../lib/enemies/registry";
+import {
+  shaperRevealTiles,
+  shaperPendingFire,
+  shaperFireLaunch,
+  shaperWallReveal,
+} from "../lib/bosses/shaper";
 import MobileControls from "./MobileControls";
 import PixelFlame, { HERO_FLAME_ANCHOR } from "./PixelFlame";
 import styles from "./TilemapGrid.module.css";
@@ -161,6 +167,7 @@ const ENEMY_NUMBER_COLOR: Record<string, string> = {
   "white-goblin": "#eaeaea",
   snake: "#74e06f",
   ghost: "#c3eeff",
+  shaper: "#b07bff",
 };
 const HERO_DAMAGE_COLOR = "#f1c27d"; // hero skin tone — clearly "the hero lost HP"
 const HERO_HEAL_COLOR = "#6afc7a"; // green = healing
@@ -223,6 +230,12 @@ interface TilemapGridProps {
    * uses this to hand off to /daily-new floor 2 with carried inventory).
    */
   onWin?: (finalState: GameState) => void;
+  /**
+   * Non-daily death hook (mirror of onWin). Fires once when the hero dies with
+   * no checkpoint to revive from. When provided, suppresses the death-screen /
+   * `/end` redirect so a sandbox page can offer its own in-place reset.
+   */
+  onDeath?: (finalState: GameState) => void;
   storageSlot?: GameStorageSlot;
   // Notify parent where the hero is (floor number + pink realm status) so it
   // can render a location title. Fires on mount and whenever either changes.
@@ -238,6 +251,7 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
   isDailyChallenge = false,
   onDailyComplete,
   onWin,
+  onDeath,
   storageSlot,
   onLocationChange,
 }) => {
@@ -338,6 +352,9 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
 
   // Screen shake state
   const [isShaking, setIsShaking] = useState(false);
+  // Per-shake intensity (px). Most shakes use the default 4; the Shaper's
+  // terrain reshape requests a bigger jolt so the no-telegraph attack is felt.
+  const [shakeIntensity, setShakeIntensity] = useState(4);
 
   // Item pickup animation state
   const [itemPickupAnimations, setItemPickupAnimations] = useState<Array<{
@@ -2677,7 +2694,8 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
   };
 
   // Helper function to trigger screen shake
-  const triggerScreenShake = (duration = 200) => {
+  const triggerScreenShake = (duration = 200, intensity = 4) => {
+    setShakeIntensity(intensity);
     setIsShaking(true);
     setTimeout(() => setIsShaking(false), duration);
   };
@@ -2695,6 +2713,34 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
     lastBombBlastKeyRef.current = key;
     triggerScreenShake(360);
   }, [gameState?.recentBombBlasts]);
+
+  // Shake the screen once per Shaper action: a terrain reshape (water flood /
+  // fire rain-down) OR a fire launch (lava rocketing up). Keyed on nonces so
+  // each fires exactly once.
+  const lastShaperAttackRef = useRef<number>(0);
+  const lastShaperLaunchRef = useRef<number>(0);
+  const lastShaperWallRef = useRef<number>(0);
+  useEffect(() => {
+    const shaper = (gameState.enemies ?? []).find((e) => e.kind === "shaper");
+    const mem = shaper?.behaviorMemory as Record<string, unknown> | undefined;
+    const launch = shaperFireLaunch(mem);
+    if (launch != null && launch !== lastShaperLaunchRef.current) {
+      lastShaperLaunchRef.current = launch;
+      triggerScreenShake(300, 8); // the boss hurls fire skyward
+      return;
+    }
+    const wall = shaperWallReveal(mem);
+    if (wall && wall.nonce !== lastShaperWallRef.current) {
+      lastShaperWallRef.current = wall.nonce;
+      triggerScreenShake(240, 6); // a wall grinds up out of the ground
+      return;
+    }
+    const atk = shaperRevealTiles(mem);
+    if (!atk) return;
+    if (atk.nonce === lastShaperAttackRef.current) return;
+    lastShaperAttackRef.current = atk.nonce;
+    triggerScreenShake(360, 10); // terrain reshapes underfoot
+  }, [gameState]);
 
   useEffect(() => {
     try {
@@ -2802,6 +2848,22 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
     }
 
     if (shouldAnimateHeroDeath && heroDeathPhase !== "complete") {
+      return;
+    }
+
+    // Sandbox/test hook: the parent owns the death (in-place reset). Skip the
+    // death screen, analytics, and every redirect; just clear our save slot.
+    if (onDeath && !isDailyChallenge && gameState.mode !== "story") {
+      setGameCompletionProcessed(true);
+      triggerScreenShake(400);
+      try {
+        if (typeof window !== "undefined") {
+          CurrentGameStorage.clearCurrentGame(resolvedStorageSlot);
+        }
+      } catch {
+        // ignore storage errors
+      }
+      onDeath(gameState);
       return;
     }
 
@@ -3028,6 +3090,7 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
     gameState.stats,
     isDailyChallenge,
     onDailyComplete,
+    onDeath,
     router,
     resolvedStorageSlot,
     heroDeathPhase,
@@ -3896,7 +3959,7 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
           </div>
         </div>
       )}
-      <ScreenShake isShaking={isShaking} intensity={4} duration={300}>
+      <ScreenShake isShaking={isShaking} intensity={shakeIntensity} duration={300}>
         <div className="relative flex justify-center" data-testid="tilemap-grid-wrapper">
           {checkpointFlash && (
             <div className="absolute top-4 right-4 z-50">
@@ -4634,6 +4697,138 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
                       />
                     );
                   })()}
+                {/* Shaper attack reveal: NO telegraph — when the boss reshapes
+                    the ground, its tiles flash in outward (closest-first) over
+                    the freshly-placed lava/water, so the change reads as a fast
+                    real-time spread. Keyed on the attack nonce so it plays once
+                    per attack. The screen shake is fired from an effect below. */}
+                {(() => {
+                  const shaper = (gameState.enemies ?? []).find(
+                    (e) => e.kind === "shaper"
+                  );
+                  if (!shaper) return null;
+                  const atk = shaperRevealTiles(
+                    shaper.behaviorMemory as Record<string, unknown> | undefined
+                  );
+                  if (!atk) return null;
+                  const tileSize = 40;
+                  const isLava = atk.element === "lava";
+                  const color = isLava ? "#ff5a2c" : "#3aa0ff";
+                  return atk.tiles.map(([ty, tx], i) => (
+                    <div
+                      key={`shaper-reveal-${atk.nonce}-${ty}-${tx}`}
+                      aria-hidden="true"
+                      className="absolute pointer-events-none"
+                      style={{
+                        left: `${tx * tileSize}px`,
+                        top: `${ty * tileSize}px`,
+                        width: `${tileSize}px`,
+                        height: `${tileSize}px`,
+                        backgroundColor: color,
+                        borderRadius: "3px",
+                        zIndex: 11000,
+                        opacity: 0,
+                        // fast outward sweep: ~45ms per ring-step, then fade to
+                        // reveal the real terrain underneath.
+                        animation: `shaperReveal 260ms ease-out ${i * 45}ms both`,
+                      }}
+                    />
+                  ));
+                })()}
+                {/* Shaper FIRE telegraph: a subtle warm glow on the tiles where
+                    fire will rain down NEXT turn — the fair warning to step off. */}
+                {(() => {
+                  const shaper = (gameState.enemies ?? []).find(
+                    (e) => e.kind === "shaper"
+                  );
+                  if (!shaper) return null;
+                  const pending = shaperPendingFire(
+                    shaper.behaviorMemory as Record<string, unknown> | undefined
+                  );
+                  if (!pending) return null;
+                  const tileSize = 40;
+                  return pending.map(([ty, tx]) => (
+                    <div
+                      key={`shaper-fire-glow-${ty}-${tx}`}
+                      data-testid="shaper-fire-glow"
+                      aria-hidden="true"
+                      className="absolute pointer-events-none"
+                      style={{
+                        left: `${tx * tileSize + 4}px`,
+                        top: `${ty * tileSize + 4}px`,
+                        width: `${tileSize - 8}px`,
+                        height: `${tileSize - 8}px`,
+                        borderRadius: "50%",
+                        background:
+                          "radial-gradient(circle, rgba(255,140,60,0.5) 0%, rgba(255,90,30,0.16) 65%, transparent 100%)",
+                        zIndex: 10800,
+                        animation: "shaperFireGlow 900ms ease-in-out infinite",
+                      }}
+                    />
+                  ));
+                })()}
+                {/* Shaper FIRE launch: a column of lava rockets up out of view
+                    from the boss the turn it hurls fire skyward. */}
+                {(() => {
+                  const shaper = (gameState.enemies ?? []).find(
+                    (e) => e.kind === "shaper"
+                  );
+                  if (!shaper) return null;
+                  const nonce = shaperFireLaunch(
+                    shaper.behaviorMemory as Record<string, unknown> | undefined
+                  );
+                  if (nonce == null) return null;
+                  const tileSize = 40;
+                  return (
+                    <div
+                      key={`shaper-fire-launch-${nonce}`}
+                      aria-hidden="true"
+                      className="absolute pointer-events-none"
+                      style={{
+                        left: `${shaper.x * tileSize + tileSize / 2 - 9}px`,
+                        top: 0,
+                        width: "18px",
+                        height: `${shaper.y * tileSize + tileSize / 2}px`,
+                        background:
+                          "linear-gradient(to top, rgba(255,90,30,0.9), rgba(255,170,70,0.5) 45%, transparent)",
+                        zIndex: 12200,
+                        opacity: 0,
+                        animation: "shaperFireLaunch 520ms ease-out both",
+                      }}
+                    />
+                  );
+                })()}
+                {/* Shaper WALL raise: a quick stone flash as a fresh wall rises. */}
+                {(() => {
+                  const shaper = (gameState.enemies ?? []).find(
+                    (e) => e.kind === "shaper"
+                  );
+                  if (!shaper) return null;
+                  const wall = shaperWallReveal(
+                    shaper.behaviorMemory as Record<string, unknown> | undefined
+                  );
+                  if (!wall) return null;
+                  const tileSize = 40;
+                  return wall.tiles.map(([ty, tx]) => (
+                    <div
+                      key={`shaper-wall-${wall.nonce}-${ty}-${tx}`}
+                      data-testid="shaper-wall-rise"
+                      aria-hidden="true"
+                      className="absolute pointer-events-none"
+                      style={{
+                        left: `${tx * tileSize}px`,
+                        top: `${ty * tileSize}px`,
+                        width: `${tileSize}px`,
+                        height: `${tileSize}px`,
+                        borderRadius: "3px",
+                        backgroundColor: "#7c8288",
+                        zIndex: 12100,
+                        opacity: 0,
+                        animation: "shaperReveal 300ms ease-out both",
+                      }}
+                    />
+                  ));
+                })()}
                 {/* Bomb detonation: the three BAM frames layered and scaled up over the
                     3x3 blast, triggered in a staggered sequence for a big cartoon boom. */}
                 {(gameState.recentBombBlasts ?? []).length > 0 &&
@@ -5762,6 +5957,7 @@ function renderTileGrid(
                 | "stone-goblin"
                 | "snake"
                 | "white-goblin"
+                | "shaper"
                 | undefined
             }
             enemySwarmCount={swarmCountAtTile}

--- a/lib/bosses/shaper.ts
+++ b/lib/bosses/shaper.ts
@@ -1,0 +1,741 @@
+// The Shaper: a terrain-reshaping pursuit boss. It sits in the center chamber
+// and reshapes the ground toward you. Attacks land with a screen shake and a
+// fast outward tile-by-tile reveal. Once alerted it runs a clear strategy
+// (WATER to slow you, telegraphed FIRE to kill you, and WALLS to fence you in).
+//
+// WALLS MATTER (attacks respect and interact with them):
+//   - a lava stream MELTS the first wall it reaches into charred floor (SINGED)
+//     and STOPS — one layer only, never passing through.
+//   - a water stream STOPS at a wall (doing nothing to it) and pools to the
+//     left and right of the point of impact (if within range).
+//   - neither attack ever reshapes tiles on the far side of a wall.
+//   - the wall strategy BUILDS walls but can never seal you out: tryBuildWall
+//     only commits a wall that keeps a standable boss-neighbor reachable
+//     (heroCanReachBoss), so a melee tile always survives.
+//
+// ELEMENTS FIGHT EACH OTHER (the weapon): lava onto ANY water -> SINGED safe
+// ground; water onto lava -> SINGED; SINGED is neutral floor either element can
+// reclaim. Otherwise lava ignites bare ground (instant death; cool with a rock
+// -> obsidian), water floods bare -> shallow and DEEPENS shallow -> deep.
+//
+// FAIRNESS: the untelegraphed water/idle spew (planShaperAttack) NEVER reshapes
+// the tile you're on or the tile you're stepping into (its `spared` set), so it
+// can't kill you outright. FIRE is different: it is TELEGRAPHED one turn ahead
+// (mem.pendingFire, a warm glow) and CAN turn your tile to lethal lava when it
+// lands — but fireTargets always leaves at least one walkable escape neighbor,
+// so stepping off the telegraph is always survivable. Reaching the boss IS the
+// fight; once adjacent it takes normal melee (low HP).
+//
+// Pure/testable: imports the BehaviorContext type (erased) + TileSubtype + the
+// leaf line-of-sight helper (no cycle: line_of_sight imports nothing of ours).
+import { TileSubtype } from "../map/constants";
+import { canSee } from "../line_of_sight";
+import type { BehaviorContext } from "../enemies/registry";
+
+export const SHAPER_HP = 5;
+export const SHAPER_MAX_RANGE = 8;
+export const SHAPER_MIN_TILES = 5;
+export const SHAPER_MAX_TILES = 8;
+// Pacing. Unalerted: it hasn't spotted you — spew only every 5-6 turns (random),
+// otherwise pace or hold. Alerted (it has line-of-sight within VISION): attack
+// EVERY turn, alternating lava/water, and sometimes back away.
+export const SHAPER_VISION = 8; // Manhattan, matches the engine's enemy vision
+const SHAPER_HOME_RANGE = 5; // how far it roams from its start (stays in its chamber)
+const SHAPER_IDLE_SPEW_MIN = 5; // unalerted spew cadence: 5 or 6 turns
+const SHAPER_IDLE_PACE_CHANCE = 0.5;
+// Unalerted spews are small, local pokes around itself (it hasn't seen you yet).
+const SHAPER_IDLE_MIN_TILES = 2;
+const SHAPER_IDLE_MAX_TILES = 3;
+// Alerted strategy is a fixed cycle: squirt WATER at you twice (flood -> deepen
+// into torch-snuffing DEEP water that slows your approach), then LAUNCH FIRE
+// (telegraphed — it rockets up, glowing target tiles appear), then next turn the
+// FIRE RAINS DOWN as lethal lava on those tiles. Fire actively avoids water.
+const SHAPER_FIRE_MIN_TILES = 4;
+const SHAPER_FIRE_MAX_TILES = 6;
+const SHAPER_FIRE_WATER_HIT_CHANCE = 0.15; // fire mostly avoids water tiles
+
+// Per-encounter STRATEGY, rolled once when it first spots you (a tendency, not a
+// rigid rule — each carries the other's flavour):
+//   - DROWNING: the water-water-fire cycle; occasionally throws a lone pillar.
+//   - WALL: builds walls to fence you off (never sealing you out); when it can't
+//     extend a wall, it hurls a lava splatter instead.
+export type ShaperStrategy = "drowning" | "wall";
+const SHAPER_WALL_STRATEGY_CHANCE = 0.45; // else drowning
+const SHAPER_WALL_LAVA_MIX = 0.3; // wall strategy: chance to lob fire instead of a wall
+const SHAPER_DROWNING_PILLAR_CHANCE = 0.15; // drowning strategy: chance of a lone pillar
+
+export type ShaperElement = "lava" | "water";
+export type ShaperShape = "path" | "splatter";
+
+// A single tile change: set base FLOOR (opens a melted wall) + a single subtype.
+export interface ShaperMutation {
+  y: number;
+  x: number;
+  sub: number; // LAVA | SHALLOW_WATER | DEEP_WATER | SINGED
+}
+
+interface ShaperMemory {
+  turn?: number;
+  attacks?: number;
+  alerted?: boolean;
+  spewCountdown?: number; // turns until the next unalerted spew
+  homeY?: number; // where it started — it roams around here, doesn't leave the chamber
+  homeX?: number;
+  // Optional hard roam box (set by the arena to the chamber interior). When
+  // present it overrides the home-range roam, so an off-center boss still can't
+  // wander out through an entrance.
+  roamMinY?: number;
+  roamMaxY?: number;
+  roamMinX?: number;
+  roamMaxX?: number;
+  // Per-encounter strategy (rolled on the first alert).
+  strategy?: ShaperStrategy;
+  // Drowning strategy cycle: 0/1 = water squirts, 2 = fire launch.
+  strat?: number;
+  lastWaterTiles?: Array<[number, number]>; // so the 2nd squirt deepens the 1st
+  // Fire launched last turn; it rains down THIS turn. Rendered as a subtle warm
+  // glow while pending so the player knows which tiles to avoid.
+  pendingFire?: { tiles: Array<[number, number]> } | null;
+  fireLaunchNonce?: number; // fires the launch shake + upward-lava animation once
+  // A wall it raised this turn (for the stone-rise flash + shake).
+  lastWall?: { nonce: number; tiles: Array<[number, number]> } | null;
+  lastAttack?: { nonce: number; element: ShaperElement; tiles: Array<[number, number]> } | null;
+}
+
+const FLOOR = 0;
+const WALL = 1;
+const FLOWERS = 5;
+
+const TERRAIN_SUBS = new Set<number>([
+  TileSubtype.SHALLOW_WATER,
+  TileSubtype.DEEP_WATER,
+  TileSubtype.LAVA,
+  TileSubtype.SINGED,
+]);
+
+type TerrainState =
+  | "bare"
+  | "shallow"
+  | "deep"
+  | "lava"
+  | "singed"
+  | "object" // floor carrying a non-terrain overlay (rock/pot/chest/...) — flow past, don't touch
+  | "wall"
+  | "oob";
+
+function inBounds(grid: number[][], y: number, x: number): boolean {
+  return y >= 0 && x >= 0 && y < grid.length && x < (grid[0]?.length ?? 0);
+}
+function cheb(ay: number, ax: number, by: number, bx: number): number {
+  return Math.max(Math.abs(ay - by), Math.abs(ax - bx));
+}
+function isBorder(grid: number[][], y: number, x: number): boolean {
+  return y === 0 || x === 0 || y === grid.length - 1 || x === (grid[0]?.length ?? 0) - 1;
+}
+
+function terrainStateAt(grid: number[][], subs: number[][][], y: number, x: number): TerrainState {
+  if (!inBounds(grid, y, x)) return "oob";
+  const t = grid[y][x];
+  if (t === WALL) return "wall";
+  if (t !== FLOOR && t !== FLOWERS) return "object"; // trees/roofs etc. — never reshape
+  // The PLAYER marker is not furniture — fire must be able to rain onto the tile
+  // the hero is standing on. Classify by the terrain under the marker.
+  const s = (subs[y]?.[x] ?? []).filter((v) => v !== TileSubtype.PLAYER);
+  if (s.length === 0) return "bare";
+  if (s.some((v) => !TERRAIN_SUBS.has(v))) return "object";
+  if (s.includes(TileSubtype.LAVA)) return "lava";
+  if (s.includes(TileSubtype.DEEP_WATER)) return "deep";
+  if (s.includes(TileSubtype.SHALLOW_WATER)) return "shallow";
+  if (s.includes(TileSubtype.SINGED)) return "singed";
+  return "bare";
+}
+
+// The subtype a FLOOR tile in `state` becomes when hit by `element`, or null for
+// a no-op (lava on lava, water on deep).
+function resultSubForFloor(element: ShaperElement, state: TerrainState): number | null {
+  if (element === "lava") {
+    if (state === "shallow" || state === "deep") return TileSubtype.SINGED; // quench
+    if (state === "lava") return null;
+    return TileSubtype.LAVA; // bare / singed
+  }
+  if (state === "lava") return TileSubtype.SINGED; // douse
+  if (state === "deep") return null;
+  if (state === "shallow") return TileSubtype.DEEP_WATER; // deepen
+  return TileSubtype.SHALLOW_WATER; // bare / singed
+}
+
+function bresenham(y0: number, x0: number, y1: number, x1: number): Array<[number, number]> {
+  const pts: Array<[number, number]> = [];
+  const dx = Math.abs(x1 - x0);
+  const dy = Math.abs(y1 - y0);
+  const sx = x0 < x1 ? 1 : -1;
+  const sy = y0 < y1 ? 1 : -1;
+  let err = dx - dy;
+  let x = x0;
+  let y = y0;
+  for (let i = 0; i < 80; i++) {
+    pts.push([y, x]);
+    if (x === x1 && y === y1) break;
+    const e2 = 2 * err;
+    if (e2 > -dy) {
+      err -= dy;
+      x += sx;
+    }
+    if (e2 < dx) {
+      err += dx;
+      y += sy;
+    }
+  }
+  return pts;
+}
+
+const NEIGHBORS8: Array<[number, number]> = [
+  [-1, -1], [-1, 0], [-1, 1],
+  [0, -1], [0, 1],
+  [1, -1], [1, 0], [1, 1],
+];
+
+export function planShaperAttack(
+  shape: ShaperShape,
+  element: ShaperElement,
+  boss: { y: number; x: number },
+  hero: { y: number; x: number },
+  heroNext: { y: number; x: number },
+  grid: number[][],
+  subs: number[][][],
+  rng: () => number,
+  opts?: { minTiles?: number; maxTiles?: number }
+): ShaperMutation[] {
+  const minTiles = opts?.minTiles ?? SHAPER_MIN_TILES;
+  const maxTiles = opts?.maxTiles ?? SHAPER_MAX_TILES;
+  const spared = new Set<string>([
+    `${hero.y},${hero.x}`,
+    `${heroNext.y},${heroNext.x}`,
+    `${boss.y},${boss.x}`,
+  ]);
+  const claimed = new Set<string>();
+  const muts: ShaperMutation[] = [];
+  const state = (y: number, x: number) => terrainStateAt(grid, subs, y, x);
+
+  const addFloor = (y: number, x: number): boolean => {
+    const key = `${y},${x}`;
+    if (spared.has(key) || claimed.has(key)) return false;
+    if (cheb(y, x, boss.y, boss.x) > SHAPER_MAX_RANGE + 1) return false;
+    const st = state(y, x);
+    if (st === "wall" || st === "oob" || st === "object") return false;
+    const sub = resultSubForFloor(element, st);
+    if (sub === null) return false;
+    claimed.add(key);
+    muts.push({ y, x, sub });
+    return true;
+  };
+  // Lava melts a wall into charred floor (unless it's the map border).
+  const meltWall = (y: number, x: number): boolean => {
+    const key = `${y},${x}`;
+    if (spared.has(key) || claimed.has(key)) return false;
+    if (cheb(y, x, boss.y, boss.x) > SHAPER_MAX_RANGE + 1) return false;
+    if (isBorder(grid, y, x)) return false;
+    claimed.add(key);
+    muts.push({ y, x, sub: TileSubtype.SINGED });
+    return true;
+  };
+
+  const ray = bresenham(boss.y, boss.x, hero.y, hero.x);
+  const vertical = Math.abs(hero.y - boss.y) >= Math.abs(hero.x - boss.x);
+
+  if (shape === "path") {
+    let prev: [number, number] = [boss.y, boss.x];
+    for (let i = 1; i < ray.length; i++) {
+      const [ty, tx] = ray[i];
+      if (cheb(ty, tx, boss.y, boss.x) > SHAPER_MAX_RANGE) break;
+      if (spared.has(`${ty},${tx}`)) break; // reached the hero — stop before them
+      const st = state(ty, tx);
+      if (st === "oob") break;
+      if (st === "wall") {
+        if (element === "lava") {
+          meltWall(ty, tx); // char one layer...
+        } else {
+          // water: pool left/right of the last floor tile before the wall
+          const [py, px] = prev;
+          const flanks: Array<[number, number]> = vertical
+            ? [[py, px - 1], [py, px + 1]]
+            : [[py - 1, px], [py + 1, px]];
+          for (const [fy, fx] of flanks) addFloor(fy, fx);
+        }
+        break; // ...and NEVER pass through
+      }
+      if (st === "object") {
+        prev = [ty, tx];
+        continue; // flow past a rock/pot without touching it
+      }
+      addFloor(ty, tx);
+      prev = [ty, tx];
+    }
+    // a little splatter off the far (hero-side) end
+    let tries = 0;
+    while (muts.length < minTiles && tries < 16) {
+      const [oy, ox] = NEIGHBORS8[Math.floor(rng() * NEIGHBORS8.length)] ?? [0, 1];
+      addFloor(prev[0] + oy, prev[1] + ox);
+      tries++;
+    }
+    return orderFrom(boss.y, boss.x, muts, maxTiles);
+  }
+
+  // SPLATTER: trace the ray to the impact (stopping at the first wall/range), then
+  // scatter a blob there. Lava chars any walls it splatters onto; water skips them.
+  let impact: [number, number] = [boss.y, boss.x];
+  for (let i = 1; i < ray.length; i++) {
+    const [ty, tx] = ray[i];
+    if (cheb(ty, tx, boss.y, boss.x) > SHAPER_MAX_RANGE) break;
+    if (spared.has(`${ty},${tx}`)) break;
+    const st = state(ty, tx);
+    if (st === "wall" || st === "oob") break;
+    if (st === "object") {
+      impact = [ty, tx];
+      continue;
+    }
+    impact = [ty, tx];
+  }
+  addFloor(impact[0], impact[1]);
+  const target = minTiles + Math.floor(rng() * (maxTiles - minTiles + 1));
+  let tries = 0;
+  while (muts.length < target && tries < 40) {
+    const oy = Math.floor(rng() * 5) - 2;
+    const ox = Math.floor(rng() * 5) - 2;
+    const qy = impact[0] + oy;
+    const qx = impact[1] + ox;
+    const st = state(qy, qx);
+    if (st === "wall") {
+      if (element === "lava") meltWall(qy, qx); // lava splatter chars walls
+    } else {
+      addFloor(qy, qx);
+    }
+    tries++;
+  }
+  return orderFrom(impact[0], impact[1], muts, maxTiles);
+}
+
+function orderFrom(oy: number, ox: number, muts: ShaperMutation[], maxTiles: number): ShaperMutation[] {
+  return [...muts].sort((a, b) => cheb(a.y, a.x, oy, ox) - cheb(b.y, b.x, oy, ox)).slice(0, maxTiles);
+}
+
+// Apply mutations to the live map: open a melted wall to floor, set the subtype.
+export function executeShaperAttack(
+  muts: ShaperMutation[],
+  grid: number[][],
+  subs: number[][][]
+): void {
+  for (const { y, x, sub } of muts) {
+    if (!inBounds(grid, y, x)) continue;
+    grid[y][x] = FLOOR; // no-op for floor tiles; opens a lava-melted wall
+    // Preserve the hero marker if fire/water reshapes the tile they're on, so
+    // the engine can still locate (and, on lava, kill) them.
+    const hadPlayer = (subs[y][x] ?? []).includes(TileSubtype.PLAYER);
+    subs[y][x] = hadPlayer ? [sub, TileSubtype.PLAYER] : [sub];
+  }
+}
+
+// Reshape a specific list of tiles with one element (used by the water second
+// squirt to deepen, and by the fire rain-down to ignite). Skips walls/objects.
+function floodTiles(
+  element: ShaperElement,
+  tiles: Array<[number, number]>,
+  grid: number[][],
+  subs: number[][][]
+): ShaperMutation[] {
+  const muts: ShaperMutation[] = [];
+  for (const [y, x] of tiles) {
+    const st = terrainStateAt(grid, subs, y, x);
+    if (st === "wall" || st === "oob" || st === "object") continue;
+    const sub = resultSubForFloor(element, st);
+    if (sub !== null) muts.push({ y, x, sub });
+  }
+  return muts;
+}
+
+// Fire target tiles: a blob raining down around `aim`, actively AVOIDING water
+// (a lava-on-water hit just makes safe ground, so it's a wasted kill). Includes
+// the aim tile itself — the telegraph is the fair warning to step off. Never the
+// boss's own tile. Ordered outward for the reveal sweep.
+export function fireTargets(
+  boss: { y: number; x: number },
+  aim: { y: number; x: number },
+  grid: number[][],
+  subs: number[][][],
+  rng: () => number
+): Array<[number, number]> {
+  const out: Array<[number, number]> = [];
+  const seen = new Set<string>([`${boss.y},${boss.x}`]);
+  const consider = (y: number, x: number) => {
+    const key = `${y},${x}`;
+    if (seen.has(key)) return;
+    if (cheb(y, x, boss.y, boss.x) > SHAPER_MAX_RANGE) return;
+    const st = terrainStateAt(grid, subs, y, x);
+    if (st === "wall" || st === "oob" || st === "object") return;
+    if ((st === "shallow" || st === "deep") && rng() > SHAPER_FIRE_WATER_HIT_CHANCE) return;
+    seen.add(key);
+    out.push([y, x]);
+  };
+  consider(aim.y, aim.x);
+  const target = SHAPER_FIRE_MIN_TILES + Math.floor(rng() * (SHAPER_FIRE_MAX_TILES - SHAPER_FIRE_MIN_TILES + 1));
+  let tries = 0;
+  while (out.length < target && tries < 50) {
+    consider(aim.y + Math.floor(rng() * 5) - 2, aim.x + Math.floor(rng() * 5) - 2);
+    tries++;
+  }
+  // Fairness guard: the telegraph must always leave a way out. If every
+  // walkable, non-lava orthogonal neighbor of the aim tile is targeted (as can
+  // happen in a 1-wide corridor), the fire would rain down with no survivable
+  // step -> an unavoidable death. Spare one such neighbor so a hero on the aim
+  // tile can always dodge off the telegraph.
+  const isEscape = (y: number, x: number): boolean => {
+    const st = terrainStateAt(grid, subs, y, x);
+    if (st === "wall" || st === "oob" || st === "object") return false;
+    const s = subs[y]?.[x] ?? [];
+    if (s.includes(TileSubtype.LAVA) && !s.includes(TileSubtype.OBSIDIAN)) return false;
+    return true;
+  };
+  const escapeNeighbors = ([[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>)
+    .map(([dy, dx]) => [aim.y + dy, aim.x + dx] as [number, number])
+    .filter(([y, x]) => isEscape(y, x));
+  const targeted = new Set(out.map(([y, x]) => `${y},${x}`));
+  const hasEscape = escapeNeighbors.some(([y, x]) => !targeted.has(`${y},${x}`));
+  if (!hasEscape && escapeNeighbors.length > 0) {
+    const [sy, sx] = escapeNeighbors[0];
+    const idx = out.findIndex(([y, x]) => y === sy && x === sx);
+    if (idx >= 0) out.splice(idx, 1);
+  }
+  return out.sort((a, b) => cheb(a[0], a[1], aim.y, aim.x) - cheb(b[0], b[1], aim.y, aim.x));
+}
+
+// --- Wall strategy: build walls, but NEVER seal the hero out ---
+
+// Can the hero physically get to a tile from which they could strike the boss?
+// Treats WALL, LAVA and OPEN_ABYSS as blockers; water/singed/objects are
+// crossable (the hero wades/smashes). `blockTile` (a candidate new wall) is
+// treated as blocked. Success = the hero can STAND ON a tile orthogonally
+// adjacent to the boss — i.e. an attack tile that is itself passable. A walled
+// (or lava/abyss) boss-neighbor is NOT a valid attack tile; if the boss's every
+// neighbor is unstandable it is sealed in and this returns false, which is
+// exactly what stops tryBuildWall from placing the entombing wall.
+function heroCanReachBoss(
+  grid: number[][],
+  subs: number[][][],
+  hero: { y: number; x: number },
+  boss: { y: number; x: number },
+  blockTile?: [number, number]
+): boolean {
+  const rows = grid.length;
+  const cols = grid[0]?.length ?? 0;
+  const passable = (y: number, x: number): boolean => {
+    if (y < 0 || x < 0 || y >= rows || x >= cols) return false;
+    if (blockTile && y === blockTile[0] && x === blockTile[1]) return false;
+    if (grid[y][x] !== FLOOR && grid[y][x] !== FLOWERS) return false;
+    const s = subs[y]?.[x] ?? [];
+    if (s.includes(TileSubtype.LAVA) && !s.includes(TileSubtype.OBSIDIAN)) return false;
+    if (s.includes(TileSubtype.OPEN_ABYSS)) return false;
+    return true;
+  };
+  // Goals are the boss's orthogonal neighbors the hero could actually stand on.
+  const goals = new Set<string>();
+  for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>) {
+    const gy = boss.y + dy;
+    const gx = boss.x + dx;
+    if (passable(gy, gx)) goals.add(`${gy},${gx}`);
+  }
+  if (goals.size === 0) return false; // boss sealed in: no standable attack tile
+  // BFS from the hero's tile (start passability not required — they're there);
+  // success only when we actually reach (stand on) a standable attack tile.
+  if (goals.has(`${hero.y},${hero.x}`)) return true;
+  const seen = new Set<string>([`${hero.y},${hero.x}`]);
+  const q: Array<[number, number]> = [[hero.y, hero.x]];
+  while (q.length) {
+    const [y, x] = q.shift()!;
+    for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>) {
+      const ny = y + dy;
+      const nx = x + dx;
+      const k = `${ny},${nx}`;
+      if (seen.has(k)) continue;
+      if (!passable(ny, nx)) continue; // must be standable to step onto
+      if (goals.has(k)) return true; // reached a standable attack tile
+      seen.add(k);
+      q.push([ny, nx]);
+    }
+  }
+  return false;
+}
+
+// Ordered wall candidates: tiles on the boss's perimeter toward the hero (block
+// the approach), then its other sides (extend a partial ring), then one tile
+// further out toward the hero.
+function wallCandidates(
+  boss: { y: number; x: number },
+  hero: { y: number; x: number }
+): Array<[number, number]> {
+  const ty = Math.sign(hero.y - boss.y);
+  const tx = Math.sign(hero.x - boss.x);
+  const list: Array<[number, number]> = [];
+  if (ty !== 0) list.push([boss.y + ty, boss.x]);
+  if (tx !== 0) list.push([boss.y, boss.x + tx]);
+  if (ty !== 0 && tx !== 0) list.push([boss.y + ty, boss.x + tx]);
+  list.push([boss.y - 1, boss.x], [boss.y + 1, boss.x], [boss.y, boss.x - 1], [boss.y, boss.x + 1]);
+  if (ty !== 0) list.push([boss.y + 2 * ty, boss.x]);
+  if (tx !== 0) list.push([boss.y, boss.x + 2 * tx]);
+  const seen = new Set<string>();
+  return list.filter(([y, x]) => {
+    const k = `${y},${x}`;
+    if (seen.has(k)) return false;
+    seen.add(k);
+    return true;
+  });
+}
+
+// Try to raise one wall that impedes the hero without sealing them out. Returns
+// true if a wall was built.
+function tryBuildWall(
+  ctx: BehaviorContext,
+  mem: ShaperMemory,
+  hero: { y: number; x: number },
+  heroNext: { y: number; x: number },
+  boss: { y: number; x: number }
+): boolean {
+  const grid = ctx.grid;
+  const subs = ctx.subtypes;
+  if (!subs) return false;
+  for (const [y, x] of wallCandidates(boss, hero)) {
+    if ((y === hero.y && x === hero.x) || (y === heroNext.y && x === heroNext.x)) continue;
+    if (y === boss.y && x === boss.x) continue;
+    const st = terrainStateAt(grid, subs, y, x);
+    if (st !== "bare" && st !== "singed") continue; // build only on dry ground
+    if (!heroCanReachBoss(grid, subs, hero, boss, [y, x])) continue; // never seal the hero out
+    grid[y][x] = WALL;
+    subs[y][x] = [];
+    mem.lastWall = { nonce: mem.turn ?? 0, tiles: [[y, x]] };
+    return true;
+  }
+  return false;
+}
+
+// Telegraph a fire (used by both strategies): pick rain-down targets around the
+// aim tile and mark them pending; they land next turn.
+function launchFire(
+  ctx: BehaviorContext,
+  mem: ShaperMemory,
+  boss: { y: number; x: number },
+  aim: { y: number; x: number },
+  rng: () => number
+): void {
+  const subs = ctx.subtypes;
+  if (!subs) return;
+  const tiles = fireTargets(boss, aim, ctx.grid, subs, rng);
+  mem.pendingFire = tiles.length > 0 ? { tiles } : null;
+  if (tiles.length > 0) mem.fireLaunchNonce = mem.turn;
+}
+
+// A tile the boss may stand on while pacing/retreating: floor/flowers, safe
+// (never lava or deep water), inside its home range, not the hero's tile/step.
+function bossCanStand(
+  ctx: BehaviorContext,
+  mem: ShaperMemory,
+  hero: { y: number; x: number },
+  heroNext: { y: number; x: number },
+  y: number,
+  x: number
+): boolean {
+  const grid = ctx.grid;
+  if (y < 0 || x < 0 || y >= grid.length || x >= (grid[0]?.length ?? 0)) return false;
+  const t = grid[y][x];
+  if (t !== FLOOR && t !== FLOWERS) return false;
+  const s = ctx.subtypes?.[y]?.[x] ?? [];
+  if (s.some((v) => !TERRAIN_SUBS.has(v))) return false; // object on the tile
+  if (s.includes(TileSubtype.LAVA) || s.includes(TileSubtype.DEEP_WATER)) return false;
+  if ((y === hero.y && x === hero.x) || (y === heroNext.y && x === heroNext.x)) return false;
+  if (mem.roamMinY != null) {
+    // Hard roam box (chamber interior) — keeps an off-center boss from leaving.
+    if (y < mem.roamMinY || y > (mem.roamMaxY ?? y) || x < (mem.roamMinX ?? x) || x > (mem.roamMaxX ?? x)) {
+      return false;
+    }
+  } else {
+    const hy = mem.homeY ?? y;
+    const hx = mem.homeX ?? x;
+    if (cheb(y, x, hy, hx) > SHAPER_HOME_RANGE) return false;
+  }
+  return true;
+}
+
+function tryStep(
+  ctx: BehaviorContext,
+  mem: ShaperMemory,
+  hero: { y: number; x: number },
+  heroNext: { y: number; x: number },
+  candidates: Array<[number, number]>
+): boolean {
+  for (const [dy, dx] of candidates) {
+    if (dy === 0 && dx === 0) continue;
+    const ny = ctx.enemy.y + dy;
+    const nx = ctx.enemy.x + dx;
+    if (bossCanStand(ctx, mem, hero, heroNext, ny, nx)) {
+      ctx.enemy.y = ny;
+      ctx.enemy.x = nx;
+      ctx.enemy.facing = Math.abs(dy) >= Math.abs(dx) ? (dy < 0 ? "UP" : "DOWN") : dx < 0 ? "LEFT" : "RIGHT";
+      return true;
+    }
+  }
+  return false;
+}
+
+// An UNALERTED idle spew: a small local SPLATTER (2-3 tiles) centered on itself,
+// alternating element — ambient reshaping while it hasn't spotted you, kept
+// small so it rarely reaches the walls. (The alerted water/fire strategy lives
+// inline in shaperUpdate.)
+function idleSpew(
+  ctx: BehaviorContext,
+  mem: ShaperMemory,
+  rng: () => number
+): void {
+  const subs = ctx.subtypes;
+  if (!subs) return;
+  const n = mem.attacks ?? 0;
+  const element: ShaperElement = n % 2 === 0 ? "lava" : "water";
+  const boss = { y: ctx.enemy.y, x: ctx.enemy.x };
+  // Aim at itself (boss = hero) so the blob scatters locally, small.
+  const muts = planShaperAttack("splatter", element, boss, boss, boss, ctx.grid, subs, rng, {
+    minTiles: SHAPER_IDLE_MIN_TILES,
+    maxTiles: SHAPER_IDLE_MAX_TILES,
+  });
+  if (muts.length > 0) {
+    executeShaperAttack(muts, ctx.grid, subs);
+    mem.lastAttack = { nonce: (mem.turn ?? 0) * 100 + n, element, tiles: muts.map((m) => [m.y, m.x]) };
+  }
+  mem.attacks = n + 1;
+}
+
+export function shaperUpdate(ctx: BehaviorContext): number {
+  const mem = ctx.enemy.memory as ShaperMemory;
+  const subs = ctx.subtypes;
+  if (!subs) return 0;
+  if (mem.homeY == null) {
+    mem.homeY = ctx.enemy.y;
+    mem.homeX = ctx.enemy.x;
+  }
+  const boss = { y: ctx.enemy.y, x: ctx.enemy.x };
+  const hero = { y: ctx.player.y, x: ctx.player.x };
+  const heroNext = ctx.playerNext ?? hero;
+  const rng = ctx.rng ?? (() => 0.5);
+  mem.turn = (mem.turn ?? 0) + 1;
+
+  // Face the hero (cosmetic; overwritten by a move below if it steps).
+  const dy = hero.y - boss.y;
+  const dx = hero.x - boss.x;
+  ctx.enemy.facing =
+    Math.abs(dy) >= Math.abs(dx) ? (dy < 0 ? "UP" : "DOWN") : dx < 0 ? "LEFT" : "RIGHT";
+
+  // Latch the alert state once it gets line-of-sight within vision range, and
+  // roll a per-encounter strategy (unless one was pre-set).
+  if (!mem.alerted) {
+    const inRange = Math.abs(dy) + Math.abs(dx) <= SHAPER_VISION;
+    if (inRange && canSee(ctx.grid, [boss.y, boss.x], [hero.y, hero.x])) {
+      mem.alerted = true;
+      if (mem.strategy == null) {
+        mem.strategy = rng() < SHAPER_WALL_STRATEGY_CHANCE ? "wall" : "drowning";
+      }
+    }
+  }
+
+  if (mem.alerted) {
+    // A fire launched last turn RAINS DOWN now (before the hero's move), turning
+    // the telegraphed tiles to lethal lava. The player had this turn's warning.
+    if (mem.pendingFire) {
+      const muts = floodTiles("lava", mem.pendingFire.tiles, ctx.grid, subs);
+      if (muts.length > 0) {
+        executeShaperAttack(muts, ctx.grid, subs);
+        mem.lastAttack = { nonce: (mem.turn ?? 0) * 100 + 9, element: "lava", tiles: muts.map((m) => [m.y, m.x]) };
+      }
+      mem.pendingFire = null;
+      return 0;
+    }
+
+    if (mem.strategy === "wall") {
+      // WALL: raise a wall to fence you off; if it can't extend one (would seal
+      // you out, or no dry ground) — or on its lava-mix tendency — it lobs fire.
+      const wantsFire = rng() < SHAPER_WALL_LAVA_MIX;
+      const built = wantsFire ? false : tryBuildWall(ctx, mem, hero, heroNext, boss);
+      if (!built) launchFire(ctx, mem, boss, heroNext, rng);
+      return 0;
+    }
+
+    // DROWNING: occasionally a lone pillar to mix it up, else the water cycle.
+    if (rng() < SHAPER_DROWNING_PILLAR_CHANCE && tryBuildWall(ctx, mem, hero, heroNext, boss)) {
+      return 0;
+    }
+    const strat = mem.strat ?? 0;
+    if (strat === 0) {
+      // Water squirt #1: flood the hero's ground (floor -> shallow).
+      const muts = planShaperAttack("splatter", "water", boss, heroNext, heroNext, ctx.grid, subs, rng);
+      if (muts.length > 0) {
+        executeShaperAttack(muts, ctx.grid, subs);
+        mem.lastWaterTiles = muts.map((m) => [m.y, m.x]);
+        mem.lastAttack = { nonce: (mem.turn ?? 0) * 100, element: "water", tiles: mem.lastWaterTiles };
+      }
+      mem.strat = 1;
+    } else if (strat === 1) {
+      // Water squirt #2: deepen the same tiles into torch-snuffing DEEP water.
+      const muts = floodTiles("water", mem.lastWaterTiles ?? [], ctx.grid, subs);
+      if (muts.length > 0) {
+        executeShaperAttack(muts, ctx.grid, subs);
+        mem.lastAttack = { nonce: (mem.turn ?? 0) * 100 + 1, element: "water", tiles: muts.map((m) => [m.y, m.x]) };
+      }
+      mem.strat = 2;
+    } else {
+      // Fire launch: pick rain-down targets (avoiding water) and telegraph them.
+      launchFire(ctx, mem, boss, heroNext, rng);
+      mem.strat = 0;
+    }
+    return 0;
+  }
+
+  // Unalerted: spew only every 5-6 turns (small local pokes); otherwise pace/hold.
+  if (mem.spewCountdown == null) mem.spewCountdown = SHAPER_IDLE_SPEW_MIN + Math.floor(rng() * 2);
+  mem.spewCountdown -= 1;
+  if (mem.spewCountdown <= 0) {
+    idleSpew(ctx, mem, rng);
+    mem.spewCountdown = SHAPER_IDLE_SPEW_MIN + Math.floor(rng() * 2); // 5 or 6
+  } else if (rng() < SHAPER_IDLE_PACE_CHANCE) {
+    // Pace to a random adjacent safe tile within its chamber.
+    const dirs: Array<[number, number]> = [[-1, 0], [1, 0], [0, -1], [0, 1]];
+    const start = Math.floor(rng() * 4);
+    const order = [0, 1, 2, 3].map((i) => dirs[(start + i) % 4]);
+    tryStep(ctx, mem, hero, heroNext, order);
+  }
+  return 0;
+}
+
+export function shaperRevealTiles(
+  mem: ShaperMemory | undefined
+): { nonce: number; element: ShaperElement; tiles: Array<[number, number]> } | null {
+  if (!mem?.lastAttack || !mem.lastAttack.tiles.length) return null;
+  return mem.lastAttack;
+}
+
+// Render hook: tiles where fire will RAIN DOWN next turn — draw a subtle warm
+// glow so the player knows to step off. Null when no fire is pending.
+export function shaperPendingFire(
+  mem: ShaperMemory | undefined
+): Array<[number, number]> | null {
+  if (!mem?.pendingFire || !mem.pendingFire.tiles.length) return null;
+  return mem.pendingFire.tiles;
+}
+
+// Render hook: a one-shot nonce set the turn fire launches (for the upward-lava
+// animation + shake).
+export function shaperFireLaunch(mem: ShaperMemory | undefined): number | null {
+  return typeof mem?.fireLaunchNonce === "number" ? mem.fireLaunchNonce : null;
+}
+
+// Render hook: a wall the Shaper just raised (for the stone-rise flash + shake).
+export function shaperWallReveal(
+  mem: ShaperMemory | undefined
+): { nonce: number; tiles: Array<[number, number]> } | null {
+  if (!mem?.lastWall || !mem.lastWall.tiles.length) return null;
+  return mem.lastWall;
+}

--- a/lib/bosses/shaper_arena.ts
+++ b/lib/bosses/shaper_arena.ts
@@ -1,0 +1,189 @@
+// Shaper arenas: a 25x25 keep. FOUR concentric hall tiers (1-wide corridors, one
+// space apart) wrap an open 7x7 center where the Shaper waits. The tiers form a
+// difficulty gradient:
+//   - OUTER tiers (rings at dist 8 & 10): randomized, misaligned, NARROW (1-wide)
+//     gaps -> a real maze; hard to navigate, and you can't sneak straight in.
+//   - INNER tiers (rings at dist 4 & 6): ALIGNED, WIDER (3-wide) gaps on all four
+//     sides -> straight sightlines from the center out to the inner halls, so the
+//     Shaper sees you coming and you can't sneak up on it.
+// Ring walls sit at dist 4/6/8/10 (border 12); corridors at dist 5/7/9/11; the
+// center (dist <=3, rows/cols 9-15) is the open 7x7 room. The Shaper's lava melts
+// walls as it fights, opening the maze further.
+//
+// Split from shaper.ts so the Enemy/GameState value imports never cycle back
+// through the registry. Gap RNG defaults to Math.random; tests pass a seed.
+import { Enemy } from "../enemy";
+import { TileSubtype, Direction } from "../map/constants";
+import type { GameState } from "../map/game-state";
+
+const FLOOR = 0;
+const WALL = 1;
+const SIZE = 25;
+const CENTER = 12;
+const CENTER_LO = 9; // open 7x7 center / boss roam box: rows/cols 9-15
+const CENTER_HI = 15;
+
+export interface ShaperLayout {
+  name: string;
+  seed: "water" | "lava";
+}
+
+export const SHAPER_LAYOUTS: ShaperLayout[] = [
+  { name: "The Sunken Keep", seed: "water" },
+  { name: "The Ember Keep", seed: "lava" },
+];
+
+export type ShaperEntry = "north" | "south" | "east" | "west";
+export const SHAPER_ENTRIES: ShaperEntry[] = ["north", "south", "east", "west"];
+
+const ENTRY_HERO: Record<ShaperEntry, [number, number]> = {
+  south: [23, 12],
+  north: [1, 12],
+  east: [12, 23],
+  west: [12, 1],
+};
+
+type Grid = number[][];
+type Subs = number[][][];
+type Side = "N" | "S" | "E" | "W";
+const SIDES: Side[] = ["N", "S", "E", "W"];
+
+// Gap coords for a side of the ring at `dist`. Narrow = the single center tile;
+// wide = that tile plus its two neighbours along the wall.
+function gapCoords(dist: number, side: Side, wide: boolean): Array<[number, number]> {
+  const spread = wide ? [-1, 0, 1] : [0];
+  if (side === "N") return spread.map((d) => [CENTER - dist, CENTER + d] as [number, number]);
+  if (side === "S") return spread.map((d) => [CENTER + dist, CENTER + d] as [number, number]);
+  if (side === "W") return spread.map((d) => [CENTER + d, CENTER - dist] as [number, number]);
+  return spread.map((d) => [CENTER + d, CENTER + dist] as [number, number]); // E
+}
+
+function shuffle<T>(arr: T[], rng: () => number): T[] {
+  const a = [...arr];
+  for (let i = a.length - 1; i > 0; i--) {
+    const j = Math.floor(rng() * (i + 1));
+    [a[i], a[j]] = [a[j], a[i]];
+  }
+  return a;
+}
+
+// 1-2 random sides, excluding the neighbouring ring's sides (so outer tiers
+// misalign and you must go around).
+function chooseSides(rng: () => number, exclude: Set<Side>): Side[] {
+  const avail = SIDES.filter((s) => !exclude.has(s));
+  const count = Math.min(avail.length, 1 + Math.floor(rng() * 2));
+  return shuffle(avail, rng).slice(0, count);
+}
+
+function drawRing(tiles: Grid, dist: number, gaps: Array<[number, number]>): void {
+  const lo = CENTER - dist;
+  const hi = CENTER + dist;
+  const gapSet = new Set(gaps.map(([y, x]) => `${y},${x}`));
+  for (let i = lo; i <= hi; i++) {
+    for (const [yy, xx] of [[lo, i], [hi, i], [i, lo], [i, hi]] as Array<[number, number]>) {
+      if (!gapSet.has(`${yy},${xx}`)) tiles[yy][xx] = WALL;
+    }
+  }
+}
+
+function seedChamberTerrain(subtypes: Subs, seed: "water" | "lava"): void {
+  const put = (y: number, x: number, sub: number) => {
+    if (y === CENTER && x === CENTER) return;
+    subtypes[y][x] = [sub];
+  };
+  if (seed === "water") {
+    for (let y = 10; y <= 12; y++) for (let x = 10; x <= 11; x++) put(y, x, TileSubtype.SHALLOW_WATER);
+    put(11, 10, TileSubtype.DEEP_WATER);
+    put(13, 14, TileSubtype.LAVA);
+    put(14, 13, TileSubtype.LAVA);
+  } else {
+    for (let y = 10; y <= 12; y++) put(y, 13, TileSubtype.LAVA);
+    put(13, 13, TileSubtype.LAVA);
+    put(14, 10, TileSubtype.SHALLOW_WATER);
+    put(14, 11, TileSubtype.SHALLOW_WATER);
+  }
+}
+
+// Loot on the corridor loops (odd distances) — never on a ring wall, so it
+// always lands on floor whatever the gap rng does.
+const RING_ROCKS: Array<[number, number]> = [
+  [23, 7], [23, 17], [1, 7], [1, 17], [7, 1], [7, 23], [17, 1], [17, 23], [3, 3], [21, 21], [5, 19], [19, 5],
+];
+const RING_POTS: Array<[number, number]> = [
+  [3, 7], [21, 17], [7, 3], [17, 21],
+];
+
+function scatterLoot(tiles: Grid, subtypes: Subs): void {
+  for (const [y, x] of RING_ROCKS) {
+    if (tiles[y]?.[x] === FLOOR && subtypes[y][x].length === 0) subtypes[y][x] = [TileSubtype.ROCK];
+  }
+  for (const [y, x] of RING_POTS) {
+    if (tiles[y]?.[x] === FLOOR && subtypes[y][x].length === 0) subtypes[y][x] = [TileSubtype.POT];
+  }
+}
+
+export function buildShaperArena(
+  layout: ShaperLayout,
+  entry: ShaperEntry = "south",
+  rng: () => number = Math.random
+): GameState {
+  const tiles: Grid = Array.from({ length: SIZE }, () => Array.from({ length: SIZE }, () => WALL));
+  const subtypes: Subs = Array.from({ length: SIZE }, () =>
+    Array.from({ length: SIZE }, () => [] as number[])
+  );
+  for (let y = 1; y < SIZE - 1; y++) for (let x = 1; x < SIZE - 1; x++) tiles[y][x] = FLOOR;
+
+  // Outer maze tiers: narrow, random, misaligned.
+  const s10 = chooseSides(rng, new Set());
+  const s8 = chooseSides(rng, new Set(s10));
+  drawRing(tiles, 10, s10.flatMap((s) => gapCoords(10, s, false)));
+  drawRing(tiles, 8, s8.flatMap((s) => gapCoords(8, s, false)));
+  // Inner tiers: wide, aligned, all four sides -> the boss can see you coming.
+  drawRing(tiles, 6, SIDES.flatMap((s) => gapCoords(6, s, true)));
+  drawRing(tiles, 4, SIDES.flatMap((s) => gapCoords(4, s, true)));
+
+  seedChamberTerrain(subtypes, layout.seed);
+  scatterLoot(tiles, subtypes);
+
+  for (const [y, x] of [
+    [0, 6], [0, 18], [SIZE - 1, 6], [SIZE - 1, 18], [6, 0], [18, 0], [6, SIZE - 1], [18, SIZE - 1],
+  ] as Array<[number, number]>) {
+    subtypes[y][x] = [TileSubtype.WALL_TORCH];
+  }
+
+  const [hy, hx] = ENTRY_HERO[entry];
+  subtypes[hy][hx] = [TileSubtype.PLAYER];
+
+  tiles[CENTER][CENTER] = FLOOR;
+  subtypes[CENTER][CENTER] = [];
+  const shaper = new Enemy({ y: CENTER, x: CENTER });
+  shaper.kind = "shaper";
+  const mem = shaper.behaviorMemory as Record<string, unknown>;
+  mem.roamMinY = CENTER_LO;
+  mem.roamMaxY = CENTER_HI;
+  mem.roamMinX = CENTER_LO;
+  mem.roamMaxX = CENTER_HI;
+
+  return {
+    hasKey: false,
+    hasExitKey: false,
+    hasSword: true,
+    hasShield: false,
+    showFullMap: true,
+    win: false,
+    playerDirection: Direction.UP,
+    enemies: [shaper],
+    heroHealth: 5,
+    heroMaxHealth: 5,
+    heroAttack: 1,
+    heroTorchLit: true,
+    rockCount: 2,
+    runeCount: 0,
+    foodCount: 0,
+    potionCount: 0,
+    stats: { damageDealt: 0, damageTaken: 0, enemiesDefeated: 0, steps: 0 },
+    mapData: { tiles, subtypes, environment: "cave" },
+    recentDeaths: [],
+    mode: "normal",
+  };
+}

--- a/lib/enemies/registry.ts
+++ b/lib/enemies/registry.ts
@@ -2,7 +2,8 @@
 import { canSee } from "../line_of_sight";
 import { TileSubtype } from "../map/constants";
 import { orderPursuitSteps } from "./pursuit";
-export type EnemyKind = "fire-goblin" | "water-goblin" | "water-goblin-spear" | "earth-goblin" | "earth-goblin-knives" | "pink-goblin" | "ghost" | "stone-goblin" | "snake" | "white-goblin";
+import { shaperUpdate, SHAPER_HP } from "../bosses/shaper";
+export type EnemyKind = "fire-goblin" | "water-goblin" | "water-goblin-spear" | "earth-goblin" | "earth-goblin-knives" | "pink-goblin" | "ghost" | "stone-goblin" | "snake" | "white-goblin" | "shaper";
 
 export type Facing = "front" | "left" | "right" | "back";
 
@@ -1087,6 +1088,26 @@ export const EnemyRegistry: Record<EnemyKind, EnemyConfig> = {
         }
         return 0;
       },
+    },
+  },
+  "shaper": {
+    kind: "shaper",
+    displayName: "The Shaper",
+    assets: {
+      // Placeholder art: reuse the pink-goblin (magician) sprite, tinted via a
+      // kind filter in Tile.tsx until dedicated Shaper art exists.
+      front: "/images/enemies/fire-goblin/pink-goblin-ringless-front.png",
+      left: "/images/enemies/fire-goblin/pink-goblin-ringless-left.png",
+      right: "/images/enemies/fire-goblin/pink-goblin-ringless-left.png",
+      back: "/images/enemies/fire-goblin/pink-goblin-ringless-back.png",
+    },
+    base: { health: SHAPER_HP, attack: 0 },
+    // Standard melee: once you fight through its terrain and reach it, it dies
+    // like anything else (low HP). The challenge is the crossing, not the kill.
+    calcMeleeDamage: ({ heroAttack, swordBonus, variance }) =>
+      clampMin(heroAttack + swordBonus + variance),
+    behavior: {
+      customUpdate: shaperUpdate,
     },
   },
 };

--- a/lib/enemy.ts
+++ b/lib/enemy.ts
@@ -51,12 +51,12 @@ export class Enemy {
   facing: 'UP' | 'RIGHT' | 'DOWN' | 'LEFT' = 'DOWN';
   // Basic species/kind classification for behavior and rendering tweaks
   // 'fire-goblin' default; 'ghost' steals the hero's light when adjacent; 'stone-goblin' special hunter; 'snake' poisons
-  private _kind: 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin' = 'fire-goblin';
+  private _kind: 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin' | 'shaper' = 'fire-goblin';
   // Per-enemy memory bag for registry-driven behaviors
   private _behaviorMem: Record<string, unknown> = {};
   get behaviorMemory(): Record<string, unknown> { return this._behaviorMem; }
-  get kind(): 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin' { return this._kind; }
-  set kind(k: 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin') {
+  get kind(): 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin' | 'shaper' { return this._kind; }
+  set kind(k: 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin' | 'shaper') {
     this._kind = k;
     if (k === 'ghost') {
       // Ghosts are fragile and do not deal contact damage.
@@ -99,6 +99,12 @@ export class Enemy {
       // also updates maxHealth so the HUD reflects the buffed baseline.
       this.health = 1;
       this.attack = 1;
+    } else if (k === 'shaper') {
+      // The Shaper boss: low HP (reaching it is the challenge, not out-damaging
+      // it). attack 0 — it never deals contact damage; its weapon is the terrain
+      // it reshapes. Melee against it uses the standard formula (see registry).
+      this.health = 5;
+      this.attack = 0;
     }
     this.maxHealth = this.health;
   }
@@ -355,7 +361,7 @@ function isSafeFloorForEnemy(
   subtypes: number[][][] | undefined,
   y: number,
   x: number,
-  kind: 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin',
+  kind: 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin' | 'shaper',
   isChasing: boolean = false
 ): boolean {
   if (!isInBounds(grid, y, x)) return false;
@@ -483,8 +489,8 @@ export type PlainEnemy = {
   id?: string;
   y: number;
   x: number;
-  kind?: 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin';
-  _kind?: 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin';
+  kind?: 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin' | 'shaper';
+  _kind?: 'fire-goblin' | 'water-goblin' | 'water-goblin-spear' | 'earth-goblin' | 'earth-goblin-knives' | 'pink-goblin' | 'ghost' | 'stone-goblin' | 'snake' | 'white-goblin' | 'shaper';
   health?: number;
   attack?: number;
   facing?: 'UP' | 'RIGHT' | 'DOWN' | 'LEFT';
@@ -507,7 +513,7 @@ export function rehydrateEnemies(list: PlainEnemy[]): Enemy[] {
     // Migration: old saved games may have legacy kind names
     if (k === 'goblin') k = 'fire-goblin';
     if (k === 'stone-exciter') k = 'stone-goblin';
-    if (k === 'ghost' || k === 'stone-goblin' || k === 'fire-goblin' || k === 'water-goblin' || k === 'water-goblin-spear' || k === 'earth-goblin' || k === 'earth-goblin-knives' || k === 'pink-goblin' || k === 'snake' || k === 'white-goblin') {
+    if (k === 'ghost' || k === 'stone-goblin' || k === 'fire-goblin' || k === 'water-goblin' || k === 'water-goblin-spear' || k === 'earth-goblin' || k === 'earth-goblin-knives' || k === 'pink-goblin' || k === 'snake' || k === 'white-goblin' || k === 'shaper') {
       e.kind = k;
     }
     // Preserve health/attack if present after kind effects

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -2750,6 +2750,23 @@ function applyHeroChaseHit(
   }
 }
 
+// Lava that appears UNDER the hero (e.g. the Shaper's fire raining down onto the
+// tile they're standing on) is lethal even without a step. Stepping onto lava is
+// already fatal in the movement resolver; this catches lava that materialized
+// beneath a hero who didn't move. A living hero can only be on a lava tile if it
+// spawned under them, so this never false-fires.
+function killIfStandingOnLava(state: GameState): GameState {
+  if (state.heroHealth <= 0) return state;
+  const pos = findPlayerPosition(state.mapData);
+  if (!pos) return state;
+  const subs = state.mapData.subtypes[pos[0]]?.[pos[1]] ?? [];
+  if (subs.includes(TileSubtype.LAVA) && !subs.includes(TileSubtype.OBSIDIAN)) {
+    state.heroHealth = 0;
+    if (!state.deathCause) state.deathCause = { type: "lava" };
+  }
+  return state;
+}
+
 export function movePlayer(
   gameState: GameState,
   direction: Direction
@@ -2782,7 +2799,7 @@ export function movePlayer(
       }
     }
   }
-  const detonated = detonateLiveBombs(result);
+  const detonated = killIfStandingOnLava(detonateLiveBombs(result));
   // Drift the pink mist one turn as the hero MOVES through the realm — only while already
   // in the realm (not the entry/exit turn) so the freshly-seeded cloud holds for a beat.
   // Standing actions (throwing, using items) blind mist-covered enemies but deliberately


### PR DESCRIPTION
## What

A new EnemyKind **shaper** — a reach-the-boss puzzle fight where the boss reshapes the arena instead of chasing you. Reached only through the `/test-shaper` harness for now; **not wired into daily/endless/story**, so it's inert in all shipping game modes.

## Mechanics

- **Water slows you** — floods your ground and deepens shallow→deep to snuff your torch.
- **Fire kills you, telegraphed** — launches with a warm-glow warning, rains down as lethal lava the next turn (step off the telegraph to survive).
- **Walls fence you in** — the boss can mutate floor→wall.
- **Per-encounter strategy roll** (Drowning vs Wall) so each fight reads differently — with hard fairness guarantees.

## Fairness guarantees (verified by tests)

- The wall strategy can **never seal the hero out**: `heroCanReachBoss` only commits a wall that keeps a *standable* boss-neighbor reachable.
- Fire **always leaves a walkable escape** neighbor — no unavoidable death, even in a 1-wide corridor.

## Notable

- Engine: a living hero standing on lava now dies (`killIfStandingOnLava`); elemental terrain fights (lava/water → singed, reversible).
- 25×25 concentric-tier arena with randomized gaps (`buildShaperArena`).
- **21 shaper unit/arena tests**, including adversarial-review regressions for a self-entombment softlock and the corridor fire-escape guarantee. Full suite 750 green; typecheck + production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)