### PR TITLE
Wire the boss room into daily as an alternate ending

### DIFF
--- a/__tests__/lib/boss_daily_rotation.test.ts
+++ b/__tests__/lib/boss_daily_rotation.test.ts
@@ -1,0 +1,107 @@
+import { hashStringToSeed, mulberry32, withPatchedMathRandom } from "../../lib/rng";
+import {
+  initializeGameStateForMultiTier,
+  advanceToNextFloor,
+} from "../../lib/map/game-state";
+import type { GameState } from "../../lib/map/game-state";
+import { TileSubtype } from "../../lib/map/constants";
+
+// Build a real daily exactly the way the game does: seeded floor 1, then advance.
+function buildDay(dateStr: string): { f1: GameState; f3: GameState } {
+  const seed = hashStringToSeed(dateStr);
+  const f1 = withPatchedMathRandom(mulberry32(seed), () =>
+    initializeGameStateForMultiTier(1)
+  );
+  const f2 = advanceToNextFloor(f1, seed);
+  const f3 = advanceToNextFloor(f2, seed);
+  return { f1, f3 };
+}
+
+function count(s: GameState, sub: number): number {
+  let n = 0;
+  for (const row of s.mapData.subtypes) for (const c of row) if (c.includes(sub)) n++;
+  return n;
+}
+
+/** Does this run hand out a bomb at all? (bombs come from the L2 chest pool) */
+function dayHasBomb(f1: GameState): boolean {
+  return Object.values(f1.floorChestAllocation ?? {}).some((a) =>
+    (a.chestContents ?? []).includes(TileSubtype.BOMB)
+  );
+}
+
+function entranceOf(f3: GameState): string {
+  if (f3.outsideHasBossEntrance) return "bomb";
+  if (count(f3, TileSubtype.DARK_PORTAL) > 0) return "douse";
+  if (count(f3, TileSubtype.BOSS_ENTRANCE) > 0) return `moat-${f3.bossArenaSeed}`;
+  return "none";
+}
+
+const DAYS = Array.from({ length: 60 }, (_, i) => `2026-08-${String((i % 28) + 1).padStart(2, "0")}`)
+  .map((d, i) => (i < 28 ? d : d.replace("2026-08", "2026-09")));
+
+describe("daily boss-entrance rotation", () => {
+  test("is DETERMINISTIC — same date reproduces the whole floor and its enemies", () => {
+    for (const day of ["2026-07-28", "2026-08-14", "2026-12-25"]) {
+      const a = buildDay(day).f3;
+      const b = buildDay(day).f3;
+      expect(entranceOf(a)).toBe(entranceOf(b));
+      expect(a.bossArenaSeed).toBe(b.bossArenaSeed);
+      expect(JSON.stringify(a.mapData)).toBe(JSON.stringify(b.mapData));
+      const kinds = (s: GameState) =>
+        (s.enemies ?? []).map((e) => `${e.kind}@${e.y},${e.x}`).sort().join("|");
+      expect(kinds(a)).toBe(kinds(b));
+    }
+  });
+
+  test("EVERY day offers a reachable entrance — never a bomb door on a bombless day", () => {
+    for (const day of DAYS) {
+      const { f1, f3 } = buildDay(day);
+      const kind = entranceOf(f3);
+      // The bug this pins: a bombless day used to roll "bomb" and end up with nothing.
+      expect(kind).not.toBe("none");
+      if (!dayHasBomb(f1)) expect(kind).not.toBe("bomb");
+    }
+  });
+
+  test("a douse day always has ghosts (they're how you go dark) and water to wade", () => {
+    let douseDays = 0;
+    for (const day of DAYS) {
+      const { f3 } = buildDay(day);
+      if (entranceOf(f3) !== "douse") continue;
+      douseDays++;
+      expect((f3.enemies ?? []).filter((e) => e.kind === "ghost").length).toBeGreaterThanOrEqual(3);
+      expect(count(f3, TileSubtype.DEEP_WATER)).toBeGreaterThan(0);
+    }
+    expect(douseDays).toBeGreaterThan(0); // the sample actually covered some
+  });
+
+  test("all four kinds appear across the sample, bomb only on bomb days", () => {
+    const tally: Record<string, number> = {};
+    for (const day of DAYS) {
+      const { f1, f3 } = buildDay(day);
+      const kind = entranceOf(f3);
+      tally[kind] = (tally[kind] ?? 0) + 1;
+      if (kind === "bomb") expect(dayHasBomb(f1)).toBe(true);
+    }
+    for (const k of ["bomb", "douse", "moat-lava", "moat-water"]) {
+      expect(tally[k] ?? 0).toBeGreaterThan(0);
+    }
+  });
+
+  test("the floor stays completable: exit + key present and never drowned", () => {
+    for (const day of DAYS.slice(0, 25)) {
+      const { f3 } = buildDay(day);
+      expect(count(f3, TileSubtype.EXIT)).toBeGreaterThan(0);
+      expect(count(f3, TileSubtype.EXITKEY)).toBeGreaterThan(0);
+      for (const row of f3.mapData.subtypes) {
+        for (const c of row) {
+          if (c.includes(TileSubtype.EXIT) || c.includes(TileSubtype.EXITKEY)) {
+            expect(c.includes(TileSubtype.LAVA)).toBe(false);
+            expect(c.includes(TileSubtype.DEEP_WATER)).toBe(false);
+          }
+        }
+      }
+    }
+  });
+});

--- a/__tests__/lib/boss_entrances.test.ts
+++ b/__tests__/lib/boss_entrances.test.ts
@@ -1,3 +1,4 @@
+import { Enemy } from "../../lib/enemy";
 import { movePlayer, Direction, TileSubtype } from "../../lib/map";
 import { performThrowRock } from "../../lib/map/game-state";
 import type { GameState } from "../../lib/map/game-state";
@@ -256,5 +257,126 @@ describe("douse portal in an L3-sized room, with ghosts", () => {
   test("both moat types also carry 3 ghosts", () => {
     expect(ghostCount(buildMoatApproach("lava"))).toBe(3);
     expect(ghostCount(buildMoatApproach("water"))).toBe(3);
+  });
+});
+
+describe("boss room as an ALTERNATE ENDING", () => {
+  // A daily-like floor 3 with a boss entrance next to the hero.
+  function dailyFloorWithEntrance(): GameState {
+    const s = miniRoom({
+      currentFloor: 3,
+      maxFloors: 3,
+      mode: "daily" as unknown as GameState["mode"],
+      hasExitKey: false,
+      stats: { damageDealt: 4, damageTaken: 2, enemiesDefeated: 7, steps: 33 },
+    });
+    s.mapData.subtypes[2][2] = [TileSubtype.BOSS_ENTRANCE];
+    return s;
+  }
+
+  test("entering preserves the run (stats, floor, mode) and stashes a way back", () => {
+    const before = dailyFloorWithEntrance();
+    const after = movePlayer(before, Direction.RIGHT);
+    expect(after.inBossRoom).toBe(true);
+    // The run is intact — entering must not reset the daily.
+    expect(after.currentFloor).toBe(3);
+    expect(after.maxFloors).toBe(3);
+    expect(after.mode).toBe(before.mode);
+    expect(after.stats.steps).toBeGreaterThanOrEqual(33);
+    expect(after.stats.enemiesDefeated).toBe(7);
+    // And there's a stashed floor to come back to.
+    expect(after.bossReturn).toBeTruthy();
+    expect(after.bossReturn!.position).toEqual([2, 2]);
+  });
+
+  test("the arena has a locked exit and the boss waiting", () => {
+    const after = movePlayer(dailyFloorWithEntrance(), Direction.RIGHT);
+    const cells = after.mapData.subtypes.flat();
+    expect(cells.some((c) => c.includes(TileSubtype.EXIT))).toBe(true);
+    expect((after.enemies ?? []).some((e) => e.kind === "shaper")).toBe(true);
+    expect(after.hasExitKey).toBe(false); // the exit is not yet openable
+  });
+
+  test("walking back onto the arrival tile returns to the floor", () => {
+    const entered = movePlayer(dailyFloorWithEntrance(), Direction.RIGHT);
+    const [ay, ax] = findHero(entered);
+    // The arrival tile doubles as the way out.
+    expect(entered.mapData.subtypes[ay][ax]).toContain(TileSubtype.BOSS_ENTRANCE);
+    // Step off, then back on.
+    const off = movePlayer(entered, Direction.UP);
+    const back = movePlayer(off, Direction.DOWN);
+    expect(back.inBossRoom).toBeFalsy();
+    expect(back.mapData.tiles.length).toBe(5); // the little floor is restored
+    expect(back.currentFloor).toBe(3);
+  });
+
+  // A compact stand-in arena: hero beside a nearly-dead Shaper, plus a locked exit.
+  function arenaShowdown(): GameState {
+    const s = miniRoom({
+      inBossRoom: true,
+      currentFloor: 3,
+      maxFloors: 3,
+      hasSword: true,
+      heroAttack: 1,
+    });
+    const boss = new Enemy({ y: 2, x: 2 });
+    boss.kind = "shaper";
+    boss.health = 1;
+    s.enemies = [boss];
+    // The keep's exit is a doorway on the FLOOR (as buildShaperArena places it).
+    s.mapData.subtypes[2][4] = [TileSubtype.EXIT];
+    return s;
+  }
+
+  test("killing the Shaper drops the gold key", () => {
+    const after = movePlayer(arenaShowdown(), Direction.RIGHT); // strike it down
+    expect((after.enemies ?? []).some((e) => e.kind === "shaper")).toBe(false);
+    expect(after.bossDefeated).toBe(true);
+    const cells = after.mapData.subtypes.flat();
+    expect(cells.some((c) => c.includes(TileSubtype.EXITKEY))).toBe(true);
+    // And the kill is tallied for the end-of-day casualties.
+    expect(after.stats.byKind?.shaper).toBe(1);
+  });
+
+  test("the gold key opens the arena exit and WINS the run outright", () => {
+    let s = movePlayer(arenaShowdown(), Direction.RIGHT); // strike: boss dies, key drops
+    s = movePlayer(s, Direction.RIGHT); // step onto the key tile at (2,2)
+    expect(s.hasExitKey).toBe(true);
+    s = movePlayer(s, Direction.RIGHT); // walk to (2,3)
+    s = movePlayer(s, Direction.RIGHT); // into the exit wall at (2,4)
+    expect(s.win).toBe(true);
+    // Crucially it does NOT try to advance a floor — this is the ending.
+    expect(s.needsFloorTransition).toBeFalsy();
+  });
+});
+
+describe("carrying the level-3 gold key into the keep", () => {
+  test("the key you already hold DOES open the keep's exit (a valid boss bypass)", () => {
+    const s = miniRoom({
+      inBossRoom: true,
+      currentFloor: 3,
+      maxFloors: 3,
+      hasExitKey: true, // picked up on floor 3 before finding the entrance
+    });
+    // A live Shaper is still standing; the exit is a wall tile two steps away.
+    const boss = new Enemy({ y: 1, x: 1 });
+    boss.kind = "shaper";
+    s.enemies = [boss];
+    s.mapData.subtypes[2][4] = [TileSubtype.EXIT]; // floor doorway, as in the real keep
+
+    let out = movePlayer(s, Direction.RIGHT); // (2,2)
+    out = movePlayer(out, Direction.RIGHT); // (2,3)
+    out = movePlayer(out, Direction.RIGHT); // into the exit
+    expect(out.win).toBe(true);
+    // Skipping the kill is allowed: no boss key was needed and none was dropped.
+    expect(out.bossDefeated).toBeFalsy();
+  });
+
+  test("entering the keep preserves a key you already had", () => {
+    const s = miniRoom({ hasExitKey: true });
+    s.mapData.subtypes[2][2] = [TileSubtype.BOSS_ENTRANCE];
+    const after = movePlayer(s, Direction.RIGHT);
+    expect(after.inBossRoom).toBe(true);
+    expect(after.hasExitKey).toBe(true);
   });
 });

--- a/__tests__/lib/shaper.test.ts
+++ b/__tests__/lib/shaper.test.ts
@@ -2,6 +2,11 @@ import { Enemy } from "../../lib/enemy";
 import { movePlayer, Direction, TileSubtype } from "../../lib/map";
 import type { GameState } from "../../lib/map/game-state";
 import {
+  buildShaperArena,
+  SHAPER_LAYOUTS,
+  SHAPER_ENTRIES,
+} from "../../lib/bosses/shaper_arena";
+import {
   planShaperAttack,
   executeShaperAttack,
   fireTargets,
@@ -500,3 +505,53 @@ function findHero(s: GameState): [number, number] {
       if (subs[y][x].includes(TileSubtype.PLAYER)) return [y, x];
   throw new Error("hero not found");
 }
+
+describe("the Shaper can never wall ITSELF in (real keep)", () => {
+  test("across many full fights in the actual arena it always leaves a way to it", () => {
+    let sawWalls = 0;
+    for (let seed = 1; seed <= 30; seed++) {
+      let s = buildShaperArena(
+        SHAPER_LAYOUTS[seed % 2],
+        SHAPER_ENTRIES[seed % 4],
+        mulberryish(seed)
+      );
+      forceStrat(s, "wall"); // force the wall brain for every one of these fights
+      s.combatRng = mulberryish(seed * 7 + 3);
+      const wallsAtStart = countWalls(s);
+      for (let t = 0; t < 60; t++) {
+        if ((s.enemies ?? []).length === 0) break; // slain -> it was reachable
+        // The boss always has a tile you could stand on to hit it...
+        expect(bossHasStandableNeighbor(s)).toBe(true);
+        // ...and that tile is still reachable from wherever the hero is.
+        expect(canStillReachBoss(s)).toBe(true);
+        s = movePlayer(s, stepTowardBoss(s));
+        if (s.heroHealth <= 0) break;
+      }
+      if (countWalls(s) > wallsAtStart) sawWalls++;
+    }
+    // Confirm the fights actually exercised wall-building (not a vacuous pass).
+    expect(sawWalls).toBeGreaterThan(0);
+  });
+
+  test("it never entombs itself even when already boxed on three sides", () => {
+    for (let seed = 1; seed <= 12; seed++) {
+      const s = buildShaperArena(SHAPER_LAYOUTS[0], "south", mulberryish(seed));
+      const boss = s.enemies!.find((e) => e.kind === "shaper")!;
+      // Pre-wall three of its four neighbours; the last one must survive.
+      const around: Array<[number, number]> = [
+        [boss.y - 1, boss.x],
+        [boss.y + 1, boss.x],
+        [boss.y, boss.x - 1],
+      ];
+      for (const [wy, wx] of around) s.mapData.tiles[wy][wx] = 1;
+      forceStrat(s, "wall");
+      s.combatRng = seed === 1 ? () => 0.5 : mulberryish(seed);
+      let cur = s;
+      for (let t = 0; t < 15; t++) {
+        cur = movePlayer(cur, stepTowardBoss(cur));
+        if ((cur.enemies ?? []).length === 0 || cur.heroHealth <= 0) break;
+        expect(bossHasStandableNeighbor(cur)).toBe(true);
+      }
+    }
+  });
+});

--- a/__tests__/lib/shaper_arena.test.ts
+++ b/__tests__/lib/shaper_arena.test.ts
@@ -118,3 +118,69 @@ describe("Shaper randomized labyrinth", () => {
     }
   });
 });
+
+// The chamber is rows/cols 9-15 (Chebyshev dist <= 3 from centre).
+const CENTER_LO = 9;
+const CENTER_HI = 15;
+const inChamber = (y: number, x: number) =>
+  y >= CENTER_LO && y <= CENTER_HI && x >= CENTER_LO && x <= CENTER_HI;
+
+function findSubtype(state: GameState, sub: number): [number, number] | null {
+  const S = state.mapData.subtypes;
+  for (let y = 0; y < S.length; y++)
+    for (let x = 0; x < S[y].length; x++) if (S[y][x].includes(sub)) return [y, x];
+  return null;
+}
+
+/** Reachable tiles, optionally treating the Shaper's chamber as impassable. */
+function reachableAvoiding(
+  state: GameState,
+  from: [number, number],
+  skipChamber: boolean
+): Set<string> {
+  const T = state.mapData.tiles;
+  const H = T.length;
+  const W = T[0].length;
+  const seen = new Set<string>([`${from[0]},${from[1]}`]);
+  const q: Array<[number, number]> = [from];
+  while (q.length) {
+    const [y, x] = q.shift()!;
+    for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>) {
+      const ny = y + dy;
+      const nx = x + dx;
+      if (ny < 0 || nx < 0 || ny >= H || nx >= W) continue;
+      if (T[ny][nx] !== 0) continue; // walls block
+      if (skipChamber && inChamber(ny, nx)) continue;
+      const k = `${ny},${nx}`;
+      if (seen.has(k)) continue;
+      seen.add(k);
+      q.push([ny, nx]);
+    }
+  }
+  return seen;
+}
+
+describe("Shaper keep: the chamber is the only way across", () => {
+  for (const entry of SHAPER_ENTRIES) {
+    test(`from the ${entry} entry you CANNOT reach the exit without crossing the chamber`, () => {
+      for (let seed = 1; seed <= 40; seed++) {
+        const state = buildShaperArena(SHAPER_LAYOUTS[seed % 2], entry, mulberry32(seed));
+        const hero = findPlayer(state);
+        const exit = findSubtype(state, TileSubtype.EXIT);
+        expect(exit).not.toBeNull();
+        const [ey, ex] = exit!;
+        // The exit is a doorway you walk ONTO, so it must be floor.
+        expect(state.mapData.tiles[ey][ex]).toBe(0);
+
+        // Rim walk blocked: with the chamber sealed off, the exit is unreachable.
+        const detour = reachableAvoiding(state, hero, true);
+        expect(detour.has(`${ey},${ex}`)).toBe(false);
+        // ...but with the chamber open, the exit IS reachable (the keep stays solvable).
+        const full = reachableAvoiding(state, hero, false);
+        expect(full.has(`${ey},${ex}`)).toBe(true);
+        // And the chamber itself is reachable, so the fight is always available.
+        expect(full.has(`12,12`) || bossReachable(state)).toBe(true);
+      }
+    });
+  }
+});

--- a/lib/bosses/boss_entrances.ts
+++ b/lib/bosses/boss_entrances.ts
@@ -573,3 +573,82 @@ export function buildBombOutsideApproach(): GameState {
     }
   );
 }
+
+// --- Daily-mode rotation -----------------------------------------------------
+//
+// One entrance per boss day. The BOMB entrance is the common case (~half of days)
+// and is self-gating: it only pays off if that run actually finds a bomb. The three
+// non-bomb kinds split the rest, and they're the ones that make a boss reachable on
+// a bombless day. Rolled inside the daily's seeded RNG block so every player gets
+// the same day.
+
+export type BossEntranceKind = "bomb" | "douse" | "moat-lava" | "moat-water";
+
+/** Chance a given daily floor 3 carries a boss entrance at all. 1 = every day. */
+export const BOSS_DAY_CHANCE = 1;
+/** Share of boss days that use the bombable-wall entrance. */
+export const BOMB_ENTRANCE_SHARE = 0.5;
+
+/**
+ * Pick the day's entrance. MUST be called inside the daily seeded RNG block
+ * (withPatchedMathRandom) so the choice is identical for every player that day.
+ *
+ * `bombAvailable` is the load-bearing part: the bomb entrance needs a bomb, and bombs
+ * only come from the Level 2 optional-chest pool (2 of 3 items drawn per run), so ~1 day
+ * in 3 has none. On those days the bomb slice is reassigned to the other three kinds —
+ * otherwise a bombless day would roll "bomb" and end up with NO reachable boss at all.
+ * Always consumes exactly two draws, whichever branch it takes.
+ */
+export function rollBossEntranceKind(opts?: {
+  bombAvailable?: boolean;
+}): BossEntranceKind | null {
+  if (Math.random() >= BOSS_DAY_CHANCE) return null; // not a boss day
+  const r = Math.random();
+  const bombOk = opts?.bombAvailable !== false;
+  if (bombOk && r < BOMB_ENTRANCE_SHARE) return "bomb";
+  // Position within the non-bomb portion: rescaled when bomb was eligible, or the
+  // whole roll when it wasn't (so the three split a bombless day evenly).
+  const t = bombOk ? (r - BOMB_ENTRANCE_SHARE) / (1 - BOMB_ENTRANCE_SHARE) : r;
+  if (t < 1 / 3) return "douse";
+  if (t < 2 / 3) return "moat-lava";
+  return "moat-water";
+}
+
+/** Which elemental Shaper arena an entrance leads into (the way in sets the mood). */
+export function arenaSeedForEntrance(kind: BossEntranceKind): MoatElement {
+  return kind === "moat-water" || kind === "douse" ? "water" : "lava";
+}
+
+/**
+ * Stamp the day's entrance into an already-generated daily floor. Returns false if the
+ * floor had no safe spot for it (caller just leaves that day bossless rather than
+ * risking a broken floor). "bomb" touches nothing here — it's carved into the outside
+ * world later, gated on state.outsideHasBossEntrance.
+ */
+export function stampBossEntranceOnFloor(
+  map: MapData,
+  kind: BossEntranceKind
+): boolean {
+  if (kind === "bomb") return true;
+  const [hy, hx] = findPlayerPos(map);
+  if (kind === "moat-lava") {
+    // 4-6 rocks to cross, straight-line only, and only ever gates the secret.
+    return stampStraightLavaSpur(map, 4 + Math.floor(Math.random() * 3));
+  }
+  if (kind === "moat-water") {
+    const before = countSubtype(map, TileSubtype.BOSS_ENTRANCE);
+    stampCornerMoat(map, "water");
+    return countSubtype(map, TileSubtype.BOSS_ENTRANCE) > before;
+  }
+  // douse: a few deep-water tiles to snuff the torch, plus the dark portal itself.
+  stampCornerWaterPatch(map, hy, hx);
+  const before = countSubtype(map, TileSubtype.DARK_PORTAL);
+  placeDarkPortal(map, hy, hx);
+  return countSubtype(map, TileSubtype.DARK_PORTAL) > before;
+}
+
+function countSubtype(map: MapData, sub: number): number {
+  let n = 0;
+  for (const row of map.subtypes) for (const cell of row) if (cell.includes(sub)) n++;
+  return n;
+}

--- a/lib/bosses/shaper_arena.ts
+++ b/lib/bosses/shaper_arena.ts
@@ -43,36 +43,74 @@ const ENTRY_HERO: Record<ShaperEntry, [number, number]> = {
   west: [12, 1],
 };
 
+// The keep's own way out, on the side OPPOSITE the hero's entry: fight in, kill the
+// Shaper for its gold key in the middle, then leave through the far side instead of
+// backtracking. It sits on the outermost FLOOR tile of that side (the mirror of the
+// entry tile) rather than in the border wall, so it reads as a doorway you walk onto.
+const ENTRY_EXIT: Record<ShaperEntry, [number, number]> = {
+  south: [1, 12],
+  north: [SIZE - 2, 12],
+  east: [12, 1],
+  west: [12, SIZE - 2],
+};
+
 type Grid = number[][];
 type Subs = number[][][];
 type Side = "N" | "S" | "E" | "W";
 const SIDES: Side[] = ["N", "S", "E", "W"];
 
-// Gap coords for a side of the ring at `dist`. Narrow = the single center tile;
-// wide = that tile plus its two neighbours along the wall.
-function gapCoords(dist: number, side: Side, wide: boolean): Array<[number, number]> {
+// Gap coords for a side of the ring at `dist`, centred `offset` tiles along that side
+// (0 = the side's midpoint, which is where the sightlines run). Narrow = one tile; wide
+// = that tile plus its two neighbours along the wall.
+function gapCoords(
+  dist: number,
+  side: Side,
+  wide: boolean,
+  offset = 0
+): Array<[number, number]> {
   const spread = wide ? [-1, 0, 1] : [0];
-  if (side === "N") return spread.map((d) => [CENTER - dist, CENTER + d] as [number, number]);
-  if (side === "S") return spread.map((d) => [CENTER + dist, CENTER + d] as [number, number]);
-  if (side === "W") return spread.map((d) => [CENTER + d, CENTER - dist] as [number, number]);
-  return spread.map((d) => [CENTER + d, CENTER + dist] as [number, number]); // E
+  return spread.map((d) => {
+    const o = offset + d;
+    if (side === "N") return [CENTER - dist, CENTER + o] as [number, number];
+    if (side === "S") return [CENTER + dist, CENTER + o] as [number, number];
+    if (side === "W") return [CENTER + o, CENTER - dist] as [number, number];
+    return [CENTER + o, CENTER + dist] as [number, number]; // E
+  });
 }
 
-function shuffle<T>(arr: T[], rng: () => number): T[] {
-  const a = [...arr];
-  for (let i = a.length - 1; i > 0; i--) {
-    const j = Math.floor(rng() * (i + 1));
-    [a[i], a[j]] = [a[j], a[i]];
+// The hall loops run at the ODD distances, between the ring walls.
+const CORRIDORS = [5, 7, 9, 11];
+/**
+ * How far off the midline each hall loop is cut. Nonzero on purpose: severing exactly
+ * on the midline would also block the boss's cardinal sightlines out of the chamber.
+ */
+const SEVER_OFFSET = 2;
+
+/** Which way the keep is traversed, from the entry side to the exit side. */
+type Axis = "NS" | "EW";
+const AXIS_FOR_ENTRY: Record<ShaperEntry, Axis> = {
+  north: "NS",
+  south: "NS",
+  east: "EW",
+  west: "EW",
+};
+
+/**
+ * Cut every hall loop at two points on the axis PERPENDICULAR to the entry→exit run, so
+ * the loops stop being loops: each becomes an entry-side arc and an exit-side arc that
+ * only meet through the middle. This is what stops you strolling around the outer rim
+ * to the exit — the Shaper's chamber is the sole way across the keep.
+ */
+function severCorridors(tiles: Grid, axis: Axis): void {
+  for (const d of CORRIDORS) {
+    if (axis === "NS") {
+      tiles[CENTER + SEVER_OFFSET][CENTER - d] = WALL;
+      tiles[CENTER + SEVER_OFFSET][CENTER + d] = WALL;
+    } else {
+      tiles[CENTER - d][CENTER + SEVER_OFFSET] = WALL;
+      tiles[CENTER + d][CENTER + SEVER_OFFSET] = WALL;
+    }
   }
-  return a;
-}
-
-// 1-2 random sides, excluding the neighbouring ring's sides (so outer tiers
-// misalign and you must go around).
-function chooseSides(rng: () => number, exclude: Set<Side>): Side[] {
-  const avail = SIDES.filter((s) => !exclude.has(s));
-  const count = Math.min(avail.length, 1 + Math.floor(rng() * 2));
-  return shuffle(avail, rng).slice(0, count);
 }
 
 function drawRing(tiles: Grid, dist: number, gaps: Array<[number, number]>): void {
@@ -133,14 +171,34 @@ export function buildShaperArena(
   );
   for (let y = 1; y < SIZE - 1; y++) for (let x = 1; x < SIZE - 1; x++) tiles[y][x] = FLOOR;
 
-  // Outer maze tiers: narrow, random, misaligned.
-  const s10 = chooseSides(rng, new Set());
-  const s8 = chooseSides(rng, new Set(s10));
-  drawRing(tiles, 10, s10.flatMap((s) => gapCoords(10, s, false)));
-  drawRing(tiles, 8, s8.flatMap((s) => gapCoords(8, s, false)));
+  const axis = AXIS_FOR_ENTRY[entry];
+  // The two sides the traverse runs through: one faces the entry, the other the exit.
+  // Every outer ring MUST be gapped on both, or one half of the keep would be sealed.
+  const axisSides: Side[] = axis === "NS" ? ["N", "S"] : ["E", "W"];
+  const crossSides: Side[] = axis === "NS" ? ["E", "W"] : ["N", "S"];
+
+  // Outer maze tiers: narrow gaps, slid to a random offset along each side so the halls
+  // still wind (you walk the arc hunting the next opening) — plus an optional dead-end
+  // opening on a cross side for a red herring.
+  const outerGaps = (dist: number): Array<[number, number]> => {
+    const span = dist - 2; // keep the opening clear of the ring's corners
+    const gaps = axisSides.flatMap((s) =>
+      gapCoords(dist, s, false, Math.floor(rng() * (2 * span + 1)) - span)
+    );
+    if (rng() < 0.5) {
+      const decoy = crossSides[Math.floor(rng() * crossSides.length)];
+      gaps.push(...gapCoords(dist, decoy, false, Math.floor(rng() * (2 * span + 1)) - span));
+    }
+    return gaps;
+  };
+  drawRing(tiles, 10, outerGaps(10));
+  drawRing(tiles, 8, outerGaps(8));
   // Inner tiers: wide, aligned, all four sides -> the boss can see you coming.
   drawRing(tiles, 6, SIDES.flatMap((s) => gapCoords(6, s, true)));
   drawRing(tiles, 4, SIDES.flatMap((s) => gapCoords(4, s, true)));
+  // Cut the loops so the rim can't be walked around: entry side and exit side now only
+  // connect through the Shaper's chamber.
+  severCorridors(tiles, axis);
 
   seedChamberTerrain(subtypes, layout.seed);
   scatterLoot(tiles, subtypes);
@@ -153,6 +211,13 @@ export function buildShaperArena(
 
   const [hy, hx] = ENTRY_HERO[entry];
   subtypes[hy][hx] = [TileSubtype.PLAYER];
+
+  // The way out, on the FLOOR of the far side. Visible from the moment you walk in (a
+  // promise of an escape you can't use yet): without the gold key you can stand on it
+  // and nothing happens; with the key the Shaper drops on death, it ends the run.
+  const [ey, ex] = ENTRY_EXIT[entry];
+  tiles[ey][ex] = FLOOR;
+  subtypes[ey][ex] = [TileSubtype.EXIT];
 
   tiles[CENTER][CENTER] = FLOOR;
   subtypes[CENTER][CENTER] = [];

--- a/lib/enemies/monster_summary.ts
+++ b/lib/enemies/monster_summary.ts
@@ -70,6 +70,16 @@ const GROUP_DEFS: GroupDef[] = [
   },
   { key: "snake", label: "Snake", emoji: "🐍", rep: "snake", kinds: ["snake"] },
   { key: "wisp", label: "Wisp", emoji: "👻", rep: "ghost", kinds: ["ghost"] },
+  // The boss goes last so it reads as the headline kill of the run. Three glyphs
+  // (ice + skull + fire) capture its whole essence — a skeleton that wields water and
+  // lava — and make it unmistakably a boss beside the single-emoji enemies.
+  {
+    key: "shaper",
+    label: "The Shaper",
+    emoji: "❄️💀🔥",
+    rep: "shaper",
+    kinds: ["shaper"],
+  },
 ];
 
 // Reverse lookup: enemy kind -> its group definition.

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -53,6 +53,12 @@ import { addSnakesPerRules, addStaticGuardNearKey } from "./enemy-features";
 import { buildOutsideWorld, buildNightmareRoom, innerEdgeForDirection } from "./outside-world";
 import { buildPinkRealm } from "./pink-realm";
 import { buildShaperArena, type ShaperEntry } from "../bosses/shaper_arena";
+import {
+  rollBossEntranceKind,
+  stampBossEntranceOnFloor,
+  arenaSeedForEntrance,
+  type BossEntranceKind,
+} from "../bosses/boss_entrances";
 import { seedMist, advanceMist, mistContains } from "./pink-mist";
 import { mulberry32 as mulberry32Fn, withPatchedMathRandom } from "../rng";
 import type { HeroDiaryEntry } from "../story/hero_diary";
@@ -1649,8 +1655,19 @@ export interface GameState {
   // carves a hidden boss entrance in its far tree wall (a boss-day marker).
   inBossRoom?: boolean;
   reachedBossRoom?: boolean;
+  // Latches when the Shaper dies (gold key dropped). Run-level, so the endgame can
+  // report the boss kill even after the hero leaves the arena.
+  bossDefeated?: boolean;
   bossArenaSeed?: "water" | "lava";
   outsideHasBossEntrance?: boolean;
+  // The floor to restore when the hero walks back out of a boss arena. Kept
+  // separate from dungeonReturn/realmReturn (a boss room can be entered from the
+  // dungeon OR from inside another sub-area, so the stashes must nest).
+  bossReturn?: {
+    mapData: MapData;
+    enemies?: PlainEnemy[];
+    position: [number, number];
+  };
   // Pink realm only: the drifting mist's currently-covered tiles ([y,x] pairs). Grows/
   // shrinks organically each turn. Standing in it reverses the hero's controls; enemies
   // in it are blinded. Undefined / absent outside the realm.
@@ -2127,6 +2144,13 @@ export function advanceToNextFloor(currentState: GameState, dailySeed: number): 
 
   // Generate new map with floor-specific seed. The water roll MUST happen inside this
   // seeded block (before map generation) so daily maps stay deterministic.
+  // The day's boss entrance (floor 3 only), rolled inside the seeded block below so
+  // every player gets the same one. Null on a bombless-unlucky roll or when the floor
+  // had no safe spot for it — that day is simply bossless.
+  let bossEntrance: BossEntranceKind | null = null;
+  // Ghosts guaranteed on a douse day (they're how you go dark, and the tell).
+  const DOUSE_DAY_MIN_GHOSTS = 3;
+
   const newMapData = withPatchedMathRandom(rng, () => {
     const waterPlan = rollWaterPlan(nextFloor) ?? undefined;
     let mapData: MapData;
@@ -2135,6 +2159,19 @@ export function advanceToNextFloor(currentState: GameState, dailySeed: number): 
     } else {
       // Floors 5+: no chests or keys, just a standard map without chests/keys
       mapData = generateCompleteMapForFloor({ chests: 0, keys: 0, chestContents: [] }, nextFloor, { includeLava, waterPlan });
+    }
+    // Floor 3 is the escape floor and the only one that hides a boss room. Stamped
+    // BEFORE enemies are placed (below) so nothing spawns inside the moat/lava.
+    if (nextFloor === 3) {
+      // The bombable-wall entrance is only offered when the day actually hands out a
+      // bomb (they come from the Level 2 optional-chest pool, which skips bombs ~1 day
+      // in 3). Otherwise that day gets a douse/moat entrance instead of an unreachable
+      // one. Chest allocation is fixed at run start, so this is stable for the day.
+      const bombAvailable = Object.values(currentState.floorChestAllocation ?? {}).some(
+        (a) => (a.chestContents ?? []).includes(TileSubtype.BOMB)
+      );
+      const kind = rollBossEntranceKind({ bombAvailable });
+      if (kind && stampBossEntranceOnFloor(mapData, kind)) bossEntrance = kind;
     }
     return mapData;
   });
@@ -2183,6 +2220,28 @@ export function advanceToNextFloor(currentState: GameState, dailySeed: number): 
           
           assignWhiteGoblinSwarmIds(placed);
         }
+        // On a DOUSE day the ghosts are the mechanism AND the signpost: they snuff the
+        // torch on contact, which is what reveals the dark portal, and their presence is
+        // the hint that something is hidden here. The normal floor-3 roll can hand out
+        // zero ghosts, which would leave the portal effectively undiscoverable — so top
+        // the floor up to a guaranteed few.
+        if (bossEntrance === "douse") {
+          const have = placed.filter((e) => e.kind === "ghost").length;
+          const need = DOUSE_DAY_MIN_GHOSTS - have;
+          if (need > 0 && playerPos) {
+            const extra = placeEnemies({
+              grid: newMapData.tiles,
+              subtypes: newMapData.subtypes,
+              player: { y: playerPos[0], x: playerPos[1] },
+              count: need,
+              minDistanceFromPlayer: 6,
+            });
+            extra.forEach((g) => {
+              g.kind = "ghost";
+              placed.push(g);
+            });
+          }
+        }
         // Floor 3 (escape floor): station one static guard next to the exit key so
         // collecting it always requires a fight. Inside this seeded block so the
         // guard position is deterministic per daily seed, like the rest of floor 3.
@@ -2193,9 +2252,16 @@ export function advanceToNextFloor(currentState: GameState, dailySeed: number): 
       })
     : [];
 
-  // Add rune pots and snakes
-  const withRunes = addRunePotsForStoneExciters(newMapData, enemies);
-  const snakesAdded = addSnakesPerRules(withRunes, enemies, { floor: nextFloor });
+  // Add rune pots and snakes. These MUST run inside the seeded block like every other
+  // generation step: unseeded, two players on the same daily got different rune pots
+  // and different snakes (snakes are lethal and runes one-shot stone goblins, so it was
+  // a real fairness gap, not cosmetic).
+  const withRunes = withPatchedMathRandom(rng, () =>
+    addRunePotsForStoneExciters(newMapData, enemies)
+  );
+  const snakesAdded = withPatchedMathRandom(rng, () =>
+    addSnakesPerRules(withRunes, enemies, { floor: nextFloor })
+  );
 
   // Create new game state preserving hero stats and inventory
   return {
@@ -2207,6 +2273,10 @@ export function advanceToNextFloor(currentState: GameState, dailySeed: number): 
     hasExitKey: false, // Reset exit key for new floor
     portalLocation: undefined, // Reset placed portal — no backtracking between floors
     win: false, // Reset win state
+    // Boss room for the day: which elemental arena the entrance opens into, and (for
+    // the bomb entrance) permission for the outside world to carve its hidden mouth.
+    bossArenaSeed: bossEntrance ? arenaSeedForEntrance(bossEntrance) : undefined,
+    outsideHasBossEntrance: bossEntrance === "bomb",
     recentDeaths: [],
     recentBombBlasts: [], // don't carry a blast's VFX/shake into the next floor
     defeatedEnemies: [],
@@ -2734,27 +2804,87 @@ const BOSS_ENTRY_BY_DIRECTION: Record<Direction, ShaperEntry> = {
  * reachedBossRoom secret flag. For now every entrance leads to the Shaper; the
  * elemental variant is chosen by bossArenaSeed (default lava).
  */
-function enterBossRoom(state: GameState, direction: Direction): GameState {
+function enterBossRoom(
+  state: GameState,
+  entrancePos: [number, number],
+  direction: Direction
+): GameState {
   const seed: "water" | "lava" = state.bossArenaSeed === "water" ? "water" : "lava";
   const entry = BOSS_ENTRY_BY_DIRECTION[direction] ?? "south";
   const arena = buildShaperArena({ name: "boss", seed }, entry);
+
+  // The arena tile the hero arrives on becomes the way back out (same subtype both
+  // ways, exactly like the pink realm's ring): step off it, then back onto it, to
+  // return to the dungeon. Stepping onto it is only a RETURN while inBossRoom, so it
+  // can never re-trigger the entry warp.
+  const arenaMap = arena.mapData;
+  const arrival = findPlayerPosition(arenaMap);
+  if (arrival) {
+    const [ay, ax] = arrival;
+    const cell = arenaMap.subtypes[ay][ax];
+    if (!cell.includes(TileSubtype.BOSS_ENTRANCE)) cell.push(TileSubtype.BOSS_ENTRANCE);
+  }
+
+  // Take ONLY the arena's map + boss from the builder; every other field must come
+  // from the live run, or entering the fight would wipe the run (exit key, stats,
+  // floor, daily mode, fog) — the builder's literal is standalone-harness defaults.
   return {
-    ...arena,
-    // Carry the run's vitals + inventory into the fight (arena provides defaults).
-    heroHealth: state.heroHealth ?? arena.heroHealth,
-    heroMaxHealth: state.heroMaxHealth ?? arena.heroMaxHealth,
-    heroAttack: state.heroAttack ?? arena.heroAttack,
-    hasSword: state.hasSword ?? arena.hasSword,
-    hasShield: state.hasShield ?? false,
-    rockCount: state.rockCount ?? arena.rockCount,
-    runeCount: state.runeCount ?? arena.runeCount,
-    bombCount: state.bombCount ?? 0,
-    // Preserve run-level secret flags discovered before the boss.
-    reachedPinkRealm: state.reachedPinkRealm,
-    reachedOutsideWorld: state.reachedOutsideWorld,
+    ...state,
+    mapData: arenaMap,
+    enemies: arena.enemies,
+    npcs: [],
     inBossRoom: true,
     reachedBossRoom: true,
     playerDirection: direction,
+    // Stash the floor exactly as it was (player lifted out) so the way back is a
+    // faithful restore. Kept in its own field: dungeonReturn is already in use by
+    // the outside world / pink realm, and a boss room can be entered from either.
+    bossReturn: {
+      mapData: removePlayerFromMapData(state.mapData),
+      enemies: serializeEnemies(state.enemies),
+      position: entrancePos,
+    },
+    mist: undefined, // realm mist doesn't follow you into the arena
+    recentDeaths: [],
+    recentBombBlasts: [],
+  };
+}
+
+/**
+ * The Shaper's death drops the gold key that opens the arena's exit — the alternate
+ * ending. Detected centrally (comparing the pre-move state to the resolved one) rather
+ * than hooked into each of the many kill paths, so melee, thrown rocks and bombs all
+ * work. Idempotent via bossDefeated.
+ */
+function dropBossKeyOnDefeat(
+  after: GameState,
+  bossPosBefore: [number, number] | null
+): void {
+  if (!after.inBossRoom || after.bossDefeated) return;
+  if (!bossPosBefore) return; // no Shaper was alive going into this turn
+  if ((after.enemies ?? []).some((e) => e.kind === "shaper")) return; // still standing
+  // Prefer the recorded death tile; fall back to where it stood before the killing blow.
+  const deaths = after.recentDeaths ?? [];
+  const [ky, kx] = deaths.length > 0 ? deaths[deaths.length - 1] : bossPosBefore;
+  const cell = after.mapData.subtypes[ky]?.[kx];
+  if (cell && !cell.includes(TileSubtype.EXITKEY)) cell.push(TileSubtype.EXITKEY);
+  after.bossDefeated = true;
+}
+
+/** Step back onto the arrival tile inside a boss arena -> restore the saved floor. */
+function returnFromBossRoom(
+  state: GameState,
+  direction: Direction
+): GameState | null {
+  const ret = state.bossReturn;
+  if (!ret) return null;
+  return {
+    ...state,
+    mapData: placePlayerAt(ret.mapData, ret.position),
+    enemies: ret.enemies ? rehydrateEnemies(ret.enemies) : [],
+    playerDirection: direction,
+    inBossRoom: false,
+    bossReturn: undefined,
     recentDeaths: [],
     recentBombBlasts: [],
   };
@@ -2829,8 +2959,16 @@ export function movePlayer(
   // position so stepping out of the 3x3 blast keeps the hero safe. (movePlayer never
   // places a bomb, so every BOMB_LIVE present was armed on a previous turn.) Skip
   // detonation on a floor transition — that floor is being replaced.
+  // Snapshot the Shaper's position BEFORE resolving the turn: movePlayerCore mutates
+  // the enemies array in place, so after the call the pre-state no longer shows it.
+  const bossBefore = (gameState.enemies ?? []).find((e) => e.kind === "shaper");
+  const bossPosBefore: [number, number] | null = bossBefore
+    ? [bossBefore.y, bossBefore.x]
+    : null;
   const result = movePlayerCore(gameState, direction);
   if (result.needsFloorTransition) return result;
+  // Killing the Shaper drops the gold key for the arena's exit (alternate ending).
+  dropBossKeyOnDefeat(result, bossPosBefore);
   // Nightmare darkness drains the hero the deeper they wander. Apply only when the hero
   // actually MOVED while staying in the nightmare (not the entry step, the step back out,
   // or bumping a wall).
@@ -2944,19 +3082,27 @@ function movePlayerCore(
   // (lockless cave mouth) always triggers; a DARK_PORTAL only triggers while the
   // hero's torch is OUT (it is invisible and inert in the light). Never re-triggers
   // once already inside a boss room.
-  if (!gameState.inBossRoom) {
+  {
     const destTile = gameState.mapData.tiles[newY]?.[newX];
     const destSubs = gameState.mapData.subtypes[newY]?.[newX] ?? [];
     const onFloor = destTile === FLOOR || destTile === FLOWERS;
-    if (onFloor && destSubs.includes(TileSubtype.BOSS_ENTRANCE)) {
-      return enterBossRoom(gameState, direction);
-    }
-    if (
-      onFloor &&
-      destSubs.includes(TileSubtype.DARK_PORTAL) &&
-      gameState.heroTorchLit === false
-    ) {
-      return enterBossRoom(gameState, direction);
+    if (gameState.inBossRoom) {
+      // Inside the arena the arrival tile is the way back to the dungeon.
+      if (onFloor && destSubs.includes(TileSubtype.BOSS_ENTRANCE)) {
+        const back = returnFromBossRoom(gameState, direction);
+        if (back) return back;
+      }
+    } else {
+      if (onFloor && destSubs.includes(TileSubtype.BOSS_ENTRANCE)) {
+        return enterBossRoom(gameState, [newY, newX], direction);
+      }
+      if (
+        onFloor &&
+        destSubs.includes(TileSubtype.DARK_PORTAL) &&
+        gameState.heroTorchLit === false
+      ) {
+        return enterBossRoom(gameState, [newY, newX], direction);
+      }
     }
   }
 
@@ -3211,7 +3357,9 @@ function movePlayerCore(
         const isMultiTier = newGameState.maxFloors && newGameState.maxFloors > 1;
         const currentFloor = newGameState.currentFloor ?? 1;
         const maxFloors = newGameState.maxFloors ?? 1;
-        const isFinalFloor = currentFloor >= maxFloors;
+        // The boss arena's exit is an ALTERNATE ENDING: taking it always wins the run
+        // outright, never advances a floor (there is no floor after the boss).
+        const isFinalFloor = currentFloor >= maxFloors || !!newGameState.inBossRoom;
 
         if (isMultiTier && !isFinalFloor) {
           // Multi-tier mode: advance to next floor instead of winning
@@ -3549,7 +3697,9 @@ function movePlayerCore(
         const isMultiTier = newGameState.maxFloors && newGameState.maxFloors > 1;
         const currentFloor = newGameState.currentFloor ?? 1;
         const maxFloors = newGameState.maxFloors ?? 1;
-        const isFinalFloor = currentFloor >= maxFloors;
+        // The boss arena's exit is an ALTERNATE ENDING: taking it always wins the run
+        // outright, never advances a floor (there is no floor after the boss).
+        const isFinalFloor = currentFloor >= maxFloors || !!newGameState.inBossRoom;
 
         if (isMultiTier && !isFinalFloor) {
           // Multi-tier mode: advance to next floor instead of winning


### PR DESCRIPTION
## What

The Shaper arena becomes a real alternate ending in daily mode, live in generation (floor 3 only).

- **Alternate ending**: killing the Shaper drops a gold key that opens a floor-level exit inside the keep, ending the run. Counts as a casualty (`❄️💀🔥`) in the daily results.
- **Bomb-aware rotation**: the bomb entrance only rolls on days that actually have a bomb (~2 of 3 days, from the L2 optional-chest pool); otherwise it falls to douse / lava-moat / water-moat. No day is ever left with an unreachable boss.
- **Douse days guarantee ≥3 ghosts** — they're both the way you go dark and the tell the secret is nearby.
- **Keep redesign**: hall loops are severed off the sightline midline, so entry and exit sides only connect through the Shaper's chamber. No more walking the outer rim around the fight.
- **Exit-key bypass**: a level-3 key you already hold still opens the keep's own exit — valid and fair, since you still have to reach it through the chamber.
- **Exit is now a floor-tile doorway** (mirrors the entry tile) instead of embedded in a wall.

## Bug fix (found while verifying determinism)

Daily rune pots and snakes were generated **outside** the seeded RNG block in `advanceToNextFloor`, so two players on the same daily could get different ones. Both calls are now wrapped in the seeded stream like every other generation step. Verified via a full-map + per-enemy determinism test that failed before the fix and passes after.

## Verified

782 tests pass (including real-daily-path rotation tests — determinism, every day reachable, douse-day ghost guarantee, floor stays completable — and re-verified self-entombment guards against the redesigned keep). Typecheck clean, production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)