### PR TITLE
Report one Coilwyrm as one, and stop new bosses rewriting past days

### DIFF
--- a/__tests__/lib/boss_reporting_fidelity.test.ts
+++ b/__tests__/lib/boss_reporting_fidelity.test.ts
@@ -1,0 +1,114 @@
+// Guards the two surfaces that report a boss to the player — the shareable kill tally and the
+// stats page's per-day crest — against the specific ways each one silently lied.
+import {
+  summarizeMonsters,
+  monsterShareLines,
+} from "../../lib/enemies/monster_summary";
+import { reconcileBossDay, type BossDayInfo } from "../../lib/stats/boss_day";
+import { BOSS_KINDS, BOSS_ROSTER } from "../../lib/bosses/boss_roster";
+
+describe("kill tally: a Coilwyrm is one Coilwyrm", () => {
+  // Severing the coil reaps each cut-off length through trackEnemyKill (game-state.ts), so a
+  // real fight leaves a pile of `coilwyrm-coil` kills next to the single `coilwyrm` head.
+  const run = {
+    "earth-goblin": 12,
+    coilwyrm: 1,
+    "coilwyrm-coil": 8,
+  } as const;
+
+  test("the crest counts the head only, never the segments", () => {
+    const summary = summarizeMonsters(run);
+    const boss = summary.groups.find((g) => g.key === "coilwyrm");
+    expect(boss).toBeDefined();
+    expect(boss!.count).toBe(1);
+    expect(boss!.emoji).toBe(BOSS_ROSTER.coilwyrm.emoji.join(""));
+  });
+
+  test("segments are still reported, in their own bucket", () => {
+    const summary = summarizeMonsters(run);
+    const coil = summary.groups.find((g) => g.key === "coil");
+    expect(coil).toBeDefined();
+    expect(coil!.count).toBe(8);
+    expect(coil!.emoji).not.toBe(BOSS_ROSTER.coilwyrm.emoji.join(""));
+  });
+
+  test("the total still equals the run's kill count, so the breakdown adds up", () => {
+    // The reaping path increments enemiesDefeated per severed length, so hiding the segments
+    // rather than re-bucketing them would leave the shared total short.
+    const summary = summarizeMonsters(run);
+    expect(summary.total).toBe(12 + 1 + 8);
+  });
+
+  test("the share line reads as one boss", () => {
+    const line = monsterShareLines(summarizeMonsters(run))[0];
+    expect(line).toContain(`${BOSS_ROSTER.coilwyrm.emoji.join("")}×1`);
+    expect(line).not.toContain(`${BOSS_ROSTER.coilwyrm.emoji.join("")}×9`);
+  });
+
+  test("the boss crest still reads last, as the headline kill", () => {
+    const summary = summarizeMonsters(run);
+    expect(summary.groups[summary.groups.length - 1].key).toBe("coilwyrm");
+  });
+
+  test("every boss reports exactly one kill from a one-kill run", () => {
+    for (const kind of BOSS_KINDS) {
+      const summary = summarizeMonsters({ [kind]: 1 });
+      const group = summary.groups.find(
+        (g) => g.emoji === BOSS_ROSTER[kind].emoji.join("")
+      );
+      expect(group).toBeDefined();
+      expect(group!.count).toBe(1);
+    }
+  });
+});
+
+describe("stats page: growing the roster must not rewrite the past", () => {
+  const replayed: BossDayInfo = {
+    entranceKind: "douse",
+    arenaSeed: "water",
+    bossKind: "fisher",
+    bossEmoji: BOSS_ROSTER.fisher.emoji.join(""),
+    bossName: "The Fisher",
+  };
+
+  test("what players actually rolled overrules the replay", () => {
+    // The exact 2026-07-30 case: the day was the Shaper, but replaying it under a roster that
+    // has since grown from 2 to 4 re-indexes the same draw and yields the Fisher.
+    const out = reconcileBossDay(replayed, ["shaper", "shaper"]);
+    expect(out.bossKind).toBe("shaper");
+    expect(out.bossEmoji).toBe(BOSS_ROSTER.shaper.emoji.join(""));
+    expect(out.bossName).toBe("The Shaper");
+  });
+
+  test("the entrance is left alone — only the boss identity is in question", () => {
+    const out = reconcileBossDay(replayed, ["shaper"]);
+    expect(out.entranceKind).toBe("douse");
+    expect(out.arenaSeed).toBe("water");
+  });
+
+  test("falls back to the replay when nobody recorded a boss that day", () => {
+    expect(reconcileBossDay(replayed, []).bossKind).toBe("fisher");
+    expect(reconcileBossDay(replayed, [null, undefined]).bossKind).toBe("fisher");
+  });
+
+  test("a single malformed row cannot relabel a day", () => {
+    const out = reconcileBossDay(replayed, [
+      "quarrymaster",
+      "shaper",
+      "shaper",
+      "shaper",
+    ]);
+    expect(out.bossKind).toBe("shaper");
+  });
+
+  test("values no longer in the roster are ignored rather than trusted", () => {
+    const out = reconcileBossDay(replayed, ["warden", "shade"]);
+    expect(out.bossKind).toBe("fisher");
+  });
+
+  test("agrees with the replay when the roster has not moved", () => {
+    const out = reconcileBossDay(replayed, ["fisher"]);
+    expect(out.bossKind).toBe("fisher");
+    expect(out.bossEmoji).toBe(replayed.bossEmoji);
+  });
+});

--- a/app/api/endgame-stats/route.ts
+++ b/app/api/endgame-stats/route.ts
@@ -6,7 +6,7 @@ import {
   type StatsDayPayload,
 } from "../../../lib/stats/endgame_stats";
 import { level2ChestStatusForDate } from "../../../lib/stats/daily_chest";
-import { bossDayInfoForDate } from "../../../lib/stats/boss_day";
+import { bossDayInfoForDate, reconcileBossDay } from "../../../lib/stats/boss_day";
 
 // Reads historical daily runs out of PostHog for the endgame stats dashboard.
 // This is a read path (PostHog Query / HogQL) and needs a *personal* API key +
@@ -208,7 +208,13 @@ export async function GET(req: NextRequest) {
     const payloadDays: StatsDayPayload[] = pageDays.map((date) => {
       const g = groupedByDate.get(date);
       const chestStatus = level2ChestStatusForDate(date);
-      const bossDay = bossDayInfoForDate(date);
+      // Replay first, then let the day's own rows overrule which boss it was — the replay
+      // re-indexes whenever the roster grows, so it cannot be trusted about the past on its
+      // own. See reconcileBossDay.
+      const bossDay = reconcileBossDay(
+        bossDayInfoForDate(date),
+        (g?.games ?? []).map((row) => row.dailyBossKind)
+      );
       return {
         date,
         chests: {

--- a/lib/enemies/monster_summary.ts
+++ b/lib/enemies/monster_summary.ts
@@ -70,6 +70,19 @@ const GROUP_DEFS: GroupDef[] = [
   },
   { key: "snake", label: "Snake", emoji: "🐍", rep: "snake", kinds: ["snake"] },
   { key: "wisp", label: "Wisp", emoji: "👻", rep: "ghost", kinds: ["ghost"] },
+  // Severed Coilwyrm lengths get their OWN bucket rather than folding into the boss below.
+  // They have to be counted somewhere: the reaping path in game-state.ts increments
+  // enemiesDefeated for each one, so dropping them here would leave the ⚔️ total short of
+  // the run's actual kill count. But they must not be counted AS Coilwyrms — a fight where
+  // you cut the coil eight times would report nine of a boss there is only ever one of.
+  // Sits with the ordinary enemies so the boss crest still reads last as the headline kill.
+  {
+    key: "coil",
+    label: "Coilwyrm Segment",
+    emoji: "➰",
+    rep: "coilwyrm-coil",
+    kinds: ["coilwyrm-coil"],
+  },
   // The boss goes last so it reads as the headline kill of the run. Three glyphs
   // (ice + skull + fire) capture its whole essence — a skeleton that wields water and
   // lava — and make it unmistakably a boss beside the single-emoji enemies.
@@ -100,14 +113,15 @@ const GROUP_DEFS: GroupDef[] = [
     kinds: ["fisher"],
   },
   {
-    // Head and body are one boss in the tally. Counting severed segments separately would
-    // report a single kill as a dozen, and the segments are the fight rather than a
-    // different enemy.
+    // The HEAD only. There is exactly one Coilwyrm per run, so this count is 0 or 1 and the
+    // crest means "you killed the boss" rather than "you hit it a lot". Its severed lengths
+    // are tallied by the `coil` group above — folding them in here summed to a count of nine
+    // for one dead boss.
     key: "coilwyrm",
     label: "The Coilwyrm",
     emoji: "🗡️🪱🗡️",
     rep: "coilwyrm",
-    kinds: ["coilwyrm", "coilwyrm-coil"],
+    kinds: ["coilwyrm"],
   },
 ];
 

--- a/lib/stats/boss_day.ts
+++ b/lib/stats/boss_day.ts
@@ -43,6 +43,53 @@ export interface BossDayInfo {
 }
 
 /**
+ * Correct a replayed day against what players' clients actually rolled that morning.
+ *
+ * The replay below is only faithful while BOSS_ROSTER is the same SIZE it was on the date in
+ * question: rollDailyBossKind is `floor(rand * BOSS_KINDS.length)`, so adding a boss re-indexes
+ * the same seeded draw and silently rewrites history. Taking the roster from 2 to 4 (the
+ * Coilwyrm and the Quarrymaster) moved 2026-07-30 from the Shaper to the Fisher, and would
+ * have shown days as bosses that did not exist yet on those days.
+ *
+ * A player's stored `daily_boss_kind` is not a replay — it is what their browser computed under
+ * the roster that was live — so it is authoritative and wins whenever we have one. Majority
+ * rather than first-seen so a single malformed row cannot relabel a day.
+ *
+ * Falls back to the replay when no row that day carries a value, which is the case the replay
+ * exists for: nobody reached floor 3, or nobody has played yet.
+ */
+export function reconcileBossDay(
+  replayed: BossDayInfo,
+  recorded: Array<string | null | undefined>
+): BossDayInfo {
+  const tally = new Map<string, number>();
+  for (const kind of recorded) {
+    if (!kind) continue;
+    if (!bossInfo(kind)) continue; // ignore values no longer in the roster
+    tally.set(kind, (tally.get(kind) ?? 0) + 1);
+  }
+  if (tally.size === 0) return replayed;
+
+  let best: string | null = null;
+  let bestCount = 0;
+  for (const [kind, count] of tally) {
+    if (count > bestCount) {
+      best = kind;
+      bestCount = count;
+    }
+  }
+  const info = bossInfo(best);
+  if (!info) return replayed;
+
+  return {
+    ...replayed,
+    bossKind: info.kind,
+    bossEmoji: info.emoji.join(""),
+    bossName: info.displayName,
+  };
+}
+
+/**
  * Compute the day's boss-entrance kind for a daily run identified by its local date
  * string (YYYY-MM-DD, the same value stored on analytics as `date_seed`).
  */


### PR DESCRIPTION
Two ways the boss surfaces were reporting something false, found while auditing whether
all four bosses actually show up on the stats page and in shared results.

## A Coilwyrm reported as nine Coilwyrms

Severing the coil reaps each cut-off length through `trackEnemyKill`, so a real fight
leaves a `coilwyrm` head next to eight `coilwyrm-coil` kills — and the tally group summed
both kinds into a single count:

```
⚔️ 21: 👹×12 🗡️🪱🗡️×9
```

Nine of a boss there is only ever one of. Merging the *label* wasn't enough; the count had
to stop absorbing segments.

The crest now counts the head alone. The segments get their **own** bucket rather than
being dropped, because the reaping path also increments `enemiesDefeated` for each one —
hiding them would leave the shared total short of the run's own kill count:

```
⚔️ 21: 👹×12 ➰×8 🗡️🪱🗡️×1
```

## Growing the roster rewrote past days on the stats page

The per-day crest comes from replaying `rollDailyBossKind`, which is
`floor(rand * BOSS_KINDS.length)`. Taking the roster from two bosses to four re-indexed the
same seeded draw and relabelled every past day — including as bosses that **did not exist**
on those days.

Concretely: **2026-07-30 was the Shaper in production, and the page was showing it as the
Fisher.** The pre-change roster was exactly `["shaper", "fisher"]`, and the draw that now
yields fisher (1 of 4) lands in `[0.25, 0.5)`, which floors to 0 of 2 — the Shaper.

A player's stored `daily_boss_kind` is not a replay; it is what their browser actually
computed that morning under the roster that was live. So it now overrules the replay — by
majority, so one malformed row cannot relabel a day — with the replay kept as the fallback
it was written for: days nobody reached floor 3, or nobody has played yet. That also means
adding a fifth boss will not silently do this again.

Blast radius was one day: the rotation shipped 2026-07-30.

## Not addressed (design calls, not defects)

- The share text never **names** the boss. The only signal is the crest inside the kill
  tally, so a Quarrymaster win reads `⚔️ 21: 👹×12 ⛏️🗿⛏️×1` and you have to know the crest.
  There's no share-side distinction between *found it and lost* and *never found it*, though
  the stats page has both states.
- `app/end/page.tsx` has a hand-written `byKind` literal type listing only 8 kinds (no
  snake, white-goblin, or any boss). It's cast at the call site so runtime is unaffected,
  but the type is stale.

## Verification

1093 tests pass (12 new, covering both defects); typecheck, lint and production build clean.
