### PR TITLE
Make snakes hunt the hero when his torch goes out

### DIFF
--- a/__tests__/lib/snake_torch_aggression.test.ts
+++ b/__tests__/lib/snake_torch_aggression.test.ts
@@ -1,0 +1,256 @@
+import { Enemy, updateEnemies } from "../../lib/enemy";
+import {
+  SNAKE_DARK_SENSE_RADIUS,
+  SNAKE_RILED_TTL,
+} from "../../lib/enemies/registry";
+import { TileSubtype, Direction } from "../../lib/map";
+import { movePlayer } from "../../lib/map/game-state";
+import type { GameState } from "../../lib/map/game-state";
+
+// Snakes invert torch-snuff stealth: a lit torch keeps them aloof, a doused one
+// turns them into heat-seeking hunters. See the SNAKE_DARK_* constants.
+
+const openGrid = (h: number, w = h) =>
+  Array.from({ length: h }, () => Array(w).fill(0));
+const emptySubs = (h: number, w = h) =>
+  Array.from({ length: h }, () => Array.from({ length: w }, () => [] as number[]));
+
+function makeSnake(y: number, x: number): Enemy {
+  const s = new Enemy({ y, x });
+  s.kind = "snake";
+  return s;
+}
+
+/** One enemy tick. `rng` defaults to a mid value so pursuit ordering is stable. */
+function tick(
+  tiles: number[][],
+  subs: number[][][],
+  enemies: Enemy[],
+  player: { y: number; x: number },
+  torchLit: boolean,
+  rng: () => number = () => 0.5
+) {
+  return updateEnemies(tiles, subs, enemies, player, {
+    rng,
+    playerTorchLit: torchLit,
+  });
+}
+
+const dist = (e: Enemy, p: { y: number; x: number }) =>
+  Math.abs(e.y - p.y) + Math.abs(e.x - p.x);
+
+function baseState(
+  tiles: number[][],
+  subtypes: number[][][],
+  overrides: Partial<GameState> = {}
+): GameState {
+  return {
+    hasKey: false,
+    hasExitKey: false,
+    mapData: { tiles, subtypes },
+    showFullMap: true,
+    win: false,
+    playerDirection: Direction.RIGHT,
+    heroHealth: 5,
+    heroMaxHealth: 5,
+    heroAttack: 1,
+    enemies: [],
+    npcs: [],
+    rockCount: 0,
+    runeCount: 0,
+    bombCount: 0,
+    heroTorchLit: true,
+    stats: { damageDealt: 0, damageTaken: 0, enemiesDefeated: 0, steps: 0 },
+    ...overrides,
+  } as GameState;
+}
+
+describe("Snake torch aggression", () => {
+  describe("torch out: snakes hunt", () => {
+    test("closes the distance every single turn", () => {
+      const tiles = openGrid(11);
+      const subs = emptySubs(11);
+      const player = { y: 5, x: 5 };
+      const snake = makeSnake(5, 9); // 4 tiles away, well inside sense range
+
+      let prev = dist(snake, player);
+      // Walk it in until adjacent; a hunter must never lose ground.
+      for (let i = 0; i < 3; i++) {
+        tick(tiles, subs, [snake], player, false);
+        const now = dist(snake, player);
+        expect(now).toBe(prev - 1);
+        prev = now;
+      }
+      expect(prev).toBe(1);
+    });
+
+    test("bites an adjacent hero — a doused hero is not safe nose-to-nose", () => {
+      const tiles = openGrid(7);
+      const subs = emptySubs(7);
+      const player = { y: 3, x: 3 };
+      const snake = makeSnake(3, 4);
+
+      const result = tick(tiles, subs, [snake], player, false);
+
+      expect(result.damage).toBeGreaterThan(0);
+      expect(result.attackingEnemies.map((a) => a.kind)).toContain("snake");
+    });
+
+    test("senses through walls (heat, not line of sight)", () => {
+      // Wall column between snake and hero, with no gap on this row.
+      const tiles = openGrid(9);
+      for (let y = 0; y < 9; y++) tiles[y][4] = 1;
+      tiles[8][4] = 0; // a way around, far to the south
+      const subs = emptySubs(9);
+      const player = { y: 2, x: 2 };
+      const snake = makeSnake(2, 6);
+
+      // No line of sight at all, yet it commits toward the hero.
+      const before = dist(snake, player);
+      tick(tiles, subs, [snake], player, false);
+      expect(dist(snake, player)).toBeLessThan(before);
+      expect(snake.behaviorMemory.hunting).toBe(true);
+    });
+
+    test("ignores a hero beyond the sense radius", () => {
+      const width = SNAKE_DARK_SENSE_RADIUS + 6;
+      const tiles = openGrid(3, width);
+      const subs = emptySubs(3, width);
+      const player = { y: 1, x: 0 };
+      // One tile past the edge of its heat sense.
+      const snake = makeSnake(1, SNAKE_DARK_SENSE_RADIUS + 1);
+
+      tick(tiles, subs, [snake], player, false);
+
+      expect(snake.behaviorMemory.hunting).toBe(false);
+      // Never sensed the hero, so it has no target to remember.
+      expect(snake.behaviorMemory.lastSensed).toBeUndefined();
+    });
+
+    test("still refuses deep water and lava while hunting", () => {
+      const tiles = openGrid(5, 7);
+      const subs = emptySubs(5, 7);
+      const player = { y: 2, x: 0 };
+      const snake = makeSnake(2, 4);
+      // Wall off the detour rows so the only path to the hero is the flooded/
+      // molten tile directly between them.
+      for (let x = 0; x < 7; x++) {
+        tiles[1][x] = 1;
+        tiles[3][x] = 1;
+      }
+      subs[2][3] = [TileSubtype.DEEP_WATER];
+
+      tick(tiles, subs, [snake], player, false);
+      expect([snake.y, snake.x]).toEqual([2, 4]); // held, did not swim
+
+      subs[2][3] = [TileSubtype.LAVA];
+      tick(tiles, subs, [snake], player, false);
+      expect([snake.y, snake.x]).toEqual([2, 4]); // held, did not burn
+    });
+  });
+
+  describe("torch lit: snakes stay aloof", () => {
+    test("mostly slinks away from a lit hero", () => {
+      const tiles = openGrid(11);
+      const subs = emptySubs(11);
+      const player = { y: 5, x: 5 };
+      const snake = makeSnake(5, 7);
+
+      // rng above the approach chance => it retreats.
+      tick(tiles, subs, [snake], player, true, () => 0.9);
+      expect(dist(snake, player)).toBe(3);
+    });
+
+    test("does not beeline the way a hunting snake does", () => {
+      const tiles = openGrid(11);
+      const subs = emptySubs(11);
+      const player = { y: 5, x: 5 };
+      const lit = makeSnake(5, 9);
+      const dark = makeSnake(9, 5);
+
+      // Same rng stream for both; only the torch differs.
+      for (let i = 0; i < 3; i++) {
+        tick(tiles, subs, [lit], player, true, () => 0.9);
+        tick(tiles, subs, [dark], player, false, () => 0.9);
+      }
+
+      expect(dist(dark, player)).toBe(1); // hunted the whole way in
+      expect(dist(lit, player)).toBeGreaterThan(4); // kept its distance
+      expect(lit.behaviorMemory.hunting).toBe(false);
+    });
+
+    test("a lit hero is still bitten if the snake ends up adjacent", () => {
+      const tiles = openGrid(7);
+      const subs = emptySubs(7);
+      const player = { y: 3, x: 3 };
+      const snake = makeSnake(3, 4);
+
+      const result = tick(tiles, subs, [snake], player, true);
+      expect(result.damage).toBeGreaterThan(0);
+    });
+  });
+
+  describe("riled memory after a relight", () => {
+    test("keeps hunting the last sensed spot, then gives up", () => {
+      const tiles = openGrid(11);
+      const subs = emptySubs(11);
+      const player = { y: 5, x: 5 };
+      const snake = makeSnake(5, 10);
+
+      // Lock on in the dark.
+      tick(tiles, subs, [snake], player, false);
+      expect(snake.behaviorMemory.hunting).toBe(true);
+      expect(snake.behaviorMemory.riledTtl).toBe(SNAKE_RILED_TTL);
+      expect(snake.behaviorMemory.lastSensed).toEqual({ y: 5, x: 5 });
+
+      // Relight: the snake stays riled for a few turns rather than resetting.
+      for (let i = 1; i <= SNAKE_RILED_TTL; i++) {
+        tick(tiles, subs, [snake], player, true, () => 0.9);
+        expect(snake.behaviorMemory.riledTtl).toBe(SNAKE_RILED_TTL - i);
+      }
+
+      // Memory spent: back to aloof, and the stale target is cleared.
+      expect(snake.behaviorMemory.hunting).toBe(false);
+      expect(snake.behaviorMemory.lastSensed).toBeUndefined();
+    });
+
+    test("chases the last sensed tile, not the hero's live position", () => {
+      const tiles = openGrid(11);
+      const subs = emptySubs(11);
+      const snake = makeSnake(0, 0);
+
+      // Sense the hero at the top-left, then relight and move him far away.
+      tick(tiles, subs, [snake], { y: 0, x: 4 }, false);
+      expect(snake.behaviorMemory.lastSensed).toEqual({ y: 0, x: 4 });
+
+      const moved = { y: 10, x: 0 }; // straight down, opposite axis
+      tick(tiles, subs, [snake], moved, true, () => 0.9);
+
+      // It committed along the remembered heading (+x), ignoring where he
+      // actually went (+y) — so relighting really does break contact.
+      expect(snake.y).toBe(0);
+      expect(snake.x).toBeGreaterThan(0);
+    });
+  });
+
+  test("end to end: a snuffed hero walking past a snake is bitten and poisoned", () => {
+    const tiles = openGrid(7);
+    const subs = emptySubs(7);
+    subs[3][1] = [TileSubtype.PLAYER];
+    const snake = makeSnake(3, 3);
+    const state = baseState(tiles, subs, {
+      enemies: [snake],
+      heroTorchLit: false, // e.g. just been snuffed by a ghost
+      combatRng: () => 0.5,
+    });
+
+    // Step toward the snake; it hunts, closes, and bites.
+    let next = movePlayer(state, Direction.RIGHT);
+    for (let i = 0; i < 3 && !next.conditions?.poisoned?.active; i++) {
+      next = movePlayer(next, Direction.RIGHT);
+    }
+
+    expect(next.heroHealth).toBeLessThan(5);
+    expect(next.conditions?.poisoned?.active).toBe(true);
+  });
+});

--- a/lib/enemies/registry.ts
+++ b/lib/enemies/registry.ts
@@ -82,6 +82,33 @@ export interface EnemyConfig {
 
 const clampMin = (n: number, min = 0) => (n < min ? min : n);
 
+// --- Snake torch aggression -------------------------------------------------
+// Snakes invert the usual torch-snuff stealth rule. Every other enemy loses the
+// hero when his flame goes out; a snake hunts by body heat, so darkness is when
+// it stops being scenery and starts being a predator. With the torch lit it is
+// aloof (mostly slinks away, occasionally drifts closer); with the torch out it
+// commits, tracks the hero through walls, and bites.
+//
+// This is deliberately global — it reads `ctx.player.torchLit`, so it applies
+// anywhere the torch can go out: ghost snuffs, swimming deep water, the unlit
+// endless floors, and the doused walk to a DARK_PORTAL boss entrance.
+
+// How far a snake senses a doused hero, in Manhattan tiles. Ignores line of
+// sight (heat, not light). Matches ENEMY_VISION_RADIUS and the HUD's "Enemies
+// in sight" panel, so a snake that has a clear line on you is one the HUD is
+// already listing — sensed-through-a-wall is the only unannounced case, and a
+// wall is also what keeps it from reaching you.
+export const SNAKE_DARK_SENSE_RADIUS = 8;
+
+// Turns a snake keeps hunting after it loses the scent — either the hero
+// relights or steps out of range. Relighting is a reprieve, not an off switch:
+// a riled snake finishes its lunge at the hero's last sensed position. Mirrors
+// ENEMY_PURSUIT_TTL, which does the same job for goblin line-of-sight memory.
+export const SNAKE_RILED_TTL = 4;
+
+// Chance an aloof (torch-lit) snake drifts toward the hero rather than away.
+export const SNAKE_LIT_APPROACH_CHANCE = 0.33;
+
 export const EnemyRegistry: Record<EnemyKind, EnemyConfig> = {
   "fire-goblin": {
     kind: "fire-goblin",
@@ -980,7 +1007,8 @@ export const EnemyRegistry: Record<EnemyKind, EnemyConfig> = {
     calcMeleeDamage: ({ heroAttack, swordBonus, variance }) =>
       clampMin(heroAttack + swordBonus + variance),
     behavior: {
-      // Move away from player when visible; wander otherwise
+      // Aloof while the hero's torch burns (mostly slinks away); a relentless
+      // heat-seeking hunter once it goes out. See the SNAKE_DARK_* constants.
       customUpdate: (ctx) => {
         const grid = ctx.grid;
         const e = ctx.enemy; // contains mutable y,x,facing,memory
@@ -992,12 +1020,37 @@ export const EnemyRegistry: Record<EnemyKind, EnemyConfig> = {
         // alternating coiled <-> moving each turn.
         e.memory.moved = false;
 
-        // Torch-snuff stealth: a hidden hero is neither seen nor bitten.
-        const heroHidden = ctx.player.torchLit === false;
-
-        // If adjacent, attack
+        const heroDark = ctx.player.torchLit === false;
         const manhattan = Math.abs(e.y - py) + Math.abs(e.x - px);
-        if (manhattan === 1 && !heroHidden) {
+
+        // Heat sense: a doused hero is prey. No line-of-sight check — the snake
+        // feels him through walls — but it still has to slither around them.
+        const sensesHeat = heroDark && manhattan <= SNAKE_DARK_SENSE_RADIUS;
+        let riledTtl = Number(e.memory.riledTtl ?? 0);
+        if (sensesHeat) {
+          riledTtl = SNAKE_RILED_TTL;
+          e.memory.lastSensed = { y: py, x: px };
+        } else if (riledTtl > 0) {
+          riledTtl -= 1;
+        }
+        e.memory.riledTtl = riledTtl;
+        if (riledTtl <= 0) delete e.memory.lastSensed;
+
+        // A riled snake chases the last place it felt the hero, not his live
+        // position — relighting mid-chase lets you break contact and slip away,
+        // the same escape goblins allow when you snuff mid-chase.
+        const sensed = e.memory.lastSensed as { y: number; x: number } | undefined;
+        const huntTarget = sensesHeat
+          ? { y: py, x: px }
+          : riledTtl > 0 && sensed
+          ? sensed
+          : null;
+        // Exposed for the render layer / debugging: is this snake in hunt mode?
+        e.memory.hunting = huntTarget !== null;
+
+        // If adjacent, bite — lit torch or not. A doused hero used to be
+        // un-bitable even nose-to-nose; darkness is the snake's advantage now.
+        if (manhattan === 1) {
           // Face the player
           if (Math.abs(px - e.x) >= Math.abs(py - e.y)) {
             e.facing = px > e.x ? "RIGHT" : "LEFT";
@@ -1022,12 +1075,40 @@ export const EnemyRegistry: Record<EnemyKind, EnemyConfig> = {
           );
         };
 
-        // If can see player, decide each tick: 33% approach, 67% avoid (move away)
-        const sees = !heroHidden && canSee(grid, [e.y, e.x], [py, px]);
+        // Hunting the dark: commit, and close the distance every single turn.
+        // Uses the shared pursuit ordering so the approach still can't be read
+        // tile-for-tile (see lib/enemies/pursuit.ts).
+        if (huntTarget) {
+          const steps = orderPursuitSteps(
+            huntTarget.y - e.y,
+            huntTarget.x - e.x,
+            ctx.rng ?? Math.random
+          );
+          for (const [my, mx] of steps) {
+            const ny = e.y + my;
+            const nx = e.x + mx;
+            if (isFloor(ny, nx)) {
+              if (mx !== 0) e.facing = mx > 0 ? "RIGHT" : "LEFT";
+              else if (my !== 0) e.facing = my > 0 ? "DOWN" : "UP";
+              e.y = ny;
+              e.x = nx;
+              e.memory.moved = true;
+              return 0;
+            }
+          }
+          // Boxed in by walls this turn — hold position and keep hunting.
+          return 0;
+        }
+
+        // Torch lit: aloof. Decide each tick — mostly avoid, sometimes approach.
+        // A doused hero who is out of heat range is genuinely lost: no flame to
+        // spot and too far to feel, so the snake falls through to wandering.
+        const sees = !heroDark && canSee(grid, [e.y, e.x], [py, px]);
         if (sees) {
           const dy = py - e.y;
           const dx = px - e.x;
-          const goToward = (ctx.rng?.() ?? Math.random()) < 0.33;
+          const goToward =
+            (ctx.rng?.() ?? Math.random()) < SNAKE_LIT_APPROACH_CHANCE;
           const tryMoves: Array<[number, number]> = [];
           if (Math.abs(dx) >= Math.abs(dy)) {
             // Favor X axis first

--- a/lib/enemy.ts
+++ b/lib/enemy.ts
@@ -679,11 +679,16 @@ export function updateEnemies(
         subtypes,
         enemies: enemies.map(en => ({ y: en.y, x: en.x, kind: en.kind, health: en.health, behaviorMemory: en.behaviorMemory })),
         enemyIndex: i,
-        player: { y: player.y, x: player.x, torchLit: opts?.playerTorchLit ?? true },
+        // Read the NORMALIZED opts, not the raw 5th arg: under the legacy
+        // 4-arg signature `opts` is undefined, which silently fed every
+        // custom-update enemy `torchLit: true`. Snakes hunt on exactly this
+        // flag (see the snake behavior in enemies/registry), so a stale `true`
+        // there would quietly disable the mechanic.
+        player: { y: player.y, x: player.x, torchLit: finalOpts?.playerTorchLit ?? true },
         playerNext: finalOpts?.playerNext,
         ghosts: ghostPositions,
         rng,
-        setPlayerTorchLit: opts?.setPlayerTorchLit,
+        setPlayerTorchLit: finalOpts?.setPlayerTorchLit,
         mist: finalOpts?.mist,
         enemy: enemyCtx,
       });
@@ -785,8 +790,9 @@ export function updateEnemies(
       });
     }
     // Robust fallback: if a ghost is adjacent, ensure torch is snuffed regardless of hook wiring
-    if (isAdjacent && e.kind === 'ghost' && opts?.setPlayerTorchLit) {
-      opts.setPlayerTorchLit(false);
+    // (normalized opts, for the same reason as the customUpdate branch above)
+    if (isAdjacent && e.kind === 'ghost' && finalOpts?.setPlayerTorchLit) {
+      finalOpts.setPlayerTorchLit(false);
     }
   }
 


### PR DESCRIPTION
Snakes now **invert** torch-snuff stealth instead of obeying it.

| Torch | Behavior |
|---|---|
| **Lit** | Aloof, unchanged — ~33% drift toward you, 67% slink away. Bites if you crowd it. |
| **Out, within 8 tiles** | Hunts. Senses body heat *through walls* (no LOS), closes one tile every turn, bites on contact → poison. |
| **Out, beyond 8 tiles** | Genuinely lost — no flame to spot, too far to feel. Wanders. |

Previously a doused hero was un-bitable **even nose-to-nose** (the adjacency check was gated on `!heroHidden`), so darkness was a free pass past every snake.

### Relighting is a reprieve, not an off switch
A locked-on snake stays riled for 4 turns and chases the tile where it *last felt* you — not your live position. So relighting mid-chase lets you break contact and slip away, mirroring the escape goblins already grant when you snuff mid-chase.

### Why it matters now
Driven off `ctx.player.torchLit`, so it applies everywhere the torch can go out: ghost snuffs, swimming deep water, unlit endless floors, and the deliberate doused walk to a `DARK_PORTAL` boss entrance. That last trip was previously free — it now costs something, which is the point.

Emergent nicety: a hunting snake won't enter deep water, so it stalks the shoreline while you swim.

Tuning knobs exported from `lib/enemies/registry.ts`: `SNAKE_DARK_SENSE_RADIUS` (8), `SNAKE_RILED_TTL` (4), `SNAKE_LIT_APPROACH_CHANCE` (0.33). Snake *speed* in the dark is deliberately left alone as the next lever.

### Fairness
8 tiles matches `ENEMY_VISION_RADIUS` and the HUD's "Enemies in sight" panel, which lists enemies within 8 tiles with LOS regardless of torch state — so an approaching hunter is already telegraphed. Sensing through a wall is the only silent case, and the wall is also what slows it down.

### Drive-by fix
`updateEnemies` fed its `customUpdate` branch the raw 5th arg instead of the normalized `finalOpts`, so under the legacy 4-arg signature every custom-update enemy silently got `torchLit: true`. No production call site uses that shape, but this mechanic hangs entirely on that flag.

### Verification
- 11 new tests in `__tests__/lib/snake_torch_aggression.test.ts` — hunt/aloof/riled/through-walls/out-of-range/terrain refusal, plus an end-to-end `movePlayer` case asserting bite + poison
- Full suite: 807 passed, 11 skipped
- `npm run typecheck` clean, `npm run build` clean
- Lint clean apart from one pre-existing `playerSees` warning in the pink goblin behavior
- No new asset paths, so the standalone build is unaffected

Not verified in-browser — turn-based AI that tests cover more precisely than screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)