### PR TITLE
Stop Jest from collecting other worktrees' tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,9 +5,21 @@ const createJestConfig = nextJest({
   dir: './'
 });
 
+// Git worktrees live under .claude/worktrees/ inside this repo, so each one is a
+// full second checkout sitting under rootDir. Without these, jest collects every
+// other branch's tests alongside our own and a stale failure over there reads as a
+// failure here. The <rootDir> prefix is load-bearing: running jest from inside a
+// worktree makes that worktree the rootDir, so its own tests still run normally.
+const worktreeIgnorePattern = '<rootDir>/\\.claude/worktrees/';
+
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/jest.setup.js'],
   testEnvironment: 'jest-environment-jsdom',
+  // next/jest appends these to its own /node_modules/ and /.next/ defaults
+  testPathIgnorePatterns: [worktreeIgnorePattern],
+  // Also keep worktrees out of the module map — duplicate copies of every module
+  // otherwise make mocking resolve unpredictably.
+  modulePathIgnorePatterns: [worktreeIgnorePattern],
   moduleNameMapper: {
     // Handle module aliases (if you have any in tsconfig)
     '^@/components/(.*)$': '<rootDir>/components/$1',


### PR DESCRIPTION
## What

Worktrees live under `.claude/worktrees/` inside the repo, so every branch checked out there sat under Jest's `rootDir` and its tests ran alongside the main checkout's.

| | suites | from worktrees |
|---|---|---|
| before | 808 | 682 |
| after | 127 | 0 |

Only **127** of the 808 suites belonged to the checkout — it was running ~6× the tests it should. Worse than the runtime cost: a stale failure on an unrelated branch would have read as a failure on the current one.

## How

Ignore `.claude/worktrees/` in both `testPathIgnorePatterns` and `modulePathIgnorePatterns`. The second one matters independently — without it, duplicate copies of every module stay in the resolver's map and make mocking behave unpredictably.

The `<rootDir>/` prefix is load-bearing. A bare `.claude/worktrees/` pattern would match a worktree's *own* absolute path when Jest runs from inside it, silently excluding every test on the branch you're working on. With the prefix it's a harmless no-op there.

`next/jest` appends custom `testPathIgnorePatterns` to its own `/node_modules/` and `/.next/` defaults, so those are not lost.

## Verification

- Full suite against the main checkout: **123 passed, 4 skipped, 1113 tests, 7.5s**, zero `.claude/worktrees/` paths collected.
- From inside a worktree, `npm run test`: 126 suites, 1104 tests, all passing — its own tests still run.
- `npm run build` passes.

Verified without modifying the main checkout, by running `jest --config <worktree config> --rootDir <main>`; main's `jest.config.js` was confirmed byte-identical afterward.

Externally-located worktrees (e.g. under `/private/tmp/.../scratchpad/wt-*`) are outside `rootDir` and were never affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)