### PR TITLE
Mark boss arenas in the floor header with a skull

### DIFF
--- a/__tests__/components/GameViewTitle.test.tsx
+++ b/__tests__/components/GameViewTitle.test.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { heroLocationTitle } from '../../components/GameView';
+import { TilemapGrid } from '../../components/TilemapGrid';
+import { TileSubtype, GameState, Direction } from '../../lib/map';
+import '@testing-library/jest-dom';
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}));
+
+describe('heroLocationTitle', () => {
+  const daily = { maxFloors: 3, isEndless: false };
+
+  it('shows the floor out of the total in the multi-floor daily', () => {
+    expect(heroLocationTitle({ ...daily, floor: 3 })).toBe('Torch Boy — Floor 3/3');
+  });
+
+  it('adds a skull to the floor while the hero is in a boss arena', () => {
+    expect(heroLocationTitle({ ...daily, floor: 3, inBossRoom: true })).toBe(
+      'Torch Boy — Floor 3/3 💀'
+    );
+  });
+
+  it('never names the boss (internal names stay internal)', () => {
+    const title = heroLocationTitle({ ...daily, floor: 3, inBossRoom: true });
+    for (const name of ['Shaper', 'Fisher', 'Quarrymaster', 'Coilwyrm']) {
+      expect(title).not.toContain(name);
+    }
+  });
+
+  it('drops the skull again once the hero walks back out of the arena', () => {
+    expect(heroLocationTitle({ ...daily, floor: 3, inBossRoom: false })).toBe(
+      'Torch Boy — Floor 3/3'
+    );
+  });
+
+  it('keeps the skull in endless, which has no floor cap to show', () => {
+    expect(
+      heroLocationTitle({ maxFloors: 999, isEndless: true, floor: 7, inBossRoom: true })
+    ).toBe('Torch Boy — Floor 7 💀');
+  });
+
+  it('prefers the boss skull over the pink realm word', () => {
+    expect(
+      heroLocationTitle({ ...daily, floor: 3, inPinkRealm: true, inBossRoom: true })
+    ).toBe('Torch Boy — Floor 3/3 💀');
+    expect(heroLocationTitle({ ...daily, floor: 3, inPinkRealm: true })).toBe(
+      'Torch Boy — Pink Realm 3/3'
+    );
+  });
+
+  it('stays plain on single-floor maps', () => {
+    expect(heroLocationTitle({ maxFloors: 1, isEndless: false, floor: 1 })).toBe('Torch Boy');
+  });
+});
+
+describe('TilemapGrid location reporting', () => {
+  const tileTypes = {
+    0: { id: 0, name: 'floor', color: '#ccc', walkable: true },
+    1: { id: 1, name: 'wall', color: '#333', walkable: false },
+  };
+
+  const stateWith = (extra: Partial<GameState>): GameState => {
+    const size = 25;
+    const tiles = Array(size).fill(0).map(() => Array(size).fill(0));
+    const subtypes = Array(size)
+      .fill(0)
+      .map(() => Array(size).fill(0).map(() => [] as number[]));
+    const c = Math.floor(size / 2);
+    subtypes[c][c] = [TileSubtype.PLAYER];
+    return {
+      hasKey: false,
+      hasExitKey: false,
+      mapData: { tiles, subtypes },
+      showFullMap: false,
+      win: false,
+      playerDirection: Direction.DOWN,
+      heroHealth: 5,
+      heroAttack: 1,
+      heroTorchLit: true,
+      stats: { damageDealt: 0, damageTaken: 0, enemiesDefeated: 0, steps: 0 },
+      currentFloor: 3,
+      maxFloors: 3,
+      ...extra,
+    };
+  };
+
+  const renderWith = (extra: Partial<GameState>) => {
+    const onLocationChange = jest.fn();
+    const state = stateWith(extra);
+    render(
+      <TilemapGrid
+        tilemap={state.mapData.tiles}
+        tileTypes={tileTypes}
+        subtypes={state.mapData.subtypes}
+        initialGameState={state}
+        onLocationChange={onLocationChange}
+      />
+    );
+    return onLocationChange;
+  };
+
+  it('reports the boss arena so the header can show the skull', () => {
+    expect(renderWith({ inBossRoom: true })).toHaveBeenCalledWith(
+      expect.objectContaining({ floor: 3, inBossRoom: true })
+    );
+  });
+
+  it('reports a plain dungeon floor as not in a boss arena', () => {
+    expect(renderWith({})).toHaveBeenCalledWith(
+      expect.objectContaining({ floor: 3, inBossRoom: false })
+    );
+  });
+});

--- a/components/GameView.tsx
+++ b/components/GameView.tsx
@@ -22,6 +22,37 @@ export interface GameViewProps {
   storageSlot?: "default" | "daily-new" | "story" | "endless";
 }
 
+/**
+ * Header title: "Torch Boy — Floor 2/3" in the multi-floor daily, "Torch Boy — Floor 7"
+ * in endless (no cap worth advertising), and the floor word becomes "Pink Realm" while
+ * the hero is warped into the secret realm. Inside a boss arena the floor keeps its
+ * number and gains a skull: "Torch Boy — Floor 3/3 💀" — deliberately no boss name,
+ * since the internal boss names aren't surfaced to players.
+ */
+export function heroLocationTitle({
+  floor,
+  maxFloors,
+  isEndless,
+  inPinkRealm,
+  inBossRoom,
+}: {
+  floor?: number;
+  maxFloors: number;
+  isEndless: boolean;
+  inPinkRealm?: boolean;
+  inBossRoom?: boolean;
+}): string {
+  const isMultiFloor = maxFloors > 1;
+  if (!floor || (!isEndless && !isMultiFloor)) return "Torch Boy";
+  // Boss arena wins over the realm word: you are standing in the arena, and the skull
+  // is the whole signal. (Unreachable together today — arenas are entered from the
+  // floor-3 dungeon, not the realm — but the precedence keeps the string sane.)
+  const place = inPinkRealm && !inBossRoom ? "Pink Realm" : "Floor";
+  const boss = inBossRoom ? " 💀" : "";
+  const where = isEndless ? `${floor}` : `${floor}/${maxFloors}`;
+  return `Torch Boy — ${place} ${where}${boss}`;
+}
+
 function GameViewInner({
   algorithm,
   replay,
@@ -179,29 +210,24 @@ function GameViewInner({
 
   const finalInitialState = replayState || initialState;
 
-  // Track the hero's location (floor + pink realm) for the title area
+  // Track the hero's location (floor + pink realm + boss arena) for the title area
   const [heroLocation, setHeroLocation] = useState<{
     floor?: number;
     inPinkRealm: boolean;
+    inBossRoom: boolean;
   }>({
     floor: finalInitialState?.currentFloor,
     inPinkRealm: !!finalInitialState?.inPinkRealm,
+    inBossRoom: !!finalInitialState?.inBossRoom,
   });
 
-  // Header title: "Torch Boy — Floor 2/3" in the multi-floor daily,
-  // "Torch Boy — Floor 7" in endless (no cap worth advertising), and the floor
-  // word becomes "Pink Realm" while the hero is warped into the secret realm.
-  const title = (() => {
-    const floor = heroLocation.floor;
-    const maxFloors = finalInitialState?.maxFloors ?? 1;
-    const isEndless = storageSlot === "endless";
-    const isMultiFloor = maxFloors > 1;
-    if (!floor || (!isEndless && !isMultiFloor)) return "Torch Boy";
-    const place = heroLocation.inPinkRealm ? "Pink Realm" : "Floor";
-    return isEndless
-      ? `Torch Boy — ${place} ${floor}`
-      : `Torch Boy — ${place} ${floor}/${maxFloors}`;
-  })();
+  const title = heroLocationTitle({
+    floor: heroLocation.floor,
+    maxFloors: finalInitialState?.maxFloors ?? 1,
+    isEndless: storageSlot === "endless",
+    inPinkRealm: heroLocation.inPinkRealm,
+    inBossRoom: heroLocation.inBossRoom,
+  });
 
   // Fire analytics for game start once we have an initial state
   useEffect(() => {

--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -264,9 +264,13 @@ interface TilemapGridProps {
    */
   onDeath?: (finalState: GameState) => void;
   storageSlot?: GameStorageSlot;
-  // Notify parent where the hero is (floor number + pink realm status) so it
-  // can render a location title. Fires on mount and whenever either changes.
-  onLocationChange?: (loc: { floor?: number; inPinkRealm: boolean }) => void;
+  // Notify parent where the hero is (floor number + pink realm / boss arena
+  // status) so it can render a location title. Fires on mount and on any change.
+  onLocationChange?: (loc: {
+    floor?: number;
+    inPinkRealm: boolean;
+    inBossRoom: boolean;
+  }) => void;
 }
 
 export const TilemapGrid: React.FC<TilemapGridProps> = ({
@@ -2446,15 +2450,21 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
     }
   }, [gameState.showFullMap, suppressDarknessOverlay]);
 
-  // Report the hero's location (floor + pink realm) up to the parent for the
-  // header title. Keyed on committed game state, so it covers floor swaps,
-  // pink-realm warps in and out, and the initial mount.
+  // Report the hero's location (floor + pink realm + boss arena) up to the parent
+  // for the header title. Keyed on committed game state, so it covers floor swaps,
+  // pink-realm warps in and out, boss-arena entry/exit, and the initial mount.
   useEffect(() => {
     onLocationChange?.({
       floor: gameState.currentFloor,
       inPinkRealm: !!gameState.inPinkRealm,
+      inBossRoom: !!gameState.inBossRoom,
     });
-  }, [gameState.currentFloor, gameState.inPinkRealm, onLocationChange]);
+  }, [
+    gameState.currentFloor,
+    gameState.inPinkRealm,
+    gameState.inBossRoom,
+    onLocationChange,
+  ]);
 
   // Endless: register the run with the server so floor checkpoints can be
   // attested (anti-fraud for the leaderboard). Fail-soft — a run that can't


### PR DESCRIPTION
## What

Entering a boss arena left the header reading `Floor 3/3` — `enterBossRoom` keeps `currentFloor` at 3, and the location report only carried the floor plus the pink-realm flag, so nothing in the title moved.

Now the arena is marked: `Torch Boy — Floor 3/3 💀`

- No boss name — the internal boss names aren't surfaced to players.
- The floor number stays put, so the "how far am I" read survives.
- Boss arena takes precedence over the Pink Realm word. Unreachable together today (arenas are entered from the floor-3 dungeon, not the realm), but the precedence keeps the string sane.

## How

`inBossRoom` is threaded up through `onLocationChange` alongside floor and pink-realm status, and the title logic moves out of an inline IIFE into a pure exported `heroLocationTitle()` so it can be tested without standing up the whole game.

## Verification

- `npm run typecheck` — clean
- `npm run build` — succeeds, all routes compile
- New `__tests__/components/GameViewTitle.test.tsx` (115 lines) covers daily/endless/pink-realm/boss-arena title cases, including a guard that no boss name ever leaks into the title
- Boss + TilemapGrid suites: 9 suites, 95 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)