### PR TITLE
Light the Quarrymaster's door with lava so a doused arrival is survivable

### DIFF
--- a/__tests__/lib/quarrymaster_arena_light.test.ts
+++ b/__tests__/lib/quarrymaster_arena_light.test.ts
@@ -1,0 +1,119 @@
+import {
+  buildQuarrymasterArena,
+  QUARRYMASTER_LAYOUTS,
+} from "../../lib/bosses/quarrymaster_arena";
+import { TileSubtype } from "../../lib/map/constants";
+
+/**
+ * The Quarrymaster arena has to be navigable by a hero who arrives with a DOUSED torch.
+ *
+ * enterBossRoom carries the live run's torch state into the arena, and the douse-to-see
+ * DARK_PORTAL entrance only appears while the torch is OUT — so on those days the hero
+ * lands in the arena blind. Every layout used to put both wall torches at the chamber
+ * mouth, ~9 tiles away across the crack field, which made that arrival a death sentence.
+ * Each layout now carries lava pools by the door: they glow (so they are visible with no
+ * torch), ending a move in their glow relights the torch, and they kill on contact.
+ *
+ * See lib/bosses/quarrymaster_arena.ts, assertLayout checks 5b/5c.
+ */
+
+/** Mirrors computeTorchGlow: Chebyshev 2, minus the four far corners. */
+const GLOW_RADIUS = 2;
+function insideGlow(
+  [ay, ax]: [number, number],
+  [by, bx]: [number, number]
+): boolean {
+  const dy = Math.abs(ay - by);
+  const dx = Math.abs(ax - bx);
+  return (
+    Math.max(dy, dx) <= GLOW_RADIUS &&
+    !(dy === GLOW_RADIUS && dx === GLOW_RADIUS)
+  );
+}
+
+function lavaTiles(subtypes: number[][][]): Array<[number, number]> {
+  const out: Array<[number, number]> = [];
+  for (let y = 0; y < subtypes.length; y++) {
+    for (let x = 0; x < subtypes[y].length; x++) {
+      if (subtypes[y][x].includes(TileSubtype.LAVA)) out.push([y, x]);
+    }
+  }
+  return out;
+}
+
+describe("Quarrymaster arena — light at the door", () => {
+  QUARRYMASTER_LAYOUTS.forEach((layout, layoutIndex) => {
+    describe(layout.name, () => {
+      const arena = buildQuarrymasterArena({ layoutIndex });
+      const lava = lavaTiles(arena.state.mapData.subtypes);
+
+      it("actually places lava on the map", () => {
+        // Guards against the whole feature silently not parsing: if the `L` characters were
+        // dropped, every assertion below would pass vacuously and the policy sim would show
+        // unchanged numbers for the wrong reason.
+        expect(lava.length).toBeGreaterThan(0);
+        // ...and the builder reports the same pools it painted.
+        expect([...arena.lava].sort()).toEqual([...lava].sort());
+      });
+
+      it("puts a light source within a doused hero's glow of the start", () => {
+        const lit = [...lava, ...arena.torches].filter((pos) =>
+          insideGlow(pos, arena.hero)
+        );
+        expect(lit.length).toBeGreaterThan(0);
+      });
+
+      it("keeps lava off the tiles orthogonally adjacent to the start", () => {
+        // Movement is orthogonal-only, so an adjacent pool means the first keypress out of
+        // the gate — pressed in the dark, before any relight — is instant death with no tell.
+        for (const [ly, lx] of lava) {
+          const manhattan =
+            Math.abs(ly - arena.hero[0]) + Math.abs(lx - arena.hero[1]);
+          expect(manhattan).not.toBe(1);
+        }
+      });
+
+      it("never puts lava on the hero, the boss, the exit, a switch or a pod", () => {
+        const reserved = [
+          arena.hero,
+          arena.boss,
+          ...arena.plates,
+          ...arena.pods,
+        ].map(([y, x]) => `${y},${x}`);
+        for (const [ly, lx] of lava) {
+          expect(reserved).not.toContain(`${ly},${lx}`);
+        }
+      });
+
+      it("still satisfies every other layout invariant", () => {
+        // assertLayout runs inside the builder and now treats lava as impassable when it
+        // walks the room, so building at all proves no pool blocks the only route to a
+        // switch or the exit.
+        expect(() => buildQuarrymasterArena({ layoutIndex })).not.toThrow();
+      });
+    });
+  });
+
+  it("fails loudly if a layout has no light near the hero start", () => {
+    // Reproduces the exact pre-fix state by stripping the lava back out of a shipped
+    // layout: valid in every other respect, torches only at the chamber mouth. Built from
+    // a real map rather than hand-authored on purpose — an earlier version of this test
+    // used a hand-made board and passed on an unrelated "switch has no gate row" error,
+    // which would have kept passing even if check 5b were deleted. Hence matching the
+    // message, not just .toThrow().
+    const unlit = QUARRYMASTER_LAYOUTS[0].map.map((row) => row.replace(/L/g, "."));
+    expect(() => buildQuarrymasterArena({ map: unlit })).toThrow(
+      /no light source \(L or T\) within 2 tiles of the hero start/
+    );
+  });
+
+  it("fails loudly if lava sits orthogonally adjacent to the hero start", () => {
+    const cruel = QUARRYMASTER_LAYOUTS[0].map.map((row, y) =>
+      // The hero is on row 15 col 8; drop lava directly above them.
+      y === 14 ? row.slice(0, 8) + "L" + row.slice(9) : row
+    );
+    expect(() => buildQuarrymasterArena({ map: cruel })).toThrow(
+      /orthogonally adjacent to the hero start/
+    );
+  });
+});

--- a/__tests__/lib/quarrymaster_policy.test.ts
+++ b/__tests__/lib/quarrymaster_policy.test.ts
@@ -44,14 +44,20 @@ function heroAt(state: GameState): Pos {
 
 /**
  * Tiles the hero must never voluntarily walk into: authored cracks, any hole a goblin has
- * already opened, and standing spike beds. All three are plainly visible in-game, so a bot
- * that blundered into them would be measuring its own carelessness rather than the arena —
- * and spikes in particular REFUSE the move, so a bot that kept trying would just wedge
- * itself against one for the rest of the fight (measured: 13 spike deaths and the Broken
- * Yard at 0/12 before this).
+ * already opened, standing spike beds, and the lava pools by the door. All are plainly
+ * visible in-game, so a bot that blundered into them would be measuring its own
+ * carelessness rather than the arena — and spikes in particular REFUSE the move, so a bot
+ * that kept trying would just wedge itself against one for the rest of the fight
+ * (measured: 13 spike deaths and the Broken Yard at 0/12 before this).
+ *
+ * Lava belongs here for the same reason and is the clearest case of it: it GLOWS, which is
+ * the whole point of putting it by the hero's start (see the arena's `L` legend), so it is
+ * the most visible hazard in the room. Omitting it took the switch-runner from 40/40 to
+ * 14/40 purely on walk-into-the-fire deaths.
  *
  * Retracted beds (SPIKE_HOLES) are deliberately absent — those are walkable, and treating
- * them as blocked would hide the fact that a thrown switch opens the way.
+ * them as blocked would hide the fact that a thrown switch opens the way. So is OBSIDIAN,
+ * a rock-cooled lava tile, which is genuinely safe to cross.
  */
 function lethalTiles(state: GameState): Set<string> {
   const out = new Set<string>();
@@ -62,7 +68,8 @@ function lethalTiles(state: GameState): Set<string> {
       if (
         cell.includes(TileSubtype.OPEN_ABYSS) ||
         cell.includes(TileSubtype.FAULTY_FLOOR) ||
-        cell.includes(TileSubtype.SPIKES)
+        cell.includes(TileSubtype.SPIKES) ||
+        (cell.includes(TileSubtype.LAVA) && !cell.includes(TileSubtype.OBSIDIAN))
       ) {
         out.add(`${y},${x}`);
       }

--- a/lib/bosses/quarrymaster_arena.ts
+++ b/lib/bosses/quarrymaster_arena.ts
@@ -43,9 +43,12 @@ type Subs = number[][][];
  *   `a` `b` `c` spike beds across the chamber mouth (answer switches 1-3)
  *   `d` the spike bed sealing the exit (answers switch 4)
  *   `r` a rock to pick up          `p` a pot          `T` wall torch (needs floor below)
+ *   `L` lava — light + instant death (must sit DIAGONALLY from `H`, see assertLayout 5b/5c)
  *
  * In every layout the chamber sits at the top behind its three gate rows, and the two pods
- * sit high and outside the chamber walls so goblins come down into the hall.
+ * sit high and outside the chamber walls so goblins come down into the hall. Every layout
+ * also owes a light source within 2 tiles of `H`, because the hero can arrive with a doused
+ * torch and the wall torches are up at the chamber mouth.
  */
 export interface QuarrymasterLayout {
   name: string;
@@ -72,7 +75,7 @@ export const QUARRYMASTER_LAYOUTS: QuarrymasterLayout[] = [
       "#.....X...X.....#",
       "#.1.X.X...X.X.p.#",
       "#...X.XXXXX.X...#",
-      "#.X.X.......X.X##",
+      "#.X.X.L...L.X.X##",
       "#.2.X...H...X.dE#",
       "#################",
     ],
@@ -96,7 +99,7 @@ export const QUARRYMASTER_LAYOUTS: QuarrymasterLayout[] = [
       "#.X..1.X.X....X.#",
       "#...XX.....XX..##",
       "#.p...X...X...dE#",
-      "#.X...........X##",
+      "#.X...L...L...X##",
       "#.......H.......#",
       "#################",
     ],
@@ -120,7 +123,7 @@ export const QUARRYMASTER_LAYOUTS: QuarrymasterLayout[] = [
       "#.X..XXXXXXX..X.#",
       "#....XXXXXXX....#",
       "#.......X.....p##",
-      "#.1...........dE#",
+      "#.1...L...L...dE#",
       "#.......H......##",
       "#################",
     ],
@@ -180,6 +183,8 @@ export interface QuarrymasterArena {
   cracks: Array<[number, number]>;
   /** Wall torches — the hero's way back from a ghost snuffing their light. */
   torches: Array<[number, number]>;
+  /** Lava pools — the light a hero who arrives doused can actually see, and a hazard. */
+  lava: Array<[number, number]>;
 }
 
 const ORTHO: Array<[number, number]> = [[-1, 0], [1, 0], [0, -1], [0, 1]];
@@ -196,6 +201,7 @@ interface ParsedMap {
   pods: Array<[number, number]>;
   cracks: Array<[number, number]>;
   torches: Array<[number, number]>;
+  lava: Array<[number, number]>;
   gateGroups: GateGroup[];
 }
 
@@ -214,6 +220,7 @@ function parseMap(map: readonly string[]): ParsedMap {
   const pods: Array<[number, number]> = [];
   const cracks: Array<[number, number]> = [];
   const torches: Array<[number, number]> = [];
+  const lava: Array<[number, number]> = [];
   const gatesByChar: Record<string, Array<[number, number]>> = {};
 
   for (let y = 0; y < size; y++) {
@@ -261,6 +268,20 @@ function parseMap(map: readonly string[]): ParsedMap {
         case "S":
           subtypes[y][x] = [TileSubtype.SPAWN_POD];
           pods.push([y, x]);
+          break;
+        case "L":
+          // A pool of molten rock, and the arena's only light the hero arrives with.
+          // enterBossRoom carries the live run's torch state in, and the douse-to-see
+          // DARK_PORTAL entrance only appears while the torch is OUT — so on those days the
+          // hero lands here in the dark, and the wall torches are up at the chamber mouth
+          // across the crack field. Lava glows on its own (see computeTorchGlow, the same
+          // area the render layer lights), so it is visible from arrival, and ending a move
+          // inside that glow relights the torch. It also kills instantly, which is the
+          // point: light you have to stand next to. Placed DIAGONALLY from the hero start,
+          // never orthogonally — movement is orthogonal-only, so the first keypress out of
+          // the gate can never walk into it blind.
+          subtypes[y][x] = [TileSubtype.LAVA];
+          lava.push([y, x]);
           break;
         case "r":
           subtypes[y][x] = [TileSubtype.ROCK];
@@ -323,6 +344,7 @@ function parseMap(map: readonly string[]): ParsedMap {
     pods,
     cracks,
     torches,
+    lava,
     gateGroups,
   };
 }
@@ -340,6 +362,12 @@ function reachable(
     // A spike bed is walkable only once its switch has retracted it.
     if (subs.includes(TileSubtype.SPIKES)) return openGates.has(`${y},${x}`);
     if (subs.includes(TileSubtype.FAULTY_FLOOR)) return false;
+    // Lava is instant death on entry, so it is a wall for routing purposes. It is a FLOOR
+    // overlay, not a wall tile, so without this line every check below would happily
+    // certify a layout whose only path to a switch or the exit runs through it — the exact
+    // invisible soft-lock this validator exists to catch. (OBSIDIAN, a rock-cooled lava
+    // tile, is safe and walkable, but no layout authors one: it only appears at runtime.)
+    if (subs.includes(TileSubtype.LAVA) && !subs.includes(TileSubtype.OBSIDIAN)) return false;
     return tiles[y]?.[x] === FLOOR && !subs.includes(TileSubtype.OPEN_ABYSS);
   };
   const seen = new Set<string>([`${from[0]},${from[1]}`]);
@@ -441,6 +469,43 @@ export function assertLayout(parsed: ParsedMap): void {
     }
   }
 
+  // 5b. A light source must be visible FROM THE HERO'S START, not merely somewhere in the
+  //     room. enterBossRoom carries the live run's torch state in, and the douse-to-see
+  //     DARK_PORTAL entrance only appears while the torch is OUT — so on those days the hero
+  //     lands here blind, with a doused FOV of their own tile plus dim neighbours. Every
+  //     layout used to put both torches at the chamber mouth, nine tiles away across the
+  //     crack field, which made a doused arrival a death sentence: you could not see far
+  //     enough to route around the cracks, and standing still let the pods bury you.
+  //
+  //     GLOW_RADIUS is Chebyshev 2 because that is what computeTorchGlow lights (an octagon,
+  //     far corners dropped) and also the range at which ending a move relights the torch.
+  //     So a source inside it is both visible on arrival and one step from a relight.
+  const GLOW_RADIUS = 2;
+  const [hy, hx] = hero;
+  const nearStart = [...parsed.lava, ...parsed.torches].some(([ly, lx]) => {
+    const dy = Math.abs(ly - hy);
+    const dx = Math.abs(lx - hx);
+    // The octagon: Chebyshev 2 minus the four far corners.
+    return Math.max(dy, dx) <= GLOW_RADIUS && !(dy === GLOW_RADIUS && dx === GLOW_RADIUS);
+  });
+  if (!nearStart) {
+    throw new Error(
+      `quarrymaster map: no light source (L or T) within ${GLOW_RADIUS} tiles of the hero start ${[hy, hx]} — a hero arriving with a doused torch (the DARK_PORTAL entrance requires one) would be blind in a crack field`
+    );
+  }
+
+  // 5c. Lava must never sit ORTHOGONALLY adjacent to the hero start. Movement is
+  //     orthogonal-only, so an adjacent pool means the very first keypress — pressed in the
+  //     dark, before the torch relights — can be instant death with no tell. Diagonal is
+  //     fine and is the intended placement: visible and lighting, but unreachable in one move.
+  for (const [ly, lx] of parsed.lava) {
+    if (Math.abs(ly - hy) + Math.abs(lx - hx) === 1) {
+      throw new Error(
+        `quarrymaster map: lava at ${[ly, lx]} is orthogonally adjacent to the hero start ${[hy, hx]} — the first keypress out of the gate would be instant death. Place it diagonally instead.`
+      );
+    }
+  }
+
   // 6. Pods must be able to field monsters that can actually reach the hero, or there is no
   //    pressure at all. Checked with gates SHUT, which is the state for most of the fight.
   for (const pod of pods) {
@@ -464,7 +529,7 @@ export function buildQuarrymasterArena(
   const parsed = parseMap(opts.map ?? layout.map);
   assertLayout(parsed);
 
-  const { tiles, subtypes, boss: bossPos, hero, plates, pods, cracks, torches, gateGroups } =
+  const { tiles, subtypes, boss: bossPos, hero, plates, pods, cracks, torches, lava, gateGroups } =
     parsed;
   const [bossY, bossX] = bossPos;
 
@@ -517,5 +582,5 @@ export function buildQuarrymasterArena(
     gateGroups,
   };
 
-  return { state, layoutName: layout.name, boss: bossPos, hero, plates, pods, cracks, torches };
+  return { state, layoutName: layout.name, boss: bossPos, hero, plates, pods, cracks, torches, lava };
 }


### PR DESCRIPTION
Reported from a real run: a douse-discovery Quarrymaster day left the hero standing in the dark in the arena, knowing that trying to navigate meant dying.

## Why it happened

`enterBossRoom` takes only the arena's map and boss from the builder and keeps every other field from the live run — correct for stats and the exit key, but it also carries the hero's **torch state** in. The douse-to-see `DARK_PORTAL` entrance only appears while the torch is **out**, so on those days you land in the arena blind.

All three layouts put both wall torches at the **chamber mouth, nine tiles away** at the far end of the crack field. The distant torches are visible (a light source forces tier 3 at any range), but the floor between them isn't — and that floor is full of cracks that read as ordinary until you're standing on one. So the choice on arrival was blunder toward the light or stand still and let the pods bury you.

## The fix

Each layout gets two lava pools by the door (`L` in the map legend). Lava is already a light source in the render layer — the same `computeTorchGlow` octagon as a wall torch — so it lights the ground around the start, and ending a move inside that glow relights the torch. It also kills on contact, which is the trade: light you have to walk up to.

**Nearest light at the hero start: 9 tiles → 2.**

Placement is **diagonal** from the start, never orthogonal. Movement is orthogonal-only, so a pool one tile up would make the first keypress out of the gate — pressed in the dark, before any relight — instant death with no tell. `assertLayout` now enforces both halves (checks 5b and 5c), so the next layout inherits the rule instead of rediscovering the bug.

## Two things that were easy to miss

- **`reachable()` judged lava walkable.** It's a FLOOR overlay, not a wall tile, so every invariant in `assertLayout` would have certified a layout whose only route to a switch or the exit ran through a pool — the exact invisible soft-lock that validator exists to catch.
- **The policy sim's `lethalTiles` left lava out**, so the switch-runner walked into the fire: **40/40 → 14/40**, every loss a lava death. Lava is the most visible hazard in the game (it glows — that's the point), so by that helper's own stated principle it belongs there. With it back, the sim is **unchanged from before this commit** — 9/12, 12/12, 6/12 per layout — which is the evidence the pools sit off the solve path rather than taxing it.

## Related, not touched

| arena | hero → nearest light | crack field? | verdict |
|---|---|---|---|
| Quarrymaster | 9 → **2** | yes | was fatal, fixed |
| Shaper | 6 | no | outside the glow, but survivable — worth a look someday |
| Coilwyrm | 2 | no | fine by design ("fought at full sight") |
| Fisher | — | no | outdoor arena |

The Shaper is the only other one outside the glow. Its lava is visible at any range and there's no crack field, so a dark walk there costs you rather than kills you. Flagging it rather than bundling it in.

## Verification

- 1169 tests pass (17 new), typecheck and lint clean, `npm run build` compiles
- Policy sim unchanged per-layout vs. baseline; zero lava deaths in the death breakdown
- New suite asserts the lava actually parses (so the unchanged sim numbers aren't vacuous), that light lands inside the doused glow, that no pool is orthogonally adjacent to the start, and that stripping the lava back out fails with the specific 5b message

🤖 Generated with [Claude Code](https://claude.com/claude-code)