### PR TITLE
Replace the outside-world boss route with a sealed doorway

### DIFF
--- a/__tests__/lib/bomb_throwing.test.ts
+++ b/__tests__/lib/bomb_throwing.test.ts
@@ -118,25 +118,24 @@ describe("Bomb detonation - 3x3 blast", () => {
     expect(blown.recentBombBlasts).toContainEqual([5, 7]);
   });
 
-  it("removes a mounted wall torch when its wall is blasted to floor", () => {
+  it("leaves a torch-bearing wall standing — set stone shrugs off the blast", () => {
+    // A torch wall is blast-proof. This is what keeps a sealed doorway's two bracketing
+    // torches intact: the bomb rests directly below the seal, so its 3x3 covers them, and
+    // without this rule the motif would blow into one anonymous 3-wide hole.
     const map = makeArena(12, 5, 5);
     map.tiles[5][8] = WALL;
     map.subtypes[5][8] = [TileSubtype.WALL_TORCH];
     const thrown = performThrowBomb(baseState(map, { playerDirection: Direction.RIGHT }));
     const blown = detonateLiveBombs(thrown);
 
-    expect(blown.mapData.tiles[5][8]).toBe(FLOOR); // wall destroyed
-    // The mounted torch must not linger on the now-open floor tile.
-    expect(blown.mapData.subtypes[5][8]).not.toContain(TileSubtype.WALL_TORCH);
-    // Hero can now walk onto the tile (a lingering torch would block it).
-    const stepped = movePlayer(
-      { ...blown, playerDirection: Direction.RIGHT },
-      Direction.RIGHT
-    );
-    // Player started at (5,5); after three rightward steps they should reach (5,8).
-    let s = stepped;
-    for (let i = 0; i < 2; i++) s = movePlayer(s, Direction.RIGHT);
-    expect(findPlayer(s.mapData)).toEqual([5, 8]);
+    expect(blown.mapData.tiles[5][8]).toBe(WALL); // still a wall
+    expect(blown.mapData.subtypes[5][8]).toContain(TileSubtype.WALL_TORCH);
+    expect(blown.mapData.subtypes[5][8]).not.toContain(TileSubtype.SINGED);
+    expect(blown.stats.wallsDestroyed ?? 0).toBe(0);
+    // And it still blocks: three steps right can only reach (5,7).
+    let s: GameState = { ...blown, playerDirection: Direction.RIGHT };
+    for (let i = 0; i < 3; i++) s = movePlayer(s, Direction.RIGHT);
+    expect(findPlayer(s.mapData)).toEqual([5, 7]);
   });
 
   it("detonates automatically on the player's next turn", () => {

--- a/__tests__/lib/boss_daily_rotation.test.ts
+++ b/__tests__/lib/boss_daily_rotation.test.ts
@@ -31,7 +31,11 @@ function dayHasBomb(f1: GameState): boolean {
 }
 
 function entranceOf(f3: GameState): string {
-  if (f3.outsideHasBossEntrance) return "bomb";
+  // A bomb day stamps a bracketed WALL_SEAL and records "boss" as its payload; the
+  // BOSS_ENTRANCE itself doesn't exist on the map until the seal is blown open. Counting
+  // WALL_SEAL tiles would NOT work — decoy cracks are rolled on every floor regardless of
+  // the entrance kind, so a douse or moat day can carry cracks too.
+  if (Object.values(f3.sealPayloads ?? {}).includes("boss")) return "bomb";
   if (count(f3, TileSubtype.DARK_PORTAL) > 0) return "douse";
   if (count(f3, TileSubtype.BOSS_ENTRANCE) > 0) return `moat-${f3.bossArenaSeed}`;
   return "none";

--- a/__tests__/lib/boss_entrances.test.ts
+++ b/__tests__/lib/boss_entrances.test.ts
@@ -6,7 +6,7 @@ import { buildOutsideWorld } from "../../lib/map/outside-world";
 import {
   buildMoatApproach,
   buildDousePortalApproach,
-  buildBombOutsideApproach,
+  buildBombSealApproach,
 } from "../../lib/bosses/boss_entrances";
 
 const SHAPER_ARENA_SIZE = 25;
@@ -197,27 +197,18 @@ describe("moat approach in a real Level-3 room", () => {
   });
 });
 
-describe("outside-world boss entrance", () => {
-  test("bossEntrance:true carves an opening and places a BOSS_ENTRANCE in the far tree wall", () => {
-    // Stepping UP out of the dungeon -> inner edge is the bottom, far wall the top.
-    const { mapData } = buildOutsideWorld(Direction.UP, 15, 15, { bossEntrance: true });
-    let found: [number, number] | null = null;
-    for (let y = 0; y < mapData.subtypes.length; y++)
-      for (let x = 0; x < mapData.subtypes[y].length; x++)
-        if (mapData.subtypes[y][x].includes(TileSubtype.BOSS_ENTRANCE)) found = [y, x];
-    expect(found).not.toBeNull();
-    // The carve runs through the far (top) tree border, so the entrance's column is FLOOR.
-    const [ey, ex] = found!;
-    expect(mapData.tiles[ey][ex]).toBe(0);
-    expect(mapData.tiles[ey + 1][ex]).toBe(0); // path punched through the border
-  });
-
-  test("without the flag, no boss entrance is carved", () => {
-    const { mapData } = buildOutsideWorld(Direction.UP, 15, 15);
-    const any = mapData.subtypes.some((row) =>
-      row.some((cell) => cell.includes(TileSubtype.BOSS_ENTRANCE))
-    );
-    expect(any).toBe(false);
+describe("outside world is no longer a boss route", () => {
+  // The old bomb entrance carved a cave mouth through the far tree wall. Once players
+  // knew it was there, bombing ANY outer wall reached the boss, so the secret was gone.
+  // The outside world is now a dead end again; the boss sits behind a sealed doorway.
+  test("carves no boss entrance in any direction", () => {
+    for (const dir of [Direction.UP, Direction.DOWN, Direction.LEFT, Direction.RIGHT]) {
+      const { mapData } = buildOutsideWorld(dir, 15, 15);
+      const any = mapData.subtypes.some((row) =>
+        row.some((cell) => cell.includes(TileSubtype.BOSS_ENTRANCE))
+      );
+      expect(any).toBe(false);
+    }
   });
 });
 
@@ -231,9 +222,16 @@ describe("approach builders are valid playable states", () => {
     expect(hasPortal).toBe(true);
     expect(douse.showFullMap).toBe(false); // fog on so the dark reveal renders
 
-    const bomb = buildBombOutsideApproach();
+    const bomb = buildBombSealApproach();
     expect(bomb.bombCount).toBe(3);
-    expect(bomb.outsideHasBossEntrance).toBe(true);
+    expect(findHero(bomb)[0]).toBeGreaterThanOrEqual(0);
+    // A sealed doorway + its decoys, and a payload recorded for each one.
+    const seals = bomb.mapData.subtypes
+      .flat()
+      .filter((c) => c.includes(TileSubtype.WALL_SEAL));
+    expect(seals.length).toBeGreaterThanOrEqual(1);
+    expect(Object.keys(bomb.sealPayloads ?? {}).length).toBe(seals.length);
+    expect(Object.values(bomb.sealPayloads ?? {})).toContain("boss");
   });
 });
 

--- a/__tests__/lib/sealed_doorway.test.ts
+++ b/__tests__/lib/sealed_doorway.test.ts
@@ -1,0 +1,371 @@
+import {
+  detonateLiveBombs,
+  movePlayer,
+  performThrowBomb,
+  type GameState,
+} from "../../lib/map/game-state";
+import { Direction, FLOOR, WALL, TileSubtype } from "../../lib/map/constants";
+import type { MapData, SealPayload } from "../../lib/map/types";
+import {
+  MAX_DECOY_SEALS,
+  rollDecoySealCount,
+  sealCoords,
+  stampDecoySeals,
+  stampSealedDoorway,
+} from "../../lib/bosses/boss_entrances";
+import {
+  advanceToNextFloor,
+  initializeGameStateForMultiTier,
+} from "../../lib/map/game-state";
+import { generateCompleteMapForFloor } from "../../lib/map/map-features";
+import { hashStringToSeed, mulberry32, withPatchedMathRandom } from "../../lib/rng";
+
+function baseState(mapData: MapData, overrides: Partial<GameState> = {}): GameState {
+  return {
+    hasKey: false,
+    hasExitKey: false,
+    hasSword: false,
+    hasShield: false,
+    showFullMap: true,
+    win: false,
+    playerDirection: Direction.UP,
+    enemies: [],
+    heroHealth: 5,
+    heroMaxHealth: 5,
+    heroAttack: 1,
+    heroTorchLit: true,
+    rockCount: 0,
+    runeCount: 0,
+    foodCount: 0,
+    potionCount: 0,
+    bombCount: 3,
+    stats: { damageDealt: 0, damageTaken: 0, enemiesDefeated: 0, steps: 0 },
+    mapData,
+    recentDeaths: [],
+    mode: "normal",
+    ...overrides,
+  } as GameState;
+}
+
+/**
+ * A 9x9 arena with a sealed doorway in the wall row at y=3: torch at (3,3), seal at
+ * (3,4), torch at (3,5). The hero starts two tiles below the seal at (5,4) facing up, so
+ * a thrown bomb comes to rest on (4,4) — directly in front of the seal.
+ */
+function sealArena(payload: SealPayload): GameState {
+  const size = 9;
+  const tiles: number[][] = [];
+  const subtypes: number[][][] = [];
+  for (let y = 0; y < size; y++) {
+    tiles.push(
+      Array.from({ length: size }, (_, x) =>
+        y === 0 || x === 0 || y === size - 1 || x === size - 1 ? WALL : FLOOR
+      )
+    );
+    subtypes.push(Array.from({ length: size }, () => [] as number[]));
+  }
+  // A one-tile-thick interior wall run at y=3 with floor below it (a faced wall).
+  for (let x = 1; x < size - 1; x++) tiles[3][x] = WALL;
+  subtypes[3][3] = [TileSubtype.WALL_TORCH];
+  subtypes[3][4] = [TileSubtype.WALL_SEAL];
+  subtypes[3][5] = [TileSubtype.WALL_TORCH];
+  subtypes[5][4] = [TileSubtype.PLAYER];
+
+  return baseState(
+    { tiles, subtypes },
+    { sealPayloads: { "3,4": payload }, playerDirection: Direction.UP }
+  );
+}
+
+/** Throw upward and resolve the fuse. */
+function bombTheSeal(state: GameState): GameState {
+  return detonateLiveBombs(performThrowBomb(state));
+}
+
+describe("sealed doorway — blowing it open", () => {
+  it("opens the real seal into a BOSS_ENTRANCE cave mouth", () => {
+    const blown = bombTheSeal(sealArena("boss"));
+
+    expect(blown.mapData.tiles[3][4]).toBe(FLOOR);
+    expect(blown.mapData.subtypes[3][4]).toContain(TileSubtype.BOSS_ENTRANCE);
+    expect(blown.mapData.subtypes[3][4]).not.toContain(TileSubtype.WALL_SEAL);
+    // The reward reads cleanly — no scorch decal fighting the cave mouth.
+    expect(blown.mapData.subtypes[3][4]).not.toContain(TileSubtype.SINGED);
+    // Payload consumed, so a second blast on the same tile can't mint another entrance.
+    expect(blown.sealPayloads?.["3,4"]).toBeUndefined();
+  });
+
+  it("leaves both bracketing torches standing, so the motif survives the blast", () => {
+    const blown = bombTheSeal(sealArena("boss"));
+
+    for (const x of [3, 5]) {
+      expect(blown.mapData.tiles[3][x]).toBe(WALL);
+      expect(blown.mapData.subtypes[3][x]).toContain(TileSubtype.WALL_TORCH);
+    }
+    // Exactly one wall came down: the seal itself.
+    expect(blown.stats.wallsDestroyed).toBe(1);
+  });
+
+  it("opens a decoy into a pot holding pink-realm fruit", () => {
+    const blown = bombTheSeal(sealArena("berry"));
+
+    expect(blown.mapData.tiles[3][4]).toBe(FLOOR);
+    expect(blown.mapData.subtypes[3][4]).toContain(TileSubtype.POT);
+    expect(blown.mapData.subtypes[3][4]).not.toContain(TileSubtype.BOSS_ENTRANCE);
+    // The pot is pre-loaded with the berry rather than rolling random contents.
+    expect(blown.potOverrides?.["3,4"]).toBe(TileSubtype.BERRY);
+  });
+
+  it("a food decoy loads ordinary food instead", () => {
+    const blown = bombTheSeal(sealArena("food"));
+    expect(blown.potOverrides?.["3,4"]).toBe(TileSubtype.FOOD);
+  });
+
+  it("walking into the opened decoy pot yields the fruit", () => {
+    let s = bombTheSeal(sealArena("berry"));
+    // Hero is at (5,4); step up onto (4,4), then bump the pot at (3,4) to open it.
+    s = movePlayer(s, Direction.UP);
+    s = movePlayer(s, Direction.UP);
+    expect(s.mapData.subtypes[3][4]).toContain(TileSubtype.BERRY);
+    expect(s.mapData.subtypes[3][4]).not.toContain(TileSubtype.POT);
+    // Then step onto it to collect.
+    s = movePlayer(s, Direction.UP);
+    expect(s.berryCount).toBe(1);
+  });
+
+  it("a seal on the boundary row opens inward, not out to the grassland", () => {
+    // The fallback site is the map's top wall row, where a blasted wall normally earns a
+    // BREACH tag and walks the hero outside. A doorway must lead to what was behind it.
+    const state = sealArena("boss");
+    // Re-home the seal onto row 0 (the perimeter) with the hero below it.
+    state.mapData.subtypes[3][4] = [];
+    state.mapData.subtypes[0][4] = [TileSubtype.WALL_SEAL];
+    state.mapData.tiles[3][4] = FLOOR;
+    state.mapData.subtypes[5][4] = [];
+    state.mapData.subtypes[2][4] = [TileSubtype.PLAYER];
+    state.sealPayloads = { "0,4": "boss" };
+
+    const blown = bombTheSeal(state);
+    expect(blown.mapData.subtypes[0][4]).toContain(TileSubtype.BOSS_ENTRANCE);
+    expect(blown.mapData.subtypes[0][4]).not.toContain(TileSubtype.BREACH);
+  });
+
+  it("a seal with no recorded payload just becomes plain floor", () => {
+    // Defensive: a stale save without sealPayloads must not crash or mint a free boss door.
+    const state = sealArena("boss");
+    const blown = bombTheSeal({ ...state, sealPayloads: undefined });
+    expect(blown.mapData.tiles[3][4]).toBe(FLOOR);
+    expect(blown.mapData.subtypes[3][4]).not.toContain(TileSubtype.BOSS_ENTRANCE);
+    expect(blown.mapData.subtypes[3][4]).not.toContain(TileSubtype.POT);
+  });
+});
+
+describe("sealed doorway — placement rules", () => {
+  function floor3(seed: number): MapData {
+    return withPatchedMathRandom(mulberry32(seed), () =>
+      generateCompleteMapForFloor({ chests: 0, keys: 0, chestContents: [] }, 3)
+    );
+  }
+
+  function sealsOf(map: MapData): Array<[number, number]> {
+    const out: Array<[number, number]> = [];
+    for (let y = 0; y < map.subtypes.length; y++)
+      for (let x = 0; x < map.subtypes[y].length; x++)
+        if (map.subtypes[y][x].includes(TileSubtype.WALL_SEAL)) out.push([y, x]);
+    return out;
+  }
+
+  /** Stamp the doorway then the max decoys, the way the harness does. */
+  function stampBoth(seed: number) {
+    const map = floor3(seed);
+    const payloads = withPatchedMathRandom(mulberry32(seed * 31), () => {
+      const real = stampSealedDoorway(map);
+      if (!real) return null;
+      return {
+        ...real,
+        ...stampDecoySeals(map, MAX_DECOY_SEALS, sealCoords(real)),
+      };
+    });
+    return { map, payloads };
+  }
+
+  it("only ever seals a wall with FLOOR below it (the only wall with a visible face)", () => {
+    for (let seed = 1; seed <= 25; seed++) {
+      const { map, payloads } = stampBoth(seed);
+      if (!payloads) continue;
+      for (const [y, x] of sealsOf(map)) {
+        expect(map.tiles[y][x]).toBe(WALL);
+        expect(map.tiles[y + 1][x]).toBe(FLOOR);
+      }
+    }
+  });
+
+  it("brackets the real seal with two torches and keeps decoys well clear of any torch", () => {
+    for (let seed = 1; seed <= 25; seed++) {
+      const { map, payloads } = stampBoth(seed);
+      if (!payloads) continue;
+
+      const bossKeys = Object.entries(payloads).filter(([, p]) => p === "boss");
+      expect(bossKeys).toHaveLength(1);
+      const [by, bx] = bossKeys[0][0].split(",").map(Number);
+      expect(map.subtypes[by][bx - 1]).toContain(TileSubtype.WALL_TORCH);
+      expect(map.subtypes[by][bx + 1]).toContain(TileSubtype.WALL_TORCH);
+
+      // A decoy must have no torch within 2 tiles, or the torch-pair tell breaks down.
+      for (const [key, payload] of Object.entries(payloads)) {
+        if (payload === "boss") continue;
+        const [y, x] = key.split(",").map(Number);
+        for (let dy = -2; dy <= 2; dy++)
+          for (let dx = -2; dx <= 2; dx++)
+            expect(map.subtypes[y + dy]?.[x + dx] ?? []).not.toContain(
+              TileSubtype.WALL_TORCH
+            );
+      }
+    }
+  });
+
+  it("records a payload for every seal it stamps, and at least one fruit decoy", () => {
+    let checked = 0;
+    for (let seed = 1; seed <= 25; seed++) {
+      const { map, payloads } = stampBoth(seed);
+      if (!payloads) continue;
+      checked++;
+      expect(Object.keys(payloads).length).toBe(sealsOf(map).length);
+      expect(Object.keys(payloads).length).toBeLessThanOrEqual(MAX_DECOY_SEALS + 1);
+      // Every decoy is worth the bomb, and the first one is always pink-realm fruit.
+      const decoys = Object.values(payloads).filter((p) => p !== "boss");
+      if (decoys.length > 0) expect(decoys).toContain("berry");
+      for (const p of Object.values(payloads))
+        expect(["boss", "berry", "food"]).toContain(p);
+    }
+    expect(checked).toBeGreaterThan(20); // a site exists on the vast majority of floors
+  });
+
+  it("never overwrites the exit, its key, or a chest", () => {
+    for (let seed = 1; seed <= 25; seed++) {
+      const map = floor3(seed);
+      const before = JSON.stringify(map.subtypes);
+      const protectedBefore = [
+        TileSubtype.EXIT,
+        TileSubtype.EXITKEY,
+        TileSubtype.CHEST,
+        TileSubtype.PLAYER,
+      ].map((s) => (before.match(new RegExp(`\\b${s}\\b`, "g")) ?? []).length);
+      withPatchedMathRandom(mulberry32(seed * 31), () => stampSealedDoorway(map));
+      const after = JSON.stringify(map.subtypes);
+      const protectedAfter = [
+        TileSubtype.EXIT,
+        TileSubtype.EXITKEY,
+        TileSubtype.CHEST,
+        TileSubtype.PLAYER,
+      ].map((s) => (after.match(new RegExp(`\\b${s}\\b`, "g")) ?? []).length);
+      expect(protectedAfter).toEqual(protectedBefore);
+    }
+  });
+
+  it("is DETERMINISTIC — the same seed stamps the same seals and payloads", () => {
+    for (const day of ["2026-08-03", "2026-09-19"]) {
+      const seed = hashStringToSeed(day);
+      const run = () => {
+        const map = floor3(seed);
+        const payloads = withPatchedMathRandom(mulberry32(seed), () => {
+          const real = stampSealedDoorway(map);
+          return real
+            ? { ...real, ...stampDecoySeals(map, MAX_DECOY_SEALS, sealCoords(real)) }
+            : null;
+        });
+        return { seals: sealsOf(map), payloads };
+      };
+      const a = run();
+      const b = run();
+      expect(a.seals).toEqual(b.seals);
+      expect(a.payloads).toEqual(b.payloads);
+    }
+  });
+});
+
+describe("decoy cracks on every floor", () => {
+  it("rolls 0, 1, or 2 — and actually produces all three over many days", () => {
+    const seen = new Set<number>();
+    for (let seed = 1; seed <= 200; seed++) {
+      const n = withPatchedMathRandom(mulberry32(seed), () => rollDecoySealCount());
+      expect(n).toBeGreaterThanOrEqual(0);
+      expect(n).toBeLessThanOrEqual(MAX_DECOY_SEALS);
+      seen.add(n);
+    }
+    expect([...seen].sort()).toEqual([0, 1, MAX_DECOY_SEALS]);
+  });
+
+  it("puts cracks on floor 1, where the hero has no bombs and can do nothing about them", () => {
+    // The point of a floor-1 crack: it teaches the motif before it can ever be used.
+    let floorsWithCracks = 0;
+    let sawEmptyFloor = false;
+    for (let i = 0; i < 40; i++) {
+      const seed = hashStringToSeed(`2026-10-${String((i % 28) + 1).padStart(2, "0")}-${i}`);
+      const f1 = withPatchedMathRandom(mulberry32(seed), () =>
+        initializeGameStateForMultiTier(1)
+      );
+      const cracks = f1.mapData.subtypes
+        .flat()
+        .filter((c) => c.includes(TileSubtype.WALL_SEAL)).length;
+      expect(cracks).toBeLessThanOrEqual(MAX_DECOY_SEALS);
+      expect(Object.keys(f1.sealPayloads ?? {}).length).toBe(cracks);
+      // Floor 1 never hides the boss — only decoys.
+      expect(Object.values(f1.sealPayloads ?? {})).not.toContain("boss");
+      expect(f1.bombCount ?? 0).toBe(0);
+      if (cracks > 0) floorsWithCracks++;
+      else sawEmptyFloor = true;
+    }
+    expect(floorsWithCracks).toBeGreaterThan(0);
+    expect(sawEmptyFloor).toBe(true); // variance is the point: some floors have none
+  });
+
+  it("puts cracks on floor 2 as well, alongside the day's chests", () => {
+    let floorsWithCracks = 0;
+    for (let i = 0; i < 25; i++) {
+      const seed = hashStringToSeed(`2026-11-${String((i % 28) + 1).padStart(2, "0")}`);
+      const f1 = withPatchedMathRandom(mulberry32(seed), () =>
+        initializeGameStateForMultiTier(1)
+      );
+      const f2 = advanceToNextFloor(f1, seed);
+      const cracks = f2.mapData.subtypes
+        .flat()
+        .filter((c) => c.includes(TileSubtype.WALL_SEAL)).length;
+      expect(cracks).toBeLessThanOrEqual(MAX_DECOY_SEALS);
+      expect(Object.keys(f2.sealPayloads ?? {}).length).toBe(cracks);
+      expect(Object.values(f2.sealPayloads ?? {})).not.toContain("boss");
+      if (cracks > 0) floorsWithCracks++;
+    }
+    expect(floorsWithCracks).toBeGreaterThan(0);
+  });
+
+  it("floor 3 carries at most one boss seal, and 0-2 decoys on top of it", () => {
+    let bombDays = 0;
+    let bombDayDecoyCounts = new Set<number>();
+    for (let i = 0; i < 40; i++) {
+      const seed = hashStringToSeed(`2026-12-${String((i % 28) + 1).padStart(2, "0")}-${i}`);
+      const f1 = withPatchedMathRandom(mulberry32(seed), () =>
+        initializeGameStateForMultiTier(1)
+      );
+      const f3 = advanceToNextFloor(advanceToNextFloor(f1, seed), seed);
+      const payloads = f3.sealPayloads ?? {};
+      const cracks = f3.mapData.subtypes
+        .flat()
+        .filter((c) => c.includes(TileSubtype.WALL_SEAL)).length;
+      expect(Object.keys(payloads).length).toBe(cracks);
+
+      const bosses = Object.values(payloads).filter((p) => p === "boss");
+      expect(bosses.length).toBeLessThanOrEqual(1);
+      const decoys = Object.values(payloads).length - bosses.length;
+      expect(decoys).toBeLessThanOrEqual(MAX_DECOY_SEALS);
+      if (bosses.length === 1) {
+        bombDays++;
+        bombDayDecoyCounts.add(decoys);
+        expect(f3.bossEntranceKind).toBe("bomb");
+      }
+    }
+    expect(bombDays).toBeGreaterThan(0);
+    // A bomb day can roll zero decoys (only the bracketed doorway) or up to the max.
+    expect(Math.min(...bombDayDecoyCounts)).toBe(0);
+  });
+});

--- a/app/test-boss-entrances/page.tsx
+++ b/app/test-boss-entrances/page.tsx
@@ -6,7 +6,7 @@ import { tileTypes } from "../../lib/map";
 import {
   buildMoatApproach,
   buildDousePortalApproach,
-  buildBombOutsideApproach,
+  buildBombSealApproach,
 } from "../../lib/bosses/boss_entrances";
 import type { GameState } from "../../lib/map/game-state";
 
@@ -59,14 +59,16 @@ const SCENARIOS: Scenario[] = [
   },
   {
     key: "bomb",
-    label: "Bomb → Outside",
-    build: buildBombOutsideApproach,
+    label: "Bomb: Sealed Door",
+    build: buildBombSealApproach,
     blurb: (
       <>
-        A sealed room with three bombs. <b>Throw a bomb at an outer wall</b> to blow a
-        breach, step out into the grassland, then push past the stone goblins to the
-        <b> opening carved in the far tree wall</b> &mdash; a path down into the boss
-        room. (In the real daily this appears only for the first wall you breach.)
+        Three bombs and a walled-up doorway hidden somewhere on the floor. Look for a{" "}
+        <b>cracked wall tile bracketed by two wall torches</b> &mdash; stand below it,
+        face up, and <b>throw a bomb</b>. The seal blows open into the cave mouth down to
+        the boss. Two lone cracked tiles with <i>no</i> torches are decoys: bombing one
+        leaves a pot holding pink-realm fruit or food, so it isn&rsquo;t a wasted bomb
+        &mdash; but you only carry three.
       </>
     ),
   },

--- a/components/Tile.module.css
+++ b/components/Tile.module.css
@@ -633,6 +633,35 @@
   opacity: 1;
 }
 
+/* Sealed doorway (WALL_SEAL): the abyss crack decal reused on a wall's face to read as
+   a walled-up entrance. Anchored to the lower 60% of the tile because the forced
+   perspective in the wall branch puts the visible stone face there — a centered decal
+   would sit on the wall's top cap and read as floor damage instead of masonry. Kept
+   subtle (screen blend at partial opacity) so the two bracketing wall torches remain
+   the thing that catches the eye at fog-of-war distance, not the crack itself. */
+.wallSealIcon {
+  position: absolute;
+  left: 15%;
+  bottom: 4%;
+  width: 70%;
+  height: 58%;
+  z-index: 2;
+  background-size: contain;
+  background-position: center bottom;
+  background-repeat: no-repeat;
+  opacity: 0.72;
+  mix-blend-mode: screen;
+  pointer-events: none;
+}
+
+.wallSealVariantA {
+  background-image: url("/images/floor/cracks-1.png");
+}
+
+.wallSealVariantB {
+  background-image: url("/images/floor/cracks-2.png");
+}
+
 /* Darkness tile: dark pit when faulty floor collapses */
 .darkness {
   background-color: #0a0a0a;

--- a/components/Tile.tsx
+++ b/components/Tile.tsx
@@ -649,6 +649,9 @@ export const Tile: React.FC<TileProps> = ({
   const hasPinkHeart = (subtypes: number[] | undefined): boolean => {
     return subtypes?.includes(TileSubtype.PINK_HEART) || false;
   };
+  const hasWallSeal = (subtypes: number[] | undefined): boolean => {
+    return subtypes?.includes(TileSubtype.WALL_SEAL) || false;
+  };
   const hasBerry = (subtypes: number[] | undefined): boolean => {
     return subtypes?.includes(TileSubtype.BERRY) || false;
   };
@@ -831,7 +834,9 @@ export const Tile: React.FC<TileProps> = ({
         subtype !== TileSubtype.BREACH &&
         // Pink realm prizes have custom rendering (heart gets a glow overlay)
         subtype !== TileSubtype.PINK_HEART &&
-        subtype !== TileSubtype.BERRY
+        subtype !== TileSubtype.BERRY &&
+        // Sealed doorway: a crack decal on the wall face
+        subtype !== TileSubtype.WALL_SEAL
     );
   };
 
@@ -918,6 +923,21 @@ export const Tile: React.FC<TileProps> = ({
             key="lightswitch"
             data-testid={`subtype-icon-${TileSubtype.LIGHTSWITCH}`}
             className={`${styles.assetIcon} ${styles.switchIcon}`}
+          />
+        )}
+
+        {/* Sealed doorway: a crack decal low on the wall's face, where the forced
+            perspective actually shows stone (see isFloorBelow in the wall branch). Sits
+            below the torch flames so a bracketed seal reads as one motif. Deterministic
+            rotation + variant per tile so no two seals on a floor look stamped. */}
+        {hasWallSeal(subtypes) && (
+          <div
+            key="wall-seal"
+            data-testid={`subtype-icon-${TileSubtype.WALL_SEAL}`}
+            className={`${styles.wallSealIcon} ${
+              pickVariant([styles.wallSealVariantA, styles.wallSealVariantB])
+            }`}
+            style={{ transform: `rotate(${getFaultyFloorRotation() % 24 - 12}deg)` }}
           />
         )}
 

--- a/lib/bosses/boss_entrances.ts
+++ b/lib/bosses/boss_entrances.ts
@@ -9,13 +9,15 @@
 //                  A lockless BOSS_ENTRANCE waits on the far side.
 //   2. DOUSE     — a dark cave. A deep-water channel snuffs your torch; only in the
 //                  dark does the DARK_PORTAL beyond it appear (invisible in the light).
-//   3. BOMB      — a walled room; bomb the outer wall and step into the outside world,
-//                  where a hidden BOSS_ENTRANCE is carved into the far tree wall.
+//   3. BOMB      — a walled-up doorway somewhere on the floor: a cracked wall tile
+//                  bracketed by two wall torches. Bomb it open and the cleared tile is
+//                  a BOSS_ENTRANCE. Bare cracked tiles (no torches) are decoys that
+//                  open onto a reward pot instead.
 //
 // Stepping onto either entrance subtype warps into the Shaper arena (enterBossRoom
 // in game-state.ts).
 import { FLOOR, WALL, FLOWERS, Direction, TileSubtype } from "../map/constants";
-import type { MapData } from "../map/types";
+import type { MapData, SealPayload, SealPayloads } from "../map/types";
 import type { GameState } from "../map/game-state";
 import { generateCompleteMapForFloor } from "../map/map-features";
 import { Enemy } from "../enemy";
@@ -51,21 +53,6 @@ function placeGhosts(map: MapData, count: number, hy: number, hx: number): Enemy
     g.maxHealth = 2;
     return g;
   });
-}
-
-/** A rectangular room: WALL border, FLOOR interior. */
-function room(width: number, height: number): { tiles: number[][]; subtypes: number[][][] } {
-  const tiles: number[][] = [];
-  const subtypes: number[][][] = [];
-  for (let y = 0; y < height; y++) {
-    tiles.push(
-      Array.from({ length: width }, (_, x) =>
-        y === 0 || x === 0 || y === height - 1 || x === width - 1 ? WALL : FLOOR
-      )
-    );
-    subtypes.push(Array.from({ length: width }, () => [] as number[]));
-  }
-  return { tiles, subtypes };
 }
 
 /** Common GameState scaffold for an approach level. */
@@ -551,26 +538,235 @@ export function buildDousePortalApproach(): GameState {
 }
 
 /**
- * BOMB approach. A walled room. Throw a bomb at the outer wall to breach it, step
- * through into the outside world (built with outsideHasBossEntrance), then walk to
- * the hidden cave mouth carved into the far tree wall.
+ * BOMB approach, in a REAL Level-3-sized room. Somewhere on the floor a walled-up
+ * doorway waits: a cracked wall tile bracketed by two wall torches. Stand below it,
+ * face up, throw a bomb — the seal blows open into a BOSS_ENTRANCE cave mouth. Two
+ * lone cracked tiles elsewhere are decoys that open onto a reward pot instead, and the
+ * hero carries exactly three bombs, so opening all three seals is the whole supply.
  */
-export function buildBombOutsideApproach(): GameState {
-  const W = 13;
-  const H = 11;
-  const { tiles, subtypes } = room(W, H);
-  subtypes[Math.floor(H / 2)][Math.floor(W / 2)] = [TileSubtype.PLAYER];
+export function buildBombSealApproach(): GameState {
+  let map = generateCompleteMapForFloor({ chests: 0, keys: 0, chestContents: [] }, 3);
+  let payloads = stampSealedDoorway(map);
+  for (let attempt = 0; attempt < 12 && !payloads; attempt++) {
+    map = generateCompleteMapForFloor({ chests: 0, keys: 0, chestContents: [] }, 3);
+    payloads = stampSealedDoorway(map);
+  }
+  // The harness always shows the full picture: doorway plus the max decoys, so both
+  // halves of the tell can be compared side by side.
+  if (payloads) {
+    payloads = {
+      ...payloads,
+      ...stampDecoySeals(map, MAX_DECOY_SEALS, sealCoords(payloads)),
+    };
+  }
+  const [hy, hx] = findPlayerPos(map);
+  const ghosts = placeGhosts(map, GHOST_COUNT, hy, hx);
 
   return approachState(
-    { tiles, subtypes, environment: "cave" },
+    { tiles: map.tiles, subtypes: map.subtypes, environment: "cave" },
     {
+      // Fog on (real L3 feel) so you have to explore into the doorway to spot it.
       showFullMap: false,
       bombCount: 3,
       rockCount: 0,
-      outsideHasBossEntrance: true,
+      sealPayloads: payloads ?? undefined,
       bossArenaSeed: "lava",
       playerDirection: Direction.UP,
+      enemies: ghosts,
     }
+  );
+}
+
+// --- Sealed doorway (the BOMB entrance) --------------------------------------
+
+/** Hard ceiling on decoy seals per floor. */
+export const MAX_DECOY_SEALS = 2;
+/** Chebyshev spacing between seals, so two of them never read as one motif. */
+const SEAL_SPACING = 4;
+/** How far from any wall torch a decoy must sit, so a torch PAIR stays the only tell. */
+const DECOY_TORCH_CLEARANCE = 2;
+
+/**
+ * How many decoy cracks this floor gets: 0, 1, or 2, rolled per floor on EVERY daily
+ * floor — not just floor 3, and not just bomb days. Cracks you can do nothing about are
+ * the point: seeing one on floor 1 with no bombs yet teaches the vocabulary, and a floor
+ * that rolls zero keeps the motif from becoming furniture.
+ * Must be called inside the daily seeded RNG block.
+ */
+export function rollDecoySealCount(): number {
+  const r = Math.random();
+  if (r < 0.3) return 0;
+  if (r < 0.75) return 1;
+  return MAX_DECOY_SEALS;
+}
+
+/** Terrain that would stop the hero standing below a seal to throw at it. */
+const UNSTANDABLE_SUBS = [
+  TileSubtype.LAVA,
+  TileSubtype.DEEP_WATER,
+  TileSubtype.OPEN_ABYSS,
+  TileSubtype.FAULTY_FLOOR,
+];
+
+/**
+ * Wall tiles the renderer gives a camera-facing face to: a WALL with FLOOR directly
+ * below it (Tile.tsx's isFloorBelow adds the forced-perspective front face there).
+ * Side and bottom walls are drawn as caps seen from above, so a crack decal on one
+ * would be unreadable — those can never hold a seal. Same predicate
+ * addWallTorchesToMap uses, which is why a torch and a seal always agree on which
+ * walls can carry art.
+ */
+function isFacedWall(map: MapData, y: number, x: number): boolean {
+  const H = map.tiles.length;
+  const W = map.tiles[0].length;
+  if (y < 0 || x < 0 || y >= H - 1 || x >= W) return false;
+  if (map.tiles[y][x] !== WALL) return false;
+  return map.tiles[y + 1][x] === FLOOR;
+}
+
+/** A faced wall with nothing already on it (no torch, no other overlay). */
+function isBareFacedWall(map: MapData, y: number, x: number): boolean {
+  return isFacedWall(map, y, x) && (map.subtypes[y]?.[x]?.length ?? 0) === 0;
+}
+
+/** Can the hero stand on the tile below (y,x) and throw upward at it? */
+function approachIsStandable(map: MapData, y: number, x: number, reachable: Set<string>): boolean {
+  const ay = y + 1;
+  if (!reachable.has(`${ay},${x}`)) return false;
+  const subs = map.subtypes[ay]?.[x] ?? [];
+  return !subs.some((s) => UNSTANDABLE_SUBS.includes(s));
+}
+
+function isNearTorch(map: MapData, y: number, x: number, radius: number): boolean {
+  for (let dy = -radius; dy <= radius; dy++)
+    for (let dx = -radius; dx <= radius; dx++) {
+      const subs = map.subtypes[y + dy]?.[x + dx] ?? [];
+      if (subs.includes(TileSubtype.WALL_TORCH)) return true;
+    }
+  return false;
+}
+
+function farEnough(taken: Array<[number, number]>, y: number, x: number): boolean {
+  return taken.every(
+    ([ty, tx]) => Math.max(Math.abs(ty - y), Math.abs(tx - x)) >= SEAL_SPACING
+  );
+}
+
+/**
+ * Stamp up to `count` decoy cracks — lone WALL_SEAL tiles with no wall torch within
+ * DECOY_TORCH_CLEARANCE, so a bracketing torch PAIR stays the only tell for the real
+ * doorway. Each opens onto a pot: the first holds pink-realm fruit, any further one flips
+ * a coin between fruit and ordinary food, so a decoy is never a wasted bomb.
+ *
+ * Runs on EVERY daily floor, so cracks show up on floors 1 and 2 where the hero has no
+ * bombs yet and simply can't act on them. Spaced ≥SEAL_SPACING from `avoid` (the real
+ * doorway, when there is one) and from each other.
+ *
+ * Must be called inside the daily seeded RNG block.
+ */
+export function stampDecoySeals(
+  map: MapData,
+  count: number,
+  avoid: Array<[number, number]> = []
+): SealPayloads {
+  const payloads: SealPayloads = {};
+  if (count <= 0) return payloads;
+  const H = map.tiles.length;
+  const W = map.tiles[0].length;
+  const [hy, hx] = findPlayerPos(map);
+  const reachable = floodReachable(map, hy, hx, { wadeable: true });
+
+  const cands: Array<[number, number]> = [];
+  for (let y = 0; y < H - 1; y++) {
+    for (let x = 0; x < W; x++) {
+      if (!isBareFacedWall(map, y, x)) continue;
+      if (isNearTorch(map, y, x, DECOY_TORCH_CLEARANCE)) continue;
+      if (!approachIsStandable(map, y, x, reachable)) continue;
+      cands.push([y, x]);
+    }
+  }
+  for (let i = cands.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [cands[i], cands[j]] = [cands[j], cands[i]];
+  }
+
+  const taken = avoid.slice();
+  let placed = 0;
+  for (const [y, x] of cands) {
+    if (placed >= count) break;
+    if (!farEnough(taken, y, x)) continue;
+    map.subtypes[y][x] = [TileSubtype.WALL_SEAL];
+    const payload: SealPayload =
+      placed === 0 ? "berry" : Math.random() < 0.5 ? "berry" : "food";
+    payloads[`${y},${x}`] = payload;
+    taken.push([y, x]);
+    placed++;
+  }
+  return payloads;
+}
+
+/**
+ * Stamp the day's real sealed doorway and return what it hides (always exactly one
+ * "boss" entry). Decoys are NOT placed here — they are an independent per-floor roll
+ * (see stampDecoySeals / rollDecoySealCount), so a floor can carry cracks with no
+ * doorway at all, and a bomb day can roll zero decoys.
+ *
+ * The doorway is three consecutive faced wall tiles — torch, cracked seal, torch — so it
+ * reads as a walled-up entrance someone once honored. Interior wall runs are strongly
+ * preferred over the map's top boundary: a 3-wide motif fits an interior run in ~92% of
+ * generated floor 3s, which is the whole reason the motif is 3 wide and not 5 (a 5-wide
+ * one only ever fits the top boundary row, making it findable by rote).
+ *
+ * Returns null (and leaves the map untouched) when the floor has no site at all —
+ * the caller then treats the day as bossless rather than shipping a broken floor.
+ * Must be called inside the daily seeded RNG block.
+ */
+export function stampSealedDoorway(map: MapData): SealPayloads | null {
+  const H = map.tiles.length;
+  const W = map.tiles[0].length;
+  const [hy, hx] = findPlayerPos(map);
+  const reachable = floodReachable(map, hy, hx, { wadeable: true });
+
+  // Every 3-wide window of bare faced wall whose middle tile the hero can reach.
+  const sites: Array<{ y: number; x: number; interior: boolean; dist: number }> = [];
+  for (let y = 0; y < H - 1; y++) {
+    for (let x = 0; x + 2 < W; x++) {
+      if (!isBareFacedWall(map, y, x)) continue;
+      if (!isBareFacedWall(map, y, x + 1)) continue;
+      if (!isBareFacedWall(map, y, x + 2)) continue;
+      if (!approachIsStandable(map, y, x + 1, reachable)) continue;
+      sites.push({
+        y,
+        x,
+        interior: y > 0,
+        dist: Math.abs(y - hy) + Math.abs(x + 1 - hx),
+      });
+    }
+  }
+  if (sites.length === 0) return null;
+
+  // Interior walls first (a seal on the top boundary is the predictable fallback), then
+  // farthest from the hero so the doorway is something you travel to, not spawn beside.
+  sites.sort((a, b) => {
+    if (a.interior !== b.interior) return a.interior ? -1 : 1;
+    return b.dist - a.dist;
+  });
+  // Break ties randomly among the best few so the same layout doesn't always pick the
+  // same wall (seeded, so still identical for every player on a given day).
+  const interiorSites = sites.filter((s) => s.interior);
+  const pool = (interiorSites.length > 0 ? interiorSites : sites).slice(0, 5);
+  const site = pool[Math.floor(Math.random() * pool.length)];
+
+  map.subtypes[site.y][site.x] = [TileSubtype.WALL_TORCH];
+  map.subtypes[site.y][site.x + 1] = [TileSubtype.WALL_SEAL];
+  map.subtypes[site.y][site.x + 2] = [TileSubtype.WALL_TORCH];
+  return { [`${site.y},${site.x + 1}`]: "boss" };
+}
+
+/** The coordinates of every WALL_SEAL recorded in a payload map. */
+export function sealCoords(payloads: SealPayloads): Array<[number, number]> {
+  return Object.keys(payloads).map(
+    (k) => k.split(",").map(Number) as [number, number]
   );
 }
 
@@ -620,31 +816,34 @@ export function arenaSeedForEntrance(kind: BossEntranceKind): MoatElement {
 }
 
 /**
- * Stamp the day's entrance into an already-generated daily floor. Returns false if the
- * floor had no safe spot for it (caller just leaves that day bossless rather than
- * risking a broken floor). "bomb" touches nothing here — it's carved into the outside
- * world later, gated on state.outsideHasBossEntrance.
+ * Stamp the day's entrance into an already-generated daily floor. `placed` is false if
+ * the floor had no safe spot for it (caller just leaves that day bossless rather than
+ * risking a broken floor). "bomb" returns the seal payload map, which the caller must
+ * carry onto the GameState — without it the sealed doorway opens onto nothing.
  */
 export function stampBossEntranceOnFloor(
   map: MapData,
   kind: BossEntranceKind
-): boolean {
-  if (kind === "bomb") return true;
+): { placed: boolean; sealPayloads?: SealPayloads } {
   const [hy, hx] = findPlayerPos(map);
+  if (kind === "bomb") {
+    const sealPayloads = stampSealedDoorway(map);
+    return sealPayloads ? { placed: true, sealPayloads } : { placed: false };
+  }
   if (kind === "moat-lava") {
     // 4-6 rocks to cross, straight-line only, and only ever gates the secret.
-    return stampStraightLavaSpur(map, 4 + Math.floor(Math.random() * 3));
+    return { placed: stampStraightLavaSpur(map, 4 + Math.floor(Math.random() * 3)) };
   }
   if (kind === "moat-water") {
     const before = countSubtype(map, TileSubtype.BOSS_ENTRANCE);
     stampCornerMoat(map, "water");
-    return countSubtype(map, TileSubtype.BOSS_ENTRANCE) > before;
+    return { placed: countSubtype(map, TileSubtype.BOSS_ENTRANCE) > before };
   }
   // douse: a few deep-water tiles to snuff the torch, plus the dark portal itself.
   stampCornerWaterPatch(map, hy, hx);
   const before = countSubtype(map, TileSubtype.DARK_PORTAL);
   placeDarkPortal(map, hy, hx);
-  return countSubtype(map, TileSubtype.DARK_PORTAL) > before;
+  return { placed: countSubtype(map, TileSubtype.DARK_PORTAL) > before };
 }
 
 function countSubtype(map: MapData, sub: number): number {

--- a/lib/map/constants.ts
+++ b/lib/map/constants.ts
@@ -127,6 +127,14 @@ export enum TileSubtype {
   // visuals never accidentally trigger a boss warp.
   BOSS_ENTRANCE = 63,
   DARK_PORTAL = 64,
+  // WALL_SEAL is a walled-up doorway: a WALL tile wearing a crack decal. Bomb it and
+  // it opens into whatever the day stashed behind it (a BOSS_ENTRANCE on the real one,
+  // a reward POT on a decoy) — see sealPayloads in game-state.ts. Only ever placed on
+  // a wall tile with FLOOR directly below it, because that is the only wall the
+  // renderer gives a camera-facing face to (see Tile.tsx's isFloorBelow), so the crack
+  // is always readable. The real seal is bracketed left and right by WALL_TORCHes;
+  // decoys are bare. That torch-pair grammar is the whole tell.
+  WALL_SEAL = 65,
 }
 
 /**

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -34,7 +34,13 @@ import {
   WALL,
   type RoomId,
 } from "./constants";
-import type { MapData, RoomSnapshot, RoomTransition } from "./types";
+import type {
+  MapData,
+  PotOverrides,
+  RoomSnapshot,
+  RoomTransition,
+  SealPayloads,
+} from "./types";
 import {
   cloneMapData,
   clonePlainEnemies,
@@ -55,7 +61,10 @@ import { buildPinkRealm } from "./pink-realm";
 import { buildShaperArena, type ShaperEntry } from "../bosses/shaper_arena";
 import {
   rollBossEntranceKind,
+  rollDecoySealCount,
+  sealCoords,
   stampBossEntranceOnFloor,
+  stampDecoySeals,
   arenaSeedForEntrance,
   type BossEntranceKind,
 } from "../bosses/boss_entrances";
@@ -138,6 +147,11 @@ function breakPotReleasingContents(
     .filter((s) => s !== TileSubtype.POT)
     .concat([reveal]);
   return { spawnedSnake: null, potOverrides };
+}
+
+/** Drop an empty seal-payload map to undefined, so state stays clean when nothing rolled. */
+function orUndefined(payloads: SealPayloads): SealPayloads | undefined {
+  return Object.keys(payloads).length > 0 ? payloads : undefined;
 }
 
 function incrementStepsAndTime(state: GameState, amount: number = 1): void {
@@ -1220,6 +1234,10 @@ export function detonateLiveBombs(state: GameState): GameState {
   // enemy kills) to avoid re-processing a stale, previously-defeated enemy.
   let snakePotKills = 0;
   let playerHit = false;
+  // Sealed doorways opened by this blast. Their payloads are stamped AFTER the
+  // destruction pass below, so the same blast that clears the wall can't also wipe the
+  // pot or cave mouth it just uncovered.
+  const openedSeals: Array<[number, number]> = [];
 
   for (const [cy, cx] of liveCenters) {
     blastCenters.push([cy, cx]);
@@ -1237,12 +1255,21 @@ export function detonateLiveBombs(state: GameState): GameState {
         const wasTree = newMapData.tiles[y][x] === TREE;
         const wasWall =
           newMapData.tiles[y][x] === WALL || wasTree;
-        const openedWall = wasWall && !isProtected;
+        // A torch-bearing wall is set stone and shrugs the blast off. This is what keeps
+        // a sealed doorway's two bracketing torches standing: the bomb rests directly
+        // below the seal, so its 3x3 covers them, and without this the whole motif would
+        // blow into one anonymous 3-wide hole instead of an unsealed door between torches.
+        const isTorchWall =
+          newMapData.tiles[y][x] === WALL && subs.includes(TileSubtype.WALL_TORCH);
+        const openedWall = wasWall && !isProtected && !isTorchWall;
         if (openedWall) {
           newMapData.tiles[y][x] = FLOOR;
           wallsDestroyed += 1;
           if (wasTree) treesDestroyed += 1;
+          if (subs.includes(TileSubtype.WALL_SEAL)) openedSeals.push([y, x]);
         }
+        // A torch wall survives intact — no scorch, no stripped overlays.
+        if (isTorchWall) continue;
 
         // Damage enemies caught in the blast. Most die; tough enemies (stone goblin,
         // 8 HP) can survive a single bomb.
@@ -1335,6 +1362,35 @@ export function detonateLiveBombs(state: GameState): GameState {
   stats.wallsDestroyed = (stats.wallsDestroyed ?? 0) + wallsDestroyed;
   stats.treesDestroyed = (stats.treesDestroyed ?? 0) + treesDestroyed;
 
+  // Unseal any doorway this blast opened. Done after the destruction pass so what the
+  // seal was hiding lands on already-cleared floor: the real doorway becomes a lockless
+  // BOSS_ENTRANCE cave mouth, a decoy becomes a pot holding pink-realm fruit or food.
+  // SINGED is dropped so the reward reads cleanly, and BREACH with it: a seal on the
+  // fallback boundary row would otherwise be tagged as a hole in the dungeon's shell and
+  // walk the hero out to the grassland instead of into what was walled up behind it.
+  let sealPayloads = state.sealPayloads;
+  let potOverrides = state.potOverrides;
+  for (const [y, x] of openedSeals) {
+    const key = `${y},${x}`;
+    const payload = sealPayloads?.[key];
+    if (!payload) continue;
+    const kept = (newMapData.subtypes[y][x] || []).filter(
+      (s) => s !== TileSubtype.SINGED && s !== TileSubtype.BREACH
+    );
+    if (payload === "boss") {
+      newMapData.subtypes[y][x] = kept.concat([TileSubtype.BOSS_ENTRANCE]);
+    } else {
+      newMapData.subtypes[y][x] = kept.concat([TileSubtype.POT]);
+      potOverrides = {
+        ...(potOverrides ?? {}),
+        [key]: payload === "berry" ? TileSubtype.BERRY : TileSubtype.FOOD,
+      };
+    }
+    const next = { ...(sealPayloads ?? {}) };
+    delete next[key];
+    sealPayloads = Object.keys(next).length ? next : undefined;
+  }
+
   let heroHealth = state.heroHealth;
   let bonusHearts = state.bonusHearts;
   let deathCause = state.deathCause;
@@ -1361,6 +1417,8 @@ export function detonateLiveBombs(state: GameState): GameState {
     bonusHearts,
     deathCause,
     recentBombBlasts: blastCenters,
+    sealPayloads,
+    potOverrides,
   };
 
   // Process story events for ONLY the enemies this blast defeated (no-op outside story
@@ -1622,7 +1680,11 @@ export interface GameState {
   rooms?: Record<RoomId, RoomSnapshot>;
   currentRoomId?: RoomId;
   roomTransitions?: RoomTransition[];
-  potOverrides?: Record<string, TileSubtype.FOOD | TileSubtype.MED>;
+  potOverrides?: PotOverrides;
+  // What each WALL_SEAL on this floor hides, keyed by `${y},${x}`. Deliberately held
+  // here instead of on the tile so every seal looks identical until it is blown open
+  // (see SealPayload). Consumed by detonateLiveBombs and reset on each new floor.
+  sealPayloads?: SealPayloads;
   lastCheckpoint?: CheckpointSnapshot;
   // Portal state for snake medallion
   portalLocation?: {
@@ -1651,8 +1713,6 @@ export interface GameState {
   // inBossRoom: transient, true while the hero is inside a boss arena.
   // reachedBossRoom: run-level latch, true once a boss arena was entered this run.
   // bossArenaSeed: which elemental Shaper arena to build on entry (defaults lava).
-  // outsideHasBossEntrance: when true, the outside world built from this floor
-  // carves a hidden boss entrance in its far tree wall (a boss-day marker).
   inBossRoom?: boolean;
   reachedBossRoom?: boolean;
   // Latches when the Shaper dies (gold key dropped). Run-level, so the endgame can
@@ -1667,7 +1727,6 @@ export interface GameState {
   // hero leaving) so future boss variety is reportable per run from day one.
   bossKind?: "shaper";
   bossArenaSeed?: "water" | "lava";
-  outsideHasBossEntrance?: boolean;
   // The floor to restore when the hero walks back out of a boss arena. Kept
   // separate from dungeonReturn/realmReturn (a boss room can be entered from the
   // dungeon OR from inside another sub-area, so the stashes must nest).
@@ -1980,6 +2039,13 @@ export function initializeGameStateForMultiTier(floor: number = 1): GameState {
   const floorAlloc = floorChestAllocation[floor] ?? { chests: 0, keys: 0, chestContents: [] };
   const mapData = generateCompleteMapForFloor(floorAlloc, floor);
 
+  // Decoy cracks, 0-2, on every floor including this one. On floor 1 the hero has no
+  // bombs at all, so a crack here is pure intrigue — it teaches the motif before it can
+  // ever be used. (The real sealed doorway is floor 3 only; see advanceToNextFloor.)
+  const sealPayloads = orUndefined(
+    stampDecoySeals(mapData, rollDecoySealCount())
+  );
+
   const playerPos = findPlayerPosition(mapData);
   const enemies = playerPos
     ? placeEnemies({
@@ -2040,6 +2106,7 @@ export function initializeGameStateForMultiTier(floor: number = 1): GameState {
     currentFloor: floor,
     maxFloors: 3,
     mapData: withRunes,
+    sealPayloads,
     showFullMap: false,
     win: false,
     playerDirection: Direction.DOWN,
@@ -2156,6 +2223,8 @@ export function advanceToNextFloor(currentState: GameState, dailySeed: number): 
   // every player gets the same one. Null on a bombless-unlucky roll or when the floor
   // had no safe spot for it — that day is simply bossless.
   let bossEntrance: BossEntranceKind | null = null;
+  // What each WALL_SEAL on a bomb day hides (empty on the other entrance kinds).
+  let sealPayloads: SealPayloads | undefined;
   // Ghosts guaranteed on a douse day (they're how you go dark, and the tell).
   const DOUSE_DAY_MIN_GHOSTS = 3;
 
@@ -2179,8 +2248,23 @@ export function advanceToNextFloor(currentState: GameState, dailySeed: number): 
         (a) => (a.chestContents ?? []).includes(TileSubtype.BOMB)
       );
       const kind = rollBossEntranceKind({ bombAvailable });
-      if (kind && stampBossEntranceOnFloor(mapData, kind)) bossEntrance = kind;
+      if (kind) {
+        const stamped = stampBossEntranceOnFloor(mapData, kind);
+        if (stamped.placed) {
+          bossEntrance = kind;
+          sealPayloads = stamped.sealPayloads;
+        }
+      }
     }
+    // Decoy cracks, 0-2, on EVERY floor — independent of the boss roll, so a floor can
+    // carry cracks with no doorway behind any of them and a bomb day can roll none at
+    // all. Placed after the doorway so they keep their distance from it.
+    const decoys = stampDecoySeals(
+      mapData,
+      rollDecoySealCount(),
+      sealPayloads ? sealCoords(sealPayloads) : []
+    );
+    sealPayloads = orUndefined({ ...(sealPayloads ?? {}), ...decoys });
     return mapData;
   });
 
@@ -2281,13 +2365,13 @@ export function advanceToNextFloor(currentState: GameState, dailySeed: number): 
     hasExitKey: false, // Reset exit key for new floor
     portalLocation: undefined, // Reset placed portal — no backtracking between floors
     win: false, // Reset win state
-    // Boss room for the day: which elemental arena the entrance opens into, and (for
-    // the bomb entrance) permission for the outside world to carve its hidden mouth.
-    // bossEntranceKind is persisted even if the hero never finds the entrance, so
-    // analytics can report what kind of door the day actually had.
+    // Boss room for the day: which elemental arena the entrance opens into, and (on a
+    // bomb day) what each sealed wall tile hides. bossEntranceKind is persisted even if
+    // the hero never finds the entrance, so analytics can report what kind of door the
+    // day actually had.
     bossEntranceKind: bossEntrance ?? undefined,
     bossArenaSeed: bossEntrance ? arenaSeedForEntrance(bossEntrance) : undefined,
-    outsideHasBossEntrance: bossEntrance === "bomb",
+    sealPayloads,
     recentDeaths: [],
     recentBombBlasts: [], // don't carry a blast's VFX/shake into the next floor
     defeatedEnemies: [],
@@ -2589,8 +2673,7 @@ function enterOutsideWorld(
   const { mapData: outsideMap, enemies: outsideEnemies, entry } = buildOutsideWorld(
     direction,
     width,
-    height,
-    { bossEntrance: state.outsideHasBossEntrance }
+    height
   );
   const dungeonReturn = {
     mapData: removePlayerFromMapData(state.mapData),

--- a/lib/map/outside-world.ts
+++ b/lib/map/outside-world.ts
@@ -49,7 +49,6 @@ export function buildOutsideWorld(
   direction: Direction,
   width: number,
   height: number,
-  opts?: { bossEntrance?: boolean }
 ): { mapData: MapData; enemies: PlainEnemy[]; entry: [number, number] } {
   const tiles: number[][] = [];
   const subtypes: number[][][] = [];
@@ -137,27 +136,12 @@ export function buildOutsideWorld(
     }
   }
 
-  // Boss-day marker: carve a 1-wide corridor straight through the FAR tree wall
-  // (opposite the dungeon-facing edge) and place a lockless cave mouth at its outer
-  // end. Reads as an opening in the trees with a path leading down into the boss
-  // room; the stone-goblin line guards the approach to it.
-  if (opts?.bossEntrance) {
-    let entrance: [number, number];
-    if (inner === "top") {
-      for (let y = lastY - TREE_BORDER + 1; y <= lastY; y++) tiles[y][midX] = FLOOR;
-      entrance = [lastY, midX];
-    } else if (inner === "bottom") {
-      for (let y = 0; y <= TREE_BORDER - 1; y++) tiles[y][midX] = FLOOR;
-      entrance = [0, midX];
-    } else if (inner === "left") {
-      for (let x = lastX - TREE_BORDER + 1; x <= lastX; x++) tiles[midY][x] = FLOOR;
-      entrance = [midY, lastX];
-    } else {
-      for (let x = 0; x <= TREE_BORDER - 1; x++) tiles[midY][x] = FLOOR;
-      entrance = [midY, 0];
-    }
-    subtypes[entrance[0]][entrance[1]].push(TileSubtype.BOSS_ENTRANCE);
-  }
+  // NOTE: the outside world used to carve a hidden boss entrance through its far tree
+  // wall on bomb days. That route is gone — once players knew it existed, bombing any
+  // outer wall got you to the boss, so there was nothing left to find. The boss now sits
+  // behind a sealed doorway inside the dungeon (see stampSealedDoorway), and the outside
+  // world is back to being what it was designed as: a dead-end curiosity with stone
+  // goblins and no reward.
 
   const mapData: MapData = { tiles, subtypes, environment: "outdoor" };
   return { mapData, enemies, entry };

--- a/lib/map/types.ts
+++ b/lib/map/types.ts
@@ -15,14 +15,37 @@ export interface MapData {
   snakeSwarm?: boolean;
 }
 
+/**
+ * Forced pot contents, keyed by `${y},${x}`, consumed the first time that pot is opened
+ * (or broken). BERRY is here because a bombed decoy seal leaves a pot holding
+ * pink-realm fruit — see SealPayload.
+ */
+export type PotOverrides = Record<
+  string,
+  TileSubtype.FOOD | TileSubtype.MED | TileSubtype.BERRY
+>;
+
 export interface RoomSnapshot {
   mapData: MapData;
   entryPoint: [number, number];
   enemies?: PlainEnemy[];
   npcs?: PlainNPC[];
-  potOverrides?: Record<string, TileSubtype.FOOD | TileSubtype.MED>;
+  potOverrides?: PotOverrides;
   metadata?: Record<string, unknown>;
 }
+
+/**
+ * What a WALL_SEAL hides. Kept OFF the tile's subtype array on purpose: every seal must
+ * look identical until it is blown open, so a player (or the DOM) can't tell the real
+ * doorway from a decoy by anything but the bracketing wall torches.
+ *  - "boss"  -> opens into a BOSS_ENTRANCE cave mouth (the real doorway)
+ *  - "berry" -> a POT holding a belted berry from the pink realm
+ *  - "food"  -> a POT holding ordinary food
+ */
+export type SealPayload = "boss" | "berry" | "food";
+
+/** Keyed by `${y},${x}` of the sealed wall tile. */
+export type SealPayloads = Record<string, SealPayload>;
 
 export interface RoomTransition {
   from: RoomId;

--- a/lib/map/utils.ts
+++ b/lib/map/utils.ts
@@ -1,7 +1,6 @@
 import type { PlainEnemy } from "../enemy";
 import { Enemy, EnemyState } from "../enemy";
-import type { MapData } from "./types";
-import { TileSubtype } from "./constants";
+import type { MapData, PotOverrides } from "./types";
 import {
   clonePlainNPCs as clonePlainNPCsUtil,
   type PlainNPC,
@@ -63,8 +62,8 @@ export function clonePlainNPCs(
 }
 
 export function clonePotOverrides(
-  overrides?: Record<string, TileSubtype.FOOD | TileSubtype.MED>
-): Record<string, TileSubtype.FOOD | TileSubtype.MED> | undefined {
+  overrides?: PotOverrides
+): PotOverrides | undefined {
   if (!overrides) return undefined;
   return { ...overrides };
 }


### PR DESCRIPTION
## The problem

The `bomb` boss entrance used to be: bomb any outer wall, step into the grassland, walk to a cave mouth carved in the far tree wall. That secret worked exactly **once**. After that, any wall got you to the boss, so there was nothing to find and no decision to make.

## The change

The boss now sits behind a walled-up doorway inside the dungeon — a cracked wall tile bracketed by two wall torches:

```
. . █ █ █ █ █ . .
. . █ ▒ ▓ ▒ █ . .    ▒ = wall torch   ▓ = cracked seal (WALL_SEAL)
. . · · · · · . .
. . . . ^ . . . .    stand below, face up, throw a bomb
```

Blowing it open turns the tile into the same lockless `BOSS_ENTRANCE` cave mouth the moat entrances use. **The torch pair is the tell** — wall torches are lit map-wide, so a pair reads from across the floor while the crack between them only resolves once you're close.

Decoy cracks are an **independent 0–2 roll on every daily floor** (30% / 45% / 25%), decoupled from the boss roll — so cracks show up on floors 1–2 where you have no bombs yet and can't do anything about them. A decoy opens onto a pot holding pink-realm fruit or ordinary food, so a misread is never a dead loss. But three bombs against three seals is the entire supply: knowing the trick isn't sufficient, you still have to read which crack is real.

Measured over 90 daily seeds:

| cracks on a floor | floor 1 | floor 2 | floor 3 |
|---|---|---|---|
| 0 | 23 | 31 | 23 |
| 1 | 40 | 42 | 32 |
| 2 | 27 | 17 | 25 |
| 3 (doorway + 2 decoys) | — | — | 10 |

26 of the 90 were bomb days; of those, 5 had the doorway alone, 11 had one decoy, 10 had two.

## Design constraints worth knowing

- **A crack is only readable on a wall with `FLOOR` directly below it** — the only wall `Tile.tsx` gives a camera-facing front face (`isFloorBelow`). Side and bottom walls render as caps seen from above, so they can never carry a seal or a torch.
- **The motif is 3 wide, not 5.** Over 60 generated floor 3s, a 5-wide run of faced wall has an interior fit on only 14 of them, vs 55 for a 3-wide run. A 5-wide seal would therefore always land on the map's top boundary row and be findable by rote; the 3-wide one lands anywhere from row 1 to row 22.
- **Payloads live in `GameState.sealPayloads`, not on the tile**, so every seal looks identical until opened — a subtype would leak the answer into the DOM as well as the render.

## Behavior changes to flag

- **Torch-bearing walls are now blast-proof.** The bomb rests directly below the seal so its 3×3 covers both bracketing torches; without this the motif would blow into one anonymous 3-wide hole. It also fixes the old oddity where a blast deleted a mounted torch. An existing test asserted the old behavior and was inverted.
- **Opened seals strip `SINGED` and `BREACH`.** The `BREACH` part is load-bearing: a seal on the boundary-row fallback would otherwise be tagged as a hole in the dungeon's shell and walk the hero out to the grassland instead of into what was walled up behind it.
- `outsideHasBossEntrance` is removed from `GameState`; `buildOutsideWorld` carves no boss entrance in any direction. The grassland keeps its stone goblins and no reward, which is what it was designed as.

## Verification

- `npm run test` — 109 suites, 822 passing, 0 failing
- `npm run typecheck` clean, `npm run lint` clean (no new warnings)
- `npm run build` clean
- New suite `__tests__/lib/sealed_doorway.test.ts` (16 tests): open-into-boss and open-into-pot paths, torch survival, the boundary-row case, a stale save with no payload, placement invariants across 25 generated floors, the 0/1/2 roll producing all three values, floor-1 cracks with `bombCount: 0` and never a `"boss"` payload, and per-seed determinism.
- `boss_daily_rotation.test.ts` needed a real fix: it detected a bomb day by "are there any `WALL_SEAL` tiles," which is now wrong since decoys appear on every floor regardless of entrance kind. It checks for a `"boss"` payload instead.

Playable at `/test-boss-entrances` → "Bomb: Sealed Door". Full write-up in `.claude/features/boss-daily-entrances/index.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)