### PR TITLE
Add organic boss-room entrances (isolated /test-boss-entrances)

### DIFF
--- a/__tests__/lib/boss_entrances.test.ts
+++ b/__tests__/lib/boss_entrances.test.ts
@@ -1,0 +1,260 @@
+import { movePlayer, Direction, TileSubtype } from "../../lib/map";
+import { performThrowRock } from "../../lib/map/game-state";
+import type { GameState } from "../../lib/map/game-state";
+import { buildOutsideWorld } from "../../lib/map/outside-world";
+import {
+  buildMoatApproach,
+  buildDousePortalApproach,
+  buildBombOutsideApproach,
+} from "../../lib/bosses/boss_entrances";
+
+const SHAPER_ARENA_SIZE = 25;
+
+// A small walled room with the hero at (2,1) and an open interior.
+function miniRoom(extra: Partial<GameState> = {}): GameState {
+  const tiles = [
+    [1, 1, 1, 1, 1],
+    [1, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [1, 0, 0, 0, 1],
+    [1, 1, 1, 1, 1],
+  ];
+  const subtypes: number[][][] = tiles.map((row) => row.map(() => [] as number[]));
+  subtypes[2][1] = [TileSubtype.PLAYER];
+  return {
+    hasKey: false, hasExitKey: false, hasSword: true, hasShield: false,
+    showFullMap: true, win: false, playerDirection: Direction.RIGHT,
+    enemies: [], heroHealth: 5, heroMaxHealth: 5, heroAttack: 1, heroTorchLit: true,
+    rockCount: 0, runeCount: 0, foodCount: 0, potionCount: 0,
+    stats: { damageDealt: 0, damageTaken: 0, enemiesDefeated: 0, steps: 0 },
+    mapData: { tiles, subtypes, environment: "cave" },
+    recentDeaths: [],
+    mode: "normal",
+    ...extra,
+  } as GameState;
+}
+
+function findHero(s: GameState): [number, number] {
+  const subs = s.mapData.subtypes;
+  for (let y = 0; y < subs.length; y++)
+    for (let x = 0; x < subs[y].length; x++)
+      if (subs[y][x].includes(TileSubtype.PLAYER)) return [y, x];
+  return [-1, -1];
+}
+
+function findSubtype(s: GameState, sub: number): [number, number] | null {
+  const subs = s.mapData.subtypes;
+  for (let y = 0; y < subs.length; y++)
+    for (let x = 0; x < subs[y].length; x++)
+      if (subs[y][x].includes(sub)) return [y, x];
+  return null;
+}
+
+// Tiles reachable from a start over DRY ground (walls + lava + deep water block).
+function dryReachableFrom(s: GameState, start: [number, number]): Set<string> {
+  const T = s.mapData.tiles;
+  const S = s.mapData.subtypes;
+  const H = T.length;
+  const W = T[0].length;
+  const pass = (y: number, x: number) => {
+    if (y < 0 || x < 0 || y >= H || x >= W) return false;
+    if (T[y][x] === 1) return false; // wall
+    const c = S[y]?.[x] ?? [];
+    return !(
+      c.includes(TileSubtype.LAVA) ||
+      c.includes(TileSubtype.DEEP_WATER) ||
+      c.includes(TileSubtype.OPEN_ABYSS)
+    );
+  };
+  const seen = new Set<string>([`${start[0]},${start[1]}`]);
+  const q: Array<[number, number]> = [start];
+  while (q.length) {
+    const [y, x] = q.shift()!;
+    for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>) {
+      const ny = y + dy;
+      const nx = x + dx;
+      const k = `${ny},${nx}`;
+      if (seen.has(k) || !pass(ny, nx)) continue;
+      seen.add(k);
+      q.push([ny, nx]);
+    }
+  }
+  return seen;
+}
+
+describe("boss-room entrance warps", () => {
+  test("stepping onto a BOSS_ENTRANCE warps into the Shaper arena", () => {
+    const s = miniRoom();
+    s.mapData.subtypes[2][2] = [TileSubtype.BOSS_ENTRANCE];
+    const after = movePlayer(s, Direction.RIGHT);
+    expect(after.inBossRoom).toBe(true);
+    expect(after.reachedBossRoom).toBe(true);
+    // The map became the 25x25 arena with a shaper waiting.
+    expect(after.mapData.tiles.length).toBe(SHAPER_ARENA_SIZE);
+    expect((after.enemies ?? []).some((e) => e.kind === "shaper")).toBe(true);
+  });
+
+  test("a CAVE_OPENING does NOT warp (story-mode safety)", () => {
+    const s = miniRoom();
+    s.mapData.subtypes[2][2] = [TileSubtype.CAVE_OPENING];
+    const after = movePlayer(s, Direction.RIGHT);
+    expect(after.inBossRoom).toBeFalsy();
+    expect(after.mapData.tiles.length).toBe(5); // still the little room
+  });
+
+  test("a DARK_PORTAL is inert while the torch is LIT", () => {
+    const s = miniRoom({ heroTorchLit: true });
+    s.mapData.subtypes[2][2] = [TileSubtype.DARK_PORTAL];
+    const after = movePlayer(s, Direction.RIGHT);
+    expect(after.inBossRoom).toBeFalsy();
+    expect(after.mapData.tiles.length).toBe(5);
+    // The hero stepped onto the portal tile, and the portal survives for later.
+    expect(findHero(after)).toEqual([2, 2]);
+    expect(after.mapData.subtypes[2][2]).toContain(TileSubtype.DARK_PORTAL);
+  });
+
+  test("a DARK_PORTAL warps once the torch is OUT", () => {
+    const s = miniRoom({ heroTorchLit: false });
+    s.mapData.subtypes[2][2] = [TileSubtype.DARK_PORTAL];
+    const after = movePlayer(s, Direction.RIGHT);
+    expect(after.inBossRoom).toBe(true);
+    expect(after.mapData.tiles.length).toBe(SHAPER_ARENA_SIZE);
+  });
+});
+
+describe("moat crossing mechanics (controlled)", () => {
+  test("stepping into uncooled lava kills the hero", () => {
+    const s = miniRoom();
+    s.mapData.subtypes[2][2] = [TileSubtype.LAVA];
+    const after = movePlayer(s, Direction.RIGHT); // hero (2,1) -> lava (2,2)
+    expect(after.heroHealth).toBe(0);
+    expect(after.deathCause?.type).toBe("lava");
+  });
+
+  test("cooling the lava edge with a rock makes it crossable", () => {
+    const s = miniRoom({ rockCount: 3 }); // facing RIGHT by default
+    s.mapData.subtypes[2][2] = [TileSubtype.LAVA];
+    const thrown = performThrowRock(s); // cools (2,2) lava -> obsidian
+    expect(thrown.mapData.subtypes[2][2]).toContain(TileSubtype.OBSIDIAN);
+    const stepOn = movePlayer(thrown, Direction.RIGHT);
+    expect(stepOn.heroHealth).toBeGreaterThan(0);
+    expect(findHero(stepOn)).toEqual([2, 2]);
+  });
+
+  test("wading deep water snuffs the torch", () => {
+    const s = miniRoom({ heroTorchLit: true });
+    s.mapData.subtypes[2][2] = [TileSubtype.DEEP_WATER];
+    const after = movePlayer(s, Direction.RIGHT);
+    expect(findHero(after)).toEqual([2, 2]);
+    expect(after.heroTorchLit).toBe(false);
+  });
+});
+
+describe("moat approach in a real Level-3 room", () => {
+  test("stamps the chosen element + a cave mouth into a genuine L3 layout", () => {
+    for (const el of ["lava", "water"] as const) {
+      const s = buildMoatApproach(el);
+      // A real floor-3 grid (much larger than the little test rooms).
+      expect(s.mapData.tiles.length).toBeGreaterThanOrEqual(20);
+      const cells = s.mapData.subtypes.flat();
+      const elementSub = el === "lava" ? TileSubtype.LAVA : TileSubtype.DEEP_WATER;
+      expect(cells.some((c) => c.includes(elementSub))).toBe(true);
+      expect(cells.some((c) => c.includes(TileSubtype.BOSS_ENTRANCE))).toBe(true);
+      // The generator still placed the hero and the floor's exit + key.
+      expect(findHero(s)[0]).toBeGreaterThanOrEqual(0);
+      expect(cells.some((c) => c.includes(TileSubtype.EXIT))).toBe(true);
+      expect(s.rockCount).toBeGreaterThanOrEqual(8);
+      expect(s.bossArenaSeed).toBe(el);
+    }
+  });
+
+  test("lava crossing is a straight spur that ONLY gates the secret", () => {
+    for (let i = 0; i < 8; i++) {
+      const s = buildMoatApproach("lava");
+      const entrance = findSubtype(s, TileSubtype.BOSS_ENTRANCE);
+      expect(entrance).not.toBeNull();
+      const [ey, ex] = entrance!;
+      // You reach the entrance by crossing lava: a neighbor of it is lava.
+      const gatedByLava = ([[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>).some(
+        ([dy, dx]) => s.mapData.subtypes[ey + dy]?.[ex + dx]?.includes(TileSubtype.LAVA)
+      );
+      expect(gatedByLava).toBe(true);
+      // The entrance is NOT reachable over dry ground (it is gated by the lava)...
+      const dry = dryReachableFrom(s, findHero(s));
+      expect(dry.has(`${ey},${ex}`)).toBe(false);
+      // ...but the room's normal exit is still approachable (nothing legit walled
+      // off). The exit is a wall-door, so check a neighbor is dry-reachable.
+      const exit = findSubtype(s, TileSubtype.EXIT);
+      if (exit) {
+        const [exy, exx] = exit;
+        const approachable = ([[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>).some(
+          ([dy, dx]) => dry.has(`${exy + dy},${exx + dx}`)
+        );
+        expect(approachable).toBe(true);
+      }
+    }
+  });
+});
+
+describe("outside-world boss entrance", () => {
+  test("bossEntrance:true carves an opening and places a BOSS_ENTRANCE in the far tree wall", () => {
+    // Stepping UP out of the dungeon -> inner edge is the bottom, far wall the top.
+    const { mapData } = buildOutsideWorld(Direction.UP, 15, 15, { bossEntrance: true });
+    let found: [number, number] | null = null;
+    for (let y = 0; y < mapData.subtypes.length; y++)
+      for (let x = 0; x < mapData.subtypes[y].length; x++)
+        if (mapData.subtypes[y][x].includes(TileSubtype.BOSS_ENTRANCE)) found = [y, x];
+    expect(found).not.toBeNull();
+    // The carve runs through the far (top) tree border, so the entrance's column is FLOOR.
+    const [ey, ex] = found!;
+    expect(mapData.tiles[ey][ex]).toBe(0);
+    expect(mapData.tiles[ey + 1][ex]).toBe(0); // path punched through the border
+  });
+
+  test("without the flag, no boss entrance is carved", () => {
+    const { mapData } = buildOutsideWorld(Direction.UP, 15, 15);
+    const any = mapData.subtypes.some((row) =>
+      row.some((cell) => cell.includes(TileSubtype.BOSS_ENTRANCE))
+    );
+    expect(any).toBe(false);
+  });
+});
+
+describe("approach builders are valid playable states", () => {
+  test("each builder places the hero and an entrance/bomb kit", () => {
+    const douse = buildDousePortalApproach();
+    expect(findHero(douse)[0]).toBeGreaterThanOrEqual(0);
+    const hasPortal = douse.mapData.subtypes.some((r) =>
+      r.some((c) => c.includes(TileSubtype.DARK_PORTAL))
+    );
+    expect(hasPortal).toBe(true);
+    expect(douse.showFullMap).toBe(false); // fog on so the dark reveal renders
+
+    const bomb = buildBombOutsideApproach();
+    expect(bomb.bombCount).toBe(3);
+    expect(bomb.outsideHasBossEntrance).toBe(true);
+  });
+});
+
+function ghostCount(s: GameState): number {
+  return (s.enemies ?? []).filter((e) => e.kind === "ghost").length;
+}
+
+describe("douse portal in an L3-sized room, with ghosts", () => {
+  test("is a real L3 room with deep water to wade, a dark portal, and 3 ghosts", () => {
+    for (let i = 0; i < 5; i++) {
+      const s = buildDousePortalApproach();
+      // Real floor-3 grid, not the old compact hand-built room.
+      expect(s.mapData.tiles.length).toBeGreaterThanOrEqual(20);
+      const cells = s.mapData.subtypes.flat();
+      expect(cells.some((c) => c.includes(TileSubtype.DEEP_WATER))).toBe(true); // torch-snuffer
+      expect(cells.some((c) => c.includes(TileSubtype.DARK_PORTAL))).toBe(true);
+      expect(ghostCount(s)).toBe(3);
+    }
+  });
+
+  test("both moat types also carry 3 ghosts", () => {
+    expect(ghostCount(buildMoatApproach("lava"))).toBe(3);
+    expect(ghostCount(buildMoatApproach("water"))).toBe(3);
+  });
+});

--- a/app/test-boss-entrances/page.tsx
+++ b/app/test-boss-entrances/page.tsx
@@ -1,0 +1,169 @@
+"use client";
+
+import React, { Suspense, useMemo, useState } from "react";
+import { TilemapGrid } from "../../components/TilemapGrid";
+import { tileTypes } from "../../lib/map";
+import {
+  buildMoatApproach,
+  buildDousePortalApproach,
+  buildBombOutsideApproach,
+} from "../../lib/bosses/boss_entrances";
+import type { GameState } from "../../lib/map/game-state";
+
+type Scenario = {
+  key: string;
+  label: string;
+  build: () => GameState;
+  blurb: React.ReactNode;
+};
+
+const SCENARIOS: Scenario[] = [
+  {
+    key: "moat-lava",
+    label: "Moat: Lava",
+    build: () => buildMoatApproach("lava"),
+    blurb: (
+      <>
+        A wall of <span className="text-orange-400">lava</span> drowns the far side.
+        Lava is instant death &mdash; <b>throw a rock</b> at the near edge to cool it
+        into a walkable stepping stone, one tile at a time, until you&rsquo;ve bridged
+        across (~8 rocks, most of a day&rsquo;s haul). The cave mouth waits beyond it.
+      </>
+    ),
+  },
+  {
+    key: "moat-water",
+    label: "Moat: Water",
+    build: () => buildMoatApproach("water"),
+    blurb: (
+      <>
+        A channel of <span className="text-blue-400">deep water</span> drowns the far
+        side. You can simply <b>wade across</b> &mdash; but deep water snuffs your torch
+        and you cross blind &mdash; or <b>throw rocks</b> into it to drop dry stepping
+        stones and keep your light. The cave mouth waits beyond it.
+      </>
+    ),
+  },
+  {
+    key: "douse",
+    label: "Douse Portal",
+    build: buildDousePortalApproach,
+    blurb: (
+      <>
+        A dark cave. Somewhere ahead is a portal you cannot see while your torch burns.
+        <b> Wade the deep-water channel</b> to snuff your torch &mdash; in the dark, a
+        glowing entrance appears. Step into it. (Relight your torch and it vanishes and
+        turns inert.)
+      </>
+    ),
+  },
+  {
+    key: "bomb",
+    label: "Bomb → Outside",
+    build: buildBombOutsideApproach,
+    blurb: (
+      <>
+        A sealed room with three bombs. <b>Throw a bomb at an outer wall</b> to blow a
+        breach, step out into the grassland, then push past the stone goblins to the
+        <b> opening carved in the far tree wall</b> &mdash; a path down into the boss
+        room. (In the real daily this appears only for the first wall you breach.)
+      </>
+    ),
+  },
+];
+
+function TestBossEntrancesInner() {
+  const [scenarioIndex, setScenarioIndex] = useState(0);
+  const [resetCount, setResetCount] = useState(0);
+  const [outcome, setOutcome] = useState<"none" | "won" | "lost">("none");
+
+  const scenario = SCENARIOS[scenarioIndex];
+  // Build the approach level once per selection so it isn't rebuilt on every render.
+  const initialState = useMemo(
+    () => scenario.build(),
+    [scenario, resetCount]
+  );
+  const reset = () => {
+    setOutcome("none");
+    setResetCount((c) => c + 1);
+  };
+
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center justify-center p-4 text-white relative"
+      style={{
+        backgroundImage: "url(/images/presentational/wall-up-close.png)",
+        backgroundRepeat: "repeat",
+        backgroundSize: "auto",
+      }}
+    >
+      <div className="absolute inset-0 bg-black/40 pointer-events-none"></div>
+      <div className="relative z-10 flex flex-col items-center gap-4">
+        <div className="text-center bg-black/70 rounded-lg p-4 backdrop-blur-sm max-w-xl">
+          <h1 className="text-2xl font-bold mb-2">Boss Entrances: getting in</h1>
+          <p className="text-sm text-gray-300">
+            Three organic ways to reach a boss room in a daily run. Each drops you into
+            the Shaper fight once you get through. Pick one and try to reach it.
+          </p>
+          <p className="text-sm text-gray-200 mt-2">{scenario.blurb}</p>
+        </div>
+
+        <div className="flex flex-wrap gap-2 justify-center bg-black/70 rounded-lg p-3 backdrop-blur-sm">
+          {SCENARIOS.map((s, i) => (
+            <button
+              key={s.key}
+              onClick={() => {
+                setScenarioIndex(i);
+                setOutcome("none");
+                setResetCount((c) => c + 1);
+              }}
+              className={`px-3 py-1 rounded text-sm ${
+                scenarioIndex === i
+                  ? "bg-amber-600 text-white"
+                  : "bg-gray-700 text-gray-300 hover:bg-gray-600"
+              }`}
+            >
+              {s.label}
+            </button>
+          ))}
+          <span className="w-px bg-gray-600 mx-1" />
+          <button
+            onClick={reset}
+            className="px-3 py-1 rounded text-sm bg-red-700 text-white hover:bg-red-600"
+          >
+            Reset
+          </button>
+        </div>
+
+        {outcome === "lost" && (
+          <div className="bg-red-900/90 rounded-lg px-4 py-2 text-sm font-bold backdrop-blur-sm">
+            You died before reaching the boss. Hit Reset to try again.
+          </div>
+        )}
+        {outcome === "won" && (
+          <div className="bg-green-900/90 rounded-lg px-4 py-2 text-sm font-bold backdrop-blur-sm">
+            You got in and broke the Shaper. Hit Reset to try another way in.
+          </div>
+        )}
+
+        <TilemapGrid
+          key={`${scenario.key}-${resetCount}`}
+          tileTypes={tileTypes}
+          initialGameState={initialState}
+          forceDaylight={true}
+          storageSlot="test"
+          onWin={() => setOutcome("won")}
+          onDeath={() => setOutcome("lost")}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function TestBossEntrancesPage() {
+  return (
+    <Suspense fallback={null}>
+      <TestBossEntrancesInner />
+    </Suspense>
+  );
+}

--- a/components/Tile.tsx
+++ b/components/Tile.tsx
@@ -766,6 +766,10 @@ export const Tile: React.FC<TileProps> = ({
         subtype !== TileSubtype.DOOR &&
         subtype !== TileSubtype.EXIT &&
         subtype !== TileSubtype.CAVE_OPENING &&
+        // Boss entrances render their own cave/portal art (and the dark portal is
+        // intentionally invisible while lit) — never fall back to a "?" glyph.
+        subtype !== TileSubtype.BOSS_ENTRANCE &&
+        subtype !== TileSubtype.DARK_PORTAL &&
         // Exclude pots/rocks and revealed items from generic rendering
         subtype !== TileSubtype.POT &&
         subtype !== TileSubtype.ROCK &&
@@ -991,6 +995,39 @@ export const Tile: React.FC<TileProps> = ({
             }}
           />
         )}
+
+        {/* Boss-room entrance: a lockless cave mouth (same art as CAVE_OPENING).
+            Always visible; stepping onto it warps into the boss arena. */}
+        {subtypes?.includes(TileSubtype.BOSS_ENTRANCE) && (
+          <div
+            key="boss-entrance"
+            data-testid={`subtype-icon-${TileSubtype.BOSS_ENTRANCE}`}
+            className={`${styles.assetIcon} ${styles.fullHeightAssetIcon} ${styles.exitIcon}`}
+            style={{
+              backgroundImage: `url('/images/door/exit-dark.png')`,
+            }}
+          />
+        )}
+
+        {/* Douse-to-see portal: a glowing entrance that only appears once the
+            hero's torch is OUT (true darkness). Invisible + inert in the light. */}
+        {subtypes?.includes(TileSubtype.DARK_PORTAL) &&
+          isVisible &&
+          !heroTorchLit &&
+          !suppressDarknessOverlay && (
+            <div
+              key="dark-portal"
+              data-testid={`subtype-icon-${TileSubtype.DARK_PORTAL}`}
+              className={`${styles.assetIcon} ${styles.fullHeightAssetIcon} ${styles.exitIcon}`}
+              style={{
+                backgroundImage: `url('/images/door/exit-dark.png')`,
+                filter: "brightness(1.7)",
+                boxShadow:
+                  "0 0 14px 5px rgba(120, 200, 255, 0.9), inset 0 0 10px rgba(170, 225, 255, 0.7)",
+                borderRadius: "6px",
+              }}
+            />
+          )}
 
         {/* Render POT/ROCK/FOOD/MED with assets if present */}
         {hasPot(subtypes) && (() => {

--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -5812,7 +5812,14 @@ function renderTileGrid(
         Array.isArray(subtype) &&
         (subtype.includes(TileSubtype.WALL_TORCH) || subtype.includes(TileSubtype.LAVA));
       const isTorchCarrier = torchCarrierPositions.has(`${rowIndex},${colIndex}`);
-      if (isSelfTorch || isTorchCarrier) tier = Math.max(tier, 3);
+      // The douse-to-see portal is its own light source while the torch is OUT: it
+      // stays lit as a beacon no matter how far away, so it can actually be found on
+      // a full-size dark level (adjacency-only would be near impossible to discover).
+      const isDarkPortalBeacon =
+        Array.isArray(subtype) &&
+        subtype.includes(TileSubtype.DARK_PORTAL) &&
+        !heroTorchLit;
+      if (isSelfTorch || isTorchCarrier || isDarkPortalBeacon) tier = Math.max(tier, 3);
       // Neighbor illumination based on glow strength
       if (g === ADJACENT_GLOW) {
         tier = Math.max(tier, 2);
@@ -5901,7 +5908,7 @@ function renderTileGrid(
           style={(() => {
             const wrapperStyle: React.CSSProperties = {};
             // Raise z-index so lit tiles appear above the dark vignette overlay
-            if (g != null || isSelfTorch) {
+            if (g != null || isSelfTorch || isDarkPortalBeacon) {
               wrapperStyle.zIndex = 10050;
             }
             // Desync each torch tile's flicker so neighbors don't pulse in

--- a/lib/bosses/boss_entrances.ts
+++ b/lib/bosses/boss_entrances.ts
@@ -1,0 +1,575 @@
+// Approach levels for the three daily boss-room entrances (see
+// .claude/features/boss-daily-entrances/index.md). These are self-contained
+// GameStates used by the /test-boss-entrances harness so the entrances can be
+// played end-to-end before wiring them into daily generation:
+//
+//   1. MOAT      — a Level-3 corner drowned in lava or deep water. Cross the lava
+//                  by cooling a rock path to obsidian (~a day's rocks), or wade the
+//                  deep water (losing your torch) / bridge it with stepping stones.
+//                  A lockless BOSS_ENTRANCE waits on the far side.
+//   2. DOUSE     — a dark cave. A deep-water channel snuffs your torch; only in the
+//                  dark does the DARK_PORTAL beyond it appear (invisible in the light).
+//   3. BOMB      — a walled room; bomb the outer wall and step into the outside world,
+//                  where a hidden BOSS_ENTRANCE is carved into the far tree wall.
+//
+// Stepping onto either entrance subtype warps into the Shaper arena (enterBossRoom
+// in game-state.ts).
+import { FLOOR, WALL, FLOWERS, Direction, TileSubtype } from "../map/constants";
+import type { MapData } from "../map/types";
+import type { GameState } from "../map/game-state";
+import { generateCompleteMapForFloor } from "../map/map-features";
+import { Enemy } from "../enemy";
+
+export type MoatElement = "lava" | "water";
+
+/** Boss-entrance levels are haunted: this many ghosts prowl the L3-sized rooms. */
+const GHOST_COUNT = 3;
+
+/** Place up to `count` ghosts on empty floor tiles, away from the hero + each other. */
+function placeGhosts(map: MapData, count: number, hy: number, hx: number): Enemy[] {
+  const cands: Array<[number, number]> = [];
+  for (let y = 1; y < map.tiles.length - 1; y++) {
+    for (let x = 1; x < map.tiles[0].length - 1; x++) {
+      if (map.tiles[y][x] !== FLOOR) continue;
+      if ((map.subtypes[y]?.[x]?.length ?? 0) !== 0) continue; // bare floor only
+      if (Math.abs(y - hy) + Math.abs(x - hx) < 5) continue; // not on top of the hero
+      cands.push([y, x]);
+    }
+  }
+  cands.sort(
+    (a, b) => Math.abs(b[0] - hy) + Math.abs(b[1] - hx) - (Math.abs(a[0] - hy) + Math.abs(a[1] - hx))
+  );
+  const chosen: Array<[number, number]> = [];
+  for (const [y, x] of cands) {
+    if (chosen.length >= count) break;
+    if (chosen.every(([cy, cx]) => Math.abs(cy - y) + Math.abs(cx - x) >= 3)) chosen.push([y, x]);
+  }
+  return chosen.map(([y, x]) => {
+    const g = new Enemy({ y, x });
+    g.kind = "ghost";
+    g.health = 2;
+    g.maxHealth = 2;
+    return g;
+  });
+}
+
+/** A rectangular room: WALL border, FLOOR interior. */
+function room(width: number, height: number): { tiles: number[][]; subtypes: number[][][] } {
+  const tiles: number[][] = [];
+  const subtypes: number[][][] = [];
+  for (let y = 0; y < height; y++) {
+    tiles.push(
+      Array.from({ length: width }, (_, x) =>
+        y === 0 || x === 0 || y === height - 1 || x === width - 1 ? WALL : FLOOR
+      )
+    );
+    subtypes.push(Array.from({ length: width }, () => [] as number[]));
+  }
+  return { tiles, subtypes };
+}
+
+/** Common GameState scaffold for an approach level. */
+function approachState(
+  mapData: MapData,
+  extra: Partial<GameState>
+): GameState {
+  return {
+    hasKey: false,
+    hasExitKey: false,
+    hasSword: true,
+    hasShield: false,
+    showFullMap: true,
+    win: false,
+    playerDirection: Direction.RIGHT,
+    enemies: [],
+    heroHealth: 5,
+    heroMaxHealth: 5,
+    heroAttack: 1,
+    heroTorchLit: true,
+    rockCount: 0,
+    runeCount: 0,
+    foodCount: 0,
+    potionCount: 0,
+    stats: { damageDealt: 0, damageTaken: 0, enemiesDefeated: 0, steps: 0 },
+    mapData,
+    recentDeaths: [],
+    mode: "normal",
+    ...extra,
+  } as GameState;
+}
+
+/** Scan a map's subtypes for the hero. */
+function findPlayerPos(map: MapData): [number, number] {
+  for (let y = 0; y < map.subtypes.length; y++)
+    for (let x = 0; x < map.subtypes[y].length; x++)
+      if (map.subtypes[y][x].includes(TileSubtype.PLAYER)) return [y, x];
+  return [1, 1];
+}
+
+// Never overwrite these when placing the cave mouth / carving a spur.
+const PROTECTED_SUBS = [
+  TileSubtype.EXIT,
+  TileSubtype.EXITKEY,
+  TileSubtype.KEY,
+  TileSubtype.CHEST,
+  TileSubtype.OPEN_CHEST,
+  TileSubtype.PLAYER,
+];
+// Existing elemental terrain a lava spur must not run through.
+const ELEMENTAL_SUBS = [
+  TileSubtype.LAVA,
+  TileSubtype.DEEP_WATER,
+  TileSubtype.SHALLOW_WATER,
+  TileSubtype.OBSIDIAN,
+  TileSubtype.STEPPING_STONE,
+];
+
+/** Place a lockless cave mouth on the FLOOR tile nearest a map corner. */
+function placeEntranceNearCorner(map: MapData, cornerY: number, cornerX: number): void {
+  const H = map.tiles.length;
+  const W = map.tiles[0].length;
+  for (let r = 0; r < Math.max(H, W); r++) {
+    for (let y = cornerY - r; y <= cornerY + r; y++) {
+      for (let x = cornerX - r; x <= cornerX + r; x++) {
+        if (y < 1 || x < 1 || y >= H - 1 || x >= W - 1) continue;
+        if (map.tiles[y][x] !== FLOOR) continue;
+        if (map.subtypes[y][x].some((s) => PROTECTED_SUBS.includes(s))) continue;
+        map.subtypes[y][x] = [TileSubtype.BOSS_ENTRANCE]; // dry landing past the moat
+        return;
+      }
+    }
+  }
+}
+
+/**
+ * Drown the map corner farthest from the hero in lava or deep water, and set a
+ * lockless cave mouth at its tip. Only bare FLOOR is flooded, so the room's exit,
+ * key, rocks, pots, torches and faulty floors all survive as dry islands.
+ */
+function stampCornerMoat(map: MapData, element: MoatElement): void {
+  const H = map.tiles.length;
+  const W = map.tiles[0].length;
+  const [hy, hx] = findPlayerPos(map);
+  const corners: Array<[number, number]> = [
+    [1, 1],
+    [1, W - 2],
+    [H - 2, 1],
+    [H - 2, W - 2],
+  ];
+  const corner = corners.reduce((best, c) =>
+    Math.hypot(c[0] - hy, c[1] - hx) > Math.hypot(best[0] - hy, best[1] - hx) ? c : best
+  );
+  const [cy, cx] = corner;
+  const blockH = Math.round(H * 0.42);
+  const blockW = Math.round(W * 0.42);
+  const y0 = cy < H / 2 ? 1 : H - 1 - blockH;
+  const y1 = cy < H / 2 ? blockH : H - 2;
+  const x0 = cx < W / 2 ? 1 : W - 1 - blockW;
+  const x1 = cx < W / 2 ? blockW : W - 2;
+
+  const deepSub = element === "lava" ? TileSubtype.LAVA : TileSubtype.DEEP_WATER;
+  for (let y = y0; y <= y1; y++) {
+    for (let x = x0; x <= x1; x++) {
+      if (map.tiles[y][x] === FLOOR && map.subtypes[y][x].length === 0) {
+        map.subtypes[y][x] = [deepSub];
+      }
+    }
+  }
+  // Water gets a wadeable shallow lip wherever it meets dry land (readability).
+  if (element === "water") {
+    for (let y = y0; y <= y1; y++) {
+      for (let x = x0; x <= x1; x++) {
+        if (!map.subtypes[y]?.[x]?.includes(TileSubtype.DEEP_WATER)) continue;
+        const touchesDry = ([[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>).some(
+          ([dy, dx]) => {
+            const ny = y + dy;
+            const nx = x + dx;
+            if (ny < 0 || nx < 0 || ny >= H || nx >= W) return false;
+            return map.tiles[ny][nx] === FLOOR && map.subtypes[ny][nx].length === 0;
+          }
+        );
+        if (touchesDry) map.subtypes[y][x] = [TileSubtype.SHALLOW_WATER];
+      }
+    }
+  }
+  placeEntranceNearCorner(map, cy, cx);
+}
+
+function cloneMap(map: MapData): MapData {
+  return {
+    tiles: map.tiles.map((r) => r.slice()),
+    subtypes: map.subtypes.map((r) => r.map((c) => c.slice())),
+    environment: map.environment,
+  };
+}
+
+/**
+ * Tiles the hero can reach on foot. Lava + abyss always block; deep water blocks
+ * unless `wadeable` (the hero can swim it, losing the torch).
+ */
+function floodReachable(
+  map: MapData,
+  sy: number,
+  sx: number,
+  opts?: { wadeable?: boolean }
+): Set<string> {
+  const H = map.tiles.length;
+  const W = map.tiles[0].length;
+  const passable = (y: number, x: number) => {
+    if (y < 0 || x < 0 || y >= H || x >= W) return false;
+    if (map.tiles[y][x] !== FLOOR && map.tiles[y][x] !== FLOWERS) return false;
+    const s = map.subtypes[y]?.[x] ?? [];
+    if (s.includes(TileSubtype.LAVA) || s.includes(TileSubtype.OPEN_ABYSS)) return false;
+    if (s.includes(TileSubtype.DEEP_WATER) && !opts?.wadeable) return false;
+    return true;
+  };
+  const seen = new Set<string>();
+  if (!passable(sy, sx)) return seen;
+  seen.add(`${sy},${sx}`);
+  const q: Array<[number, number]> = [[sy, sx]];
+  while (q.length) {
+    const [y, x] = q.shift()!;
+    for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>) {
+      const ny = y + dy;
+      const nx = x + dx;
+      const k = `${ny},${nx}`;
+      if (seen.has(k) || !passable(ny, nx)) continue;
+      seen.add(k);
+      q.push([ny, nx]);
+    }
+  }
+  return seen;
+}
+
+/**
+ * Dress the straight channel into an irregular POOL: grow lava outward from the
+ * channel (up to 2 tiles) wherever it's safe, so it reads as a pool with a cooled
+ * avenue through it rather than a rote straight strip. The channel itself (the 4-6
+ * tile crossing) and the hero's dry approach are never touched, and every added tile
+ * is connectivity-checked so the pool can't wall off a legitimate part of the room.
+ */
+function growLavaPool(
+  trial: MapData,
+  channel: Array<[number, number]>,
+  before: Set<string>,
+  carved: Set<string>,
+  keepDry: Set<string>,
+  hy: number,
+  hx: number
+): void {
+  const H = trial.tiles.length;
+  const W = trial.tiles[0].length;
+  const eligible = (y: number, x: number): boolean => {
+    if (y < 1 || x < 1 || y >= H - 1 || x >= W - 1) return false;
+    const key = `${y},${x}`;
+    if (carved.has(key) || keepDry.has(key)) return false;
+    const t = trial.tiles[y][x];
+    if (t !== WALL && t !== FLOOR) return false;
+    const s = trial.subtypes[y][x] ?? [];
+    return !s.some((sv) => PROTECTED_SUBS.includes(sv) || ELEMENTAL_SUBS.includes(sv));
+  };
+  const around: Array<[number, number]> = [
+    [-1, 0], [1, 0], [0, -1], [0, 1], [-1, -1], [-1, 1], [1, -1], [1, 1],
+  ];
+  let frontier = channel.slice();
+  for (let depth = 0; depth < 2; depth++) {
+    const next: Array<[number, number]> = [];
+    for (const [fy, fx] of frontier) {
+      for (const [dy, dx] of around) {
+        const ny = fy + dy;
+        const nx = fx + dx;
+        const key = `${ny},${nx}`;
+        if (!eligible(ny, nx)) continue;
+        if (Math.random() < 0.35) continue; // leave gaps -> a ragged, organic edge
+        const prevTile = trial.tiles[ny][nx];
+        const prevSubs = trial.subtypes[ny][nx];
+        trial.tiles[ny][nx] = FLOOR;
+        trial.subtypes[ny][nx] = [TileSubtype.LAVA];
+        carved.add(key);
+        const after = floodReachable(trial, hy, hx);
+        let ok = true;
+        for (const k of before) {
+          if (carved.has(k)) continue;
+          if (!after.has(k)) {
+            ok = false;
+            break;
+          }
+        }
+        if (ok) {
+          next.push([ny, nx]);
+        } else {
+          trial.tiles[ny][nx] = prevTile;
+          trial.subtypes[ny][nx] = prevSubs;
+          carved.delete(key);
+        }
+      }
+    }
+    frontier = next;
+  }
+}
+
+/**
+ * Carve a STRAIGHT, 1-wide lava channel as a dead-end spur ending in the boss
+ * entrance, so the hero crosses it in a single straight line (cool the tile ahead,
+ * step onto it, repeat — never turning, which over lava = instant death). Only
+ * carves through WALL tiles, and only commits a placement that (a) leaves every
+ * originally-reachable tile still reachable and (b) leaves the entrance reachable
+ * ONLY across the lava. Returns false if no such spot exists in this room.
+ */
+function stampStraightLavaSpur(map: MapData, channelLen: number): boolean {
+  const H = map.tiles.length;
+  const W = map.tiles[0].length;
+  const [hy, hx] = findPlayerPos(map);
+  const before = floodReachable(map, hy, hx);
+  const dirs: Array<[number, number]> = [[-1, 0], [1, 0], [0, -1], [0, 1]];
+  // Prefer approach tiles far from the hero (the secret feels tucked away).
+  const approaches = Array.from(before)
+    .map((k) => k.split(",").map(Number) as [number, number])
+    .sort((a, b) => Math.hypot(b[0] - hy, b[1] - hx) - Math.hypot(a[0] - hy, a[1] - hx));
+  for (const [ty, tx] of approaches) {
+    for (const [dy, dx] of dirs) {
+      // The hero must be able to reach the approach tile ALREADY facing the crossing
+      // direction (so he can throw into the lava without first turning into it): the
+      // tile directly behind it must also be reachable dry ground.
+      if (!before.has(`${ty - dy},${tx - dx}`)) continue;
+      // A straight run for the channel + one more tile for the entrance. Carve
+      // through wall OR bare floor, but never through the hero, items, or existing
+      // elemental terrain — the connectivity check below rejects anything unsafe.
+      const cells: Array<[number, number]> = [];
+      let ok = true;
+      for (let i = 1; i <= channelLen + 1; i++) {
+        const y = ty + dy * i;
+        const x = tx + dx * i;
+        if (y < 1 || x < 1 || y >= H - 1 || x >= W - 1) {
+          ok = false;
+          break;
+        }
+        const t = map.tiles[y][x];
+        if (t !== WALL && t !== FLOOR) {
+          ok = false;
+          break;
+        }
+        const cellSubs = map.subtypes[y][x] ?? [];
+        if (cellSubs.some((sv) => PROTECTED_SUBS.includes(sv) || ELEMENTAL_SUBS.includes(sv))) {
+          ok = false;
+          break;
+        }
+        cells.push([y, x]);
+      }
+      if (!ok) continue;
+      const trial = cloneMap(map);
+      const channel = cells.slice(0, channelLen);
+      const [ey, ex] = cells[channelLen];
+      for (const [y, x] of channel) {
+        trial.tiles[y][x] = FLOOR;
+        trial.subtypes[y][x] = [TileSubtype.LAVA];
+      }
+      trial.tiles[ey][ex] = FLOOR;
+      trial.subtypes[ey][ex] = [TileSubtype.BOSS_ENTRANCE];
+      const after = floodReachable(trial, hy, hx);
+      // (a) every originally-reachable tile EXCEPT the ones we carved is still
+      // reachable (so the spur never walls off a legitimate part of the room)...
+      const carved = new Set(cells.map(([y, x]) => `${y},${x}`));
+      let keptAll = true;
+      for (const k of before) {
+        if (carved.has(k)) continue;
+        if (!after.has(k)) {
+          keptAll = false;
+          break;
+        }
+      }
+      if (!keptAll) continue;
+      // (b) ...and the entrance is reachable ONLY by crossing the lava.
+      if (after.has(`${ey},${ex}`)) continue;
+      // Dress the straight channel up into an irregular pool. Protect the hero's dry
+      // approach (the tile he lines up on + the two behind it) so he can still cross.
+      const keepDry = new Set<string>([
+        `${ty},${tx}`,
+        `${ty - dy},${tx - dx}`,
+        `${ty - 2 * dy},${tx - 2 * dx}`,
+      ]);
+      growLavaPool(trial, channel, before, carved, keepDry, hy, hx);
+      map.tiles = trial.tiles;
+      map.subtypes = trial.subtypes;
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * MOAT approach, shown inside a REAL Level-3 room. Generates an actual floor-3
+ * layout (rooms, exit + key, rocks, pots, torches, faulty floors, hero spawned far
+ * from the objectives) and adds the crossing:
+ *  - LAVA: a straight, 1-wide dead-end spur (4-6 tiles) that ONLY gates the secret
+ *    cave mouth. You cross it in a straight line — cool the tile ahead with a rock,
+ *    step on, repeat — so you never have to turn (turning into lava = death), and it
+ *    never walls off any legitimate part of the room.
+ *  - WATER: a drowned far corner you wade (torch snuffs) or bridge with stepping
+ *    stones; wading can't hard-block anything, so the corner flood is fine.
+ */
+export function buildMoatApproach(element: MoatElement): GameState {
+  const channelLen = 4 + Math.floor(Math.random() * 3); // 4..6 -> 4-6 rocks to cross
+  let map = generateCompleteMapForFloor({ chests: 0, keys: 0, chestContents: [] }, 3);
+  if (element === "lava") {
+    let placed = stampStraightLavaSpur(map, channelLen);
+    // A suitable straight wall-run almost always exists; re-roll the room if not.
+    for (let attempt = 0; attempt < 12 && !placed; attempt++) {
+      map = generateCompleteMapForFloor({ chests: 0, keys: 0, chestContents: [] }, 3);
+      placed = stampStraightLavaSpur(map, channelLen);
+    }
+    if (!placed) stampCornerMoat(map, "lava"); // extremely rare fallback
+  } else {
+    stampCornerMoat(map, "water");
+  }
+  const [hy, hx] = findPlayerPos(map);
+  const ghosts = placeGhosts(map, GHOST_COUNT, hy, hx);
+  return approachState(
+    { tiles: map.tiles, subtypes: map.subtypes, environment: "cave" },
+    {
+      // Fog on (real L3 feel) so you explore into the crossing rather than seeing all.
+      showFullMap: false,
+      rockCount: 8, // enough to bridge a 4-6 tile lava channel with a little margin
+      bossArenaSeed: element,
+      enemies: ghosts,
+    }
+  );
+}
+
+/**
+ * A few deep-water tiles in the corner farthest from the hero — a small pool of
+ * flavor (and a secondary way to douse the torch). The GHOSTS are the primary way in
+ * this level: they snuff the torch when adjacent, so the water stays minimal.
+ */
+function stampCornerWaterPatch(map: MapData, hy: number, hx: number): void {
+  const H = map.tiles.length;
+  const W = map.tiles[0].length;
+  const corners: Array<[number, number]> = [[1, 1], [1, W - 2], [H - 2, 1], [H - 2, W - 2]];
+  const [cy, cx] = corners.reduce((best, c) =>
+    Math.hypot(c[0] - hy, c[1] - hx) > Math.hypot(best[0] - hy, best[1] - hx) ? c : best
+  );
+  const bare = (y: number, x: number) =>
+    y >= 1 &&
+    x >= 1 &&
+    y < H - 1 &&
+    x < W - 1 &&
+    map.tiles[y][x] === FLOOR &&
+    (map.subtypes[y][x]?.length ?? 0) === 0;
+  // Seed on the bare floor tile nearest the corner, then flood a small connected blob.
+  let seed: [number, number] | null = null;
+  for (let r = 0; r < Math.max(H, W) && !seed; r++) {
+    for (let y = cy - r; y <= cy + r && !seed; y++)
+      for (let x = cx - r; x <= cx + r && !seed; x++) if (bare(y, x)) seed = [y, x];
+  }
+  if (!seed) return;
+  const target = 4 + Math.floor(Math.random() * 3); // a few: 4..6
+  const blob: Array<[number, number]> = [];
+  const seen = new Set<string>([`${seed[0]},${seed[1]}`]);
+  const q: Array<[number, number]> = [seed];
+  while (q.length && blob.length < target) {
+    const [y, x] = q.shift()!;
+    if (!bare(y, x)) continue;
+    blob.push([y, x]);
+    for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>) {
+      const k = `${y + dy},${x + dx}`;
+      if (!seen.has(k)) {
+        seen.add(k);
+        q.push([y + dy, x + dx]);
+      }
+    }
+  }
+  for (const [y, x] of blob) map.subtypes[y][x] = [TileSubtype.DEEP_WATER];
+}
+
+/**
+ * Place the DARK_PORTAL on the reachable floor tile farthest from the hero that has
+ * NO relight source (wall torch / lava) beside it, so once the hero douses their
+ * torch it stays out and the portal remains visible + usable. Prefers tiles the hero
+ * can only get to by wading (past the water).
+ */
+function placeDarkPortal(map: MapData, hy: number, hx: number): void {
+  const H = map.tiles.length;
+  const W = map.tiles[0].length;
+  const reachable = floodReachable(map, hy, hx, { wadeable: true });
+  const noRelightNear = (y: number, x: number) => {
+    for (let dy = -1; dy <= 1; dy++)
+      for (let dx = -1; dx <= 1; dx++) {
+        const s = map.subtypes[y + dy]?.[x + dx] ?? [];
+        if (s.includes(TileSubtype.WALL_TORCH) || s.includes(TileSubtype.LAVA)) return false;
+      }
+    return true;
+  };
+  let best: [number, number] | null = null;
+  let bestD = -1;
+  for (let y = 1; y < H - 1; y++) {
+    for (let x = 1; x < W - 1; x++) {
+      if (map.tiles[y][x] !== FLOOR) continue;
+      if ((map.subtypes[y][x]?.length ?? 0) !== 0) continue; // bare floor only
+      if (!reachable.has(`${y},${x}`)) continue;
+      if (!noRelightNear(y, x)) continue;
+      const d = Math.abs(y - hy) + Math.abs(x - hx);
+      if (d > bestD) {
+        bestD = d;
+        best = [y, x];
+      }
+    }
+  }
+  if (best) map.subtypes[best[0]][best[1]] = [TileSubtype.DARK_PORTAL];
+}
+
+/**
+ * DOUSE approach, in a REAL Level-3-sized room. A dark dungeon (no wall torches, so
+ * it stays black once doused) with a forced deep-water pool: wade it to snuff your
+ * torch, and the DARK_PORTAL — invisible in the light — lights up as a beacon across
+ * the dark and can be entered. Three ghosts prowl (and, being torch-snuffers, may
+ * plunge you into the dark themselves).
+ */
+export function buildDousePortalApproach(): GameState {
+  // The GHOSTS are the way in: they snuff the torch when adjacent (and their presence
+  // signals the secret), revealing the DARK_PORTAL beacon. No wall torches, so it
+  // stays dark once snuffed. Just a few deep-water tiles sit in the far corner.
+  const map = generateCompleteMapForFloor(
+    { chests: 0, keys: 0, chestContents: [] },
+    3,
+    { wallTorches: 0 }
+  );
+  const [hy, hx] = findPlayerPos(map);
+  stampCornerWaterPatch(map, hy, hx);
+  placeDarkPortal(map, hy, hx);
+  const ghosts = placeGhosts(map, GHOST_COUNT, hy, hx);
+
+  return approachState(
+    { tiles: map.tiles, subtypes: map.subtypes, environment: "cave" },
+    {
+      // Fog on (not full map) so the darkness reveal actually renders.
+      showFullMap: false,
+      heroTorchLit: true,
+      bossArenaSeed: "water",
+      enemies: ghosts,
+    }
+  );
+}
+
+/**
+ * BOMB approach. A walled room. Throw a bomb at the outer wall to breach it, step
+ * through into the outside world (built with outsideHasBossEntrance), then walk to
+ * the hidden cave mouth carved into the far tree wall.
+ */
+export function buildBombOutsideApproach(): GameState {
+  const W = 13;
+  const H = 11;
+  const { tiles, subtypes } = room(W, H);
+  subtypes[Math.floor(H / 2)][Math.floor(W / 2)] = [TileSubtype.PLAYER];
+
+  return approachState(
+    { tiles, subtypes, environment: "cave" },
+    {
+      showFullMap: false,
+      bombCount: 3,
+      rockCount: 0,
+      outsideHasBossEntrance: true,
+      bossArenaSeed: "lava",
+      playerDirection: Direction.UP,
+    }
+  );
+}

--- a/lib/map/constants.ts
+++ b/lib/map/constants.ts
@@ -118,6 +118,15 @@ export enum TileSubtype {
   LAVA = 60,
   OBSIDIAN = 61,
   STEPPING_STONE = 62,
+  // Boss-room entrances (see .claude/features/boss-daily-entrances/index.md).
+  // BOSS_ENTRANCE is a lockless cave mouth (renders like CAVE_OPENING) that warps
+  // the hero into the boss arena when stepped on — used behind a moat and in the
+  // outside world. DARK_PORTAL is the "douse-to-see" variant: it is invisible and
+  // inert while the hero's torch is lit, and only appears + warps once the torch is
+  // out (snuffed by deep water). Kept distinct from CAVE_OPENING so story-mode cave
+  // visuals never accidentally trigger a boss warp.
+  BOSS_ENTRANCE = 63,
+  DARK_PORTAL = 64,
 }
 
 /**

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -52,6 +52,7 @@ import { addRunePotsForStoneExciters, generateCompleteMap, generateCompleteMapFo
 import { addSnakesPerRules, addStaticGuardNearKey } from "./enemy-features";
 import { buildOutsideWorld, buildNightmareRoom, innerEdgeForDirection } from "./outside-world";
 import { buildPinkRealm } from "./pink-realm";
+import { buildShaperArena, type ShaperEntry } from "../bosses/shaper_arena";
 import { seedMist, advanceMist, mistContains } from "./pink-mist";
 import { mulberry32 as mulberry32Fn, withPatchedMathRandom } from "../rng";
 import type { HeroDiaryEntry } from "../story/hero_diary";
@@ -1640,6 +1641,16 @@ export interface GameState {
   // wall and steps into the outdoor grassland. Persists across returns/floors so
   // analytics can record that the hidden outside world was found.
   reachedOutsideWorld?: boolean;
+  // Boss-room entrances (see .claude/features/boss-daily-entrances/index.md).
+  // inBossRoom: transient, true while the hero is inside a boss arena.
+  // reachedBossRoom: run-level latch, true once a boss arena was entered this run.
+  // bossArenaSeed: which elemental Shaper arena to build on entry (defaults lava).
+  // outsideHasBossEntrance: when true, the outside world built from this floor
+  // carves a hidden boss entrance in its far tree wall (a boss-day marker).
+  inBossRoom?: boolean;
+  reachedBossRoom?: boolean;
+  bossArenaSeed?: "water" | "lava";
+  outsideHasBossEntrance?: boolean;
   // Pink realm only: the drifting mist's currently-covered tiles ([y,x] pairs). Grows/
   // shrinks organically each turn. Standing in it reverses the hero's controls; enemies
   // in it are blinded. Undefined / absent outside the realm.
@@ -2497,7 +2508,8 @@ function enterOutsideWorld(
   const { mapData: outsideMap, enemies: outsideEnemies, entry } = buildOutsideWorld(
     direction,
     width,
-    height
+    height,
+    { bossEntrance: state.outsideHasBossEntrance }
   );
   const dungeonReturn = {
     mapData: removePlayerFromMapData(state.mapData),
@@ -2706,6 +2718,48 @@ function returnFromPinkRealm(
   };
 }
 
+// Map the hero's step direction to the arena edge they arrive at (walking DOWN into
+// the mouth drops them in at the north edge, and so on).
+const BOSS_ENTRY_BY_DIRECTION: Record<Direction, ShaperEntry> = {
+  [Direction.DOWN]: "north",
+  [Direction.UP]: "south",
+  [Direction.RIGHT]: "west",
+  [Direction.LEFT]: "east",
+};
+
+/**
+ * Step onto a boss-room entrance (a lockless cave mouth, or a dark portal while the
+ * torch is out) -> warp into the boss arena. Mirrors enterPinkRealm: swap in the
+ * freshly built arena map + enemies, carry the run's vitals/inventory, and latch the
+ * reachedBossRoom secret flag. For now every entrance leads to the Shaper; the
+ * elemental variant is chosen by bossArenaSeed (default lava).
+ */
+function enterBossRoom(state: GameState, direction: Direction): GameState {
+  const seed: "water" | "lava" = state.bossArenaSeed === "water" ? "water" : "lava";
+  const entry = BOSS_ENTRY_BY_DIRECTION[direction] ?? "south";
+  const arena = buildShaperArena({ name: "boss", seed }, entry);
+  return {
+    ...arena,
+    // Carry the run's vitals + inventory into the fight (arena provides defaults).
+    heroHealth: state.heroHealth ?? arena.heroHealth,
+    heroMaxHealth: state.heroMaxHealth ?? arena.heroMaxHealth,
+    heroAttack: state.heroAttack ?? arena.heroAttack,
+    hasSword: state.hasSword ?? arena.hasSword,
+    hasShield: state.hasShield ?? false,
+    rockCount: state.rockCount ?? arena.rockCount,
+    runeCount: state.runeCount ?? arena.runeCount,
+    bombCount: state.bombCount ?? 0,
+    // Preserve run-level secret flags discovered before the boss.
+    reachedPinkRealm: state.reachedPinkRealm,
+    reachedOutsideWorld: state.reachedOutsideWorld,
+    inBossRoom: true,
+    reachedBossRoom: true,
+    playerDirection: direction,
+    recentDeaths: [],
+    recentBombBlasts: [],
+  };
+}
+
 // A "chase hit": the hero lands a clipping melee blow on a pink goblin that just fled
 // from point-blank range. Pink goblins retreat when you're adjacent (see their behavior),
 // vacating the tile before the hero's strike resolves — so a melee-only hero could chase
@@ -2883,6 +2937,26 @@ function movePlayerCore(
       } else if (!pinkRingClaimedByLiving(gameState, newY, newX)) {
         return enterPinkRealm(gameState, [newY, newX], direction);
       }
+    }
+  }
+
+  // Stepping onto a boss-room entrance warps into the boss arena. A BOSS_ENTRANCE
+  // (lockless cave mouth) always triggers; a DARK_PORTAL only triggers while the
+  // hero's torch is OUT (it is invisible and inert in the light). Never re-triggers
+  // once already inside a boss room.
+  if (!gameState.inBossRoom) {
+    const destTile = gameState.mapData.tiles[newY]?.[newX];
+    const destSubs = gameState.mapData.subtypes[newY]?.[newX] ?? [];
+    const onFloor = destTile === FLOOR || destTile === FLOWERS;
+    if (onFloor && destSubs.includes(TileSubtype.BOSS_ENTRANCE)) {
+      return enterBossRoom(gameState, direction);
+    }
+    if (
+      onFloor &&
+      destSubs.includes(TileSubtype.DARK_PORTAL) &&
+      gameState.heroTorchLit === false
+    ) {
+      return enterBossRoom(gameState, direction);
     }
   }
 
@@ -3771,7 +3845,12 @@ function movePlayerCore(
       // into deep water) are floor overlays the player stands on.
       destSubtypes.includes(TileSubtype.SHALLOW_WATER) ||
       destSubtypes.includes(TileSubtype.DEEP_WATER) ||
-      destSubtypes.includes(TileSubtype.STEPPING_STONE)
+      destSubtypes.includes(TileSubtype.STEPPING_STONE) ||
+      // Boss entrances are floor overlays: a BOSS_ENTRANCE always warps before we
+      // get here, but a DARK_PORTAL walked over in the light is inert and must be
+      // preserved (not wiped) so it still works once the torch goes out.
+      destSubtypes.includes(TileSubtype.BOSS_ENTRANCE) ||
+      destSubtypes.includes(TileSubtype.DARK_PORTAL)
     ) {
       if (!destSubtypes.includes(TileSubtype.PLAYER)) {
         destSubtypes.push(TileSubtype.PLAYER);

--- a/lib/map/outside-world.ts
+++ b/lib/map/outside-world.ts
@@ -48,7 +48,8 @@ export function innerEdgeForDirection(direction: Direction): InnerEdge {
 export function buildOutsideWorld(
   direction: Direction,
   width: number,
-  height: number
+  height: number,
+  opts?: { bossEntrance?: boolean }
 ): { mapData: MapData; enemies: PlainEnemy[]; entry: [number, number] } {
   const tiles: number[][] = [];
   const subtypes: number[][][] = [];
@@ -134,6 +135,28 @@ export function buildOutsideWorld(
     for (const y of spread(OUTSIDE_GOBLIN_COUNT, TREE_BORDER, lastY - TREE_BORDER)) {
       enemies.push({ y, x: farX, kind: "stone-goblin" });
     }
+  }
+
+  // Boss-day marker: carve a 1-wide corridor straight through the FAR tree wall
+  // (opposite the dungeon-facing edge) and place a lockless cave mouth at its outer
+  // end. Reads as an opening in the trees with a path leading down into the boss
+  // room; the stone-goblin line guards the approach to it.
+  if (opts?.bossEntrance) {
+    let entrance: [number, number];
+    if (inner === "top") {
+      for (let y = lastY - TREE_BORDER + 1; y <= lastY; y++) tiles[y][midX] = FLOOR;
+      entrance = [lastY, midX];
+    } else if (inner === "bottom") {
+      for (let y = 0; y <= TREE_BORDER - 1; y++) tiles[y][midX] = FLOOR;
+      entrance = [0, midX];
+    } else if (inner === "left") {
+      for (let x = lastX - TREE_BORDER + 1; x <= lastX; x++) tiles[midY][x] = FLOOR;
+      entrance = [midY, lastX];
+    } else {
+      for (let x = 0; x <= TREE_BORDER - 1; x++) tiles[midY][x] = FLOOR;
+      entrance = [midY, 0];
+    }
+    subtypes[entrance[0]][entrance[1]].push(TileSubtype.BOSS_ENTRANCE);
   }
 
   const mapData: MapData = { tiles, subtypes, environment: "outdoor" };


### PR DESCRIPTION
## What

Four ways to reach a boss room during a daily run, all playable end-to-end at `/test-boss-entrances`. **Not wired into daily generation yet** — the new subtypes are inert unless a harness builder places them, so this is plumbing only and exposes nothing to players.

## Entrance types
- **Douse portal** — a dark L3 room where the **ghosts snuff your torch** (revealing a `DARK_PORTAL` beacon that's invisible in the light); a few deep-water tiles in the corner as a secondary douse.
- **Moat: Lava** — a straight, 1-wide dead-end spur (4-6 rocks to cross) dressed into an irregular pool, carved so it **only gates the secret** and never walls off the room.
- **Moat: Water** — a drowned far corner you wade (torch snuffs) or bridge with stepping stones.
- **Bomb wall** — breach the perimeter, cross into the outside world, reach a cave mouth carved in the far tree wall (first breach of the day only, in daily).

## Engine
- New subtypes `BOSS_ENTRANCE` (63) + `DARK_PORTAL` (64), kept distinct from the story-only `CAVE_OPENING` so story cave visuals never trigger a warp.
- `enterBossRoom` (mirrors `enterPinkRealm`): stepping a boss entrance swaps in a fresh Shaper arena, carries inventory, latches `reachedBossRoom`. The dark portal only warps while the torch is out and renders as a beacon across the dark.
- `buildOutsideWorld` can carve a hidden boss entrance in its far tree wall.
- `lib/bosses/boss_entrances.ts` builds the L3-sized approach rooms (real floor-3 layouts + 3 ghosts) and the bomb-out dungeon.

## Rotation (design; not yet wired)
Bomb ~50%; the three non-bomb kinds (douse / lava moat / water moat) split the other ~50%.

## Tests
`__tests__/lib/boss_entrances.test.ts` (14) — warps, story-safety, dark-portal gating, lava straight-spur gating (never blocks the room), outside-world carve, L3 douse room. Full suite green; typecheck + production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)