### PR TITLE
Make the douse boss entrance actually reachable, and keep torch state through a rewind

### DIFF
--- a/__tests__/lib/boss_entrances.test.ts
+++ b/__tests__/lib/boss_entrances.test.ts
@@ -7,7 +7,9 @@ import {
   buildMoatApproach,
   buildDousePortalApproach,
   buildBombSealApproach,
+  stampBossEntranceOnFloor,
 } from "../../lib/bosses/boss_entrances";
+import { generateCompleteMapForFloor, rollWaterPlan } from "../../lib/map/map-features";
 
 const SHAPER_ARENA_SIZE = 25;
 
@@ -255,6 +257,147 @@ describe("douse portal in an L3-sized room, with ghosts", () => {
   test("both moat types also carry 3 ghosts", () => {
     expect(ghostCount(buildMoatApproach("lava"))).toBe(3);
     expect(ghostCount(buildMoatApproach("water"))).toBe(3);
+  });
+
+  test("the room keeps its real wall torches", () => {
+    // It used to be built with wallTorches: 0, which made it dark by construction and so
+    // the one arrangement that cannot reproduce a torch pinning the portal off.
+    const lit = Array.from({ length: 6 }, () => buildDousePortalApproach()).filter((s) =>
+      s.mapData.subtypes.flat().some((c) => c.includes(TileSubtype.WALL_TORCH))
+    );
+    expect(lit.length).toBeGreaterThan(0);
+  });
+});
+
+/**
+ * Would ending a move on (y,x) relight a doused torch? An INDEPENDENT restatement of the
+ * two rules in movePlayer (orthogonally adjacent to a WALL_TORCH; anywhere inside a LAVA
+ * tile's glow octagon — Chebyshev 2 minus the far corners), deliberately not sharing code
+ * with the generator so this fails if the generator's own predicate is wrong. Deep water
+ * snuffs the torch and overrides every relight source.
+ */
+function relightsAt(map: GameState["mapData"], y: number, x: number): boolean {
+  const at = (yy: number, xx: number) => map.subtypes[yy]?.[xx] ?? [];
+  if (at(y, x).includes(TileSubtype.DEEP_WATER)) return false;
+  for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]]) {
+    if (at(y + dy, x + dx).includes(TileSubtype.WALL_TORCH)) return true;
+  }
+  for (let dy = -2; dy <= 2; dy++) {
+    for (let dx = -2; dx <= 2; dx++) {
+      if (dy === 0 && dx === 0) continue;
+      if (Math.abs(dy) === 2 && Math.abs(dx) === 2) continue; // octagon, not a 5x5 square
+      if (at(y + dy, x + dx).includes(TileSubtype.LAVA)) return true;
+    }
+  }
+  return false;
+}
+
+/** Tiles reachable from `seeds` without ever ending a step somewhere that relights. */
+function darkReachable(
+  map: GameState["mapData"],
+  seeds: Array<[number, number]>
+): Set<string> {
+  const H = map.tiles.length;
+  const W = map.tiles[0].length;
+  const pass = (y: number, x: number) => {
+    if (y < 0 || x < 0 || y >= H || x >= W) return false;
+    if (map.tiles[y][x] === 1) return false; // wall
+    const c = map.subtypes[y]?.[x] ?? [];
+    if (c.includes(TileSubtype.LAVA) || c.includes(TileSubtype.OPEN_ABYSS)) return false;
+    return !relightsAt(map, y, x);
+  };
+  const seen = new Set<string>();
+  const q: Array<[number, number]> = [];
+  for (const [y, x] of seeds) {
+    if (!pass(y, x) || seen.has(`${y},${x}`)) continue;
+    seen.add(`${y},${x}`);
+    q.push([y, x]);
+  }
+  while (q.length) {
+    const [y, x] = q.shift()!;
+    for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>) {
+      const k = `${y + dy},${x + dx}`;
+      if (seen.has(k) || !pass(y + dy, x + dx)) continue;
+      seen.add(k);
+      q.push([y + dy, x + dx]);
+    }
+  }
+  return seen;
+}
+
+function findAll(map: GameState["mapData"], sub: number): Array<[number, number]> {
+  const out: Array<[number, number]> = [];
+  for (let y = 0; y < map.subtypes.length; y++)
+    for (let x = 0; x < map.subtypes[y].length; x++)
+      if (map.subtypes[y][x].includes(sub)) out.push([y, x]);
+  return out;
+}
+
+/**
+ * The invariant that makes a douse day playable at all.
+ *
+ * A DARK_PORTAL only warps while the torch is OUT, the pool is the only REPEATABLE way to
+ * put it out (an adjacent ghost snuffs the torch and then vanishes, so the three ghosts are
+ * one-shot douses a player can spend anywhere), and a single wall torch beside the only
+ * corridor back relights the hero and leaves the portal inert. So: there must be a route
+ * from the water to the portal on which the torch never comes back.
+ *
+ * This is the bug that shipped — the old placement only checked the portal's own 3x3.
+ */
+describe("a douse day's portal is reachable IN THE DARK", () => {
+  function assertDarkPathToPortal(map: GameState["mapData"]) {
+    const water = findAll(map, TileSubtype.DEEP_WATER);
+    expect(water.length).toBeGreaterThan(0);
+    const portals = findAll(map, TileSubtype.DARK_PORTAL);
+    expect(portals).toHaveLength(1);
+
+    // The hero must be able to get to the pool in the first place (torch lit, wading ok).
+    const hero = findAll(map, TileSubtype.PLAYER)[0];
+    const wet = dryReachableFrom({ mapData: map } as GameState, hero);
+    const touchesPool = water.some(([wy, wx]) =>
+      [[-1, 0], [1, 0], [0, -1], [0, 1]].some(([dy, dx]) => wet.has(`${wy + dy},${wx + dx}`))
+    );
+    expect(touchesPool).toBe(true);
+
+    // ...and then walk pool -> portal without ever relighting.
+    const dark = darkReachable(map, water);
+    const [py, px] = portals[0];
+    expect(dark.has(`${py},${px}`)).toBe(true);
+  }
+
+  // Both sweeps are deliberately long. The rule this replaced left the portal
+  // unreachable on ~6% of generated floor 3s, so a handful of iterations would catch a
+  // regression only about half the time; 40 + 60 puts detection over 99%.
+  test("holds for the harness room, torches and all", () => {
+    for (let i = 0; i < 40; i++) {
+      assertDarkPathToPortal(buildDousePortalApproach().mapData);
+    }
+  });
+
+  test("holds when stamped onto a daily floor 3, water and lava and all", () => {
+    for (let i = 0; i < 60; i++) {
+      // Same terrain options the daily passes (game-state.ts): floor 3 always rolls for
+      // lava, and water is a weighted size tier. Both change the pool geometry the dark
+      // route has to thread, so a sweep without them is not the production case.
+      const map = generateCompleteMapForFloor(
+        { chests: 0, keys: 0, chestContents: [] },
+        3,
+        { includeLava: true, waterPlan: rollWaterPlan(3) ?? undefined }
+      );
+      const { placed } = stampBossEntranceOnFloor(map, "douse");
+      // Never bail: a bossless day would rewrite what past dates replay to
+      // (lib/stats/boss_day.ts reads entranceKind straight off the regenerated floor).
+      expect(placed).toBe(true);
+      assertDarkPathToPortal(map);
+    }
+  });
+
+  test("the portal itself never sits on a tile that relights", () => {
+    for (let i = 0; i < 8; i++) {
+      const map = buildDousePortalApproach().mapData;
+      const [py, px] = findAll(map, TileSubtype.DARK_PORTAL)[0];
+      expect(relightsAt(map, py, px)).toBe(false);
+    }
   });
 });
 

--- a/__tests__/lib/rewind.test.ts
+++ b/__tests__/lib/rewind.test.ts
@@ -197,6 +197,39 @@ describe("rewinding", () => {
     expect(back!.stats.damageTaken).toBe(4);
   });
 
+  it("does not relight the torch — a condition carries forward", () => {
+    // The DOUSE boss entrance depends on this: douse in the pool, wind back to the
+    // portal, arrive still dark. A wholesale restore would hand back the lit torch the
+    // snapshot was taken with and make that entrance unreachable.
+    const after = walkRight(baseState({ rewindCharges: 1, heroTorchLit: true }), 8);
+    expect(after.rewindHistory?.[0]?.state.heroTorchLit).toBe(true);
+
+    const doused: GameState = { ...after, heroTorchLit: false };
+    const back = rewindStateBy(doused, 6);
+    expect(back!.heroTorchLit).toBe(false);
+    // Position still came from the past — that's the whole trick.
+    expect(findPlayerPosition(back!.mapData)).toEqual([1, 2]);
+  });
+
+  it("carries a RELIT torch forward too — the trick works both ways", () => {
+    const after = walkRight(baseState({ rewindCharges: 1, heroTorchLit: false }), 6);
+    const relit: GameState = { ...after, heroTorchLit: true };
+    expect(rewindStateBy(relit, 4)!.heroTorchLit).toBe(true);
+  });
+
+  it("DOES rewind held quantities — carrying them forward would duplicate loot", () => {
+    // The map rolls back with the snapshot, so a looted chest is closed and full again.
+    // Keep the items too and every pickup inside the window can be collected twice.
+    const start = baseState({ rewindCharges: 1, rockCount: 2, potionCount: 0 });
+    const after = walkRight(start, 6);
+    const looted: GameState = { ...after, rockCount: 5, potionCount: 1, hasSword: true };
+
+    const back = rewindStateBy(looted, 4)!;
+    expect(back.rockCount).toBe(2);
+    expect(back.potionCount).toBe(0);
+    expect(back.hasSword).toBeFalsy();
+  });
+
   it("keeps run-level achievement latches and the last checkpoint", () => {
     const after = walkRight(baseState({ rewindCharges: 1 }), 5);
     const decorated: GameState = {

--- a/lib/bosses/boss_entrances.ts
+++ b/lib/bosses/boss_entrances.ts
@@ -20,6 +20,7 @@ import { FLOOR, WALL, FLOWERS, Direction, TileSubtype } from "../map/constants";
 import type { MapData, SealPayload, SealPayloads } from "../map/types";
 import type { GameState } from "../map/game-state";
 import { generateCompleteMapForFloor } from "../map/map-features";
+import { computeTorchGlow } from "../torch_glow";
 import { Enemy } from "../enemy";
 
 export type MoatElement = "lava" | "water";
@@ -190,6 +191,24 @@ function cloneMap(map: MapData): MapData {
   };
 }
 
+const ORTHO: Array<[number, number]> = [[-1, 0], [1, 0], [0, -1], [0, 1]];
+
+/**
+ * Can the hero stand on (y,x)? Lava + abyss always block; deep water blocks unless
+ * `wadeable` (the hero can swim it, losing the torch). Shared by every flood below so
+ * "reachable" and "reachable in the dark" can never disagree about the terrain.
+ */
+function isWalkable(map: MapData, y: number, x: number, wadeable: boolean): boolean {
+  const H = map.tiles.length;
+  const W = map.tiles[0].length;
+  if (y < 0 || x < 0 || y >= H || x >= W) return false;
+  if (map.tiles[y][x] !== FLOOR && map.tiles[y][x] !== FLOWERS) return false;
+  const s = map.subtypes[y]?.[x] ?? [];
+  if (s.includes(TileSubtype.LAVA) || s.includes(TileSubtype.OPEN_ABYSS)) return false;
+  if (s.includes(TileSubtype.DEEP_WATER) && !wadeable) return false;
+  return true;
+}
+
 /**
  * Tiles the hero can reach on foot. Lava + abyss always block; deep water blocks
  * unless `wadeable` (the hero can swim it, losing the torch).
@@ -200,23 +219,15 @@ function floodReachable(
   sx: number,
   opts?: { wadeable?: boolean }
 ): Set<string> {
-  const H = map.tiles.length;
-  const W = map.tiles[0].length;
-  const passable = (y: number, x: number) => {
-    if (y < 0 || x < 0 || y >= H || x >= W) return false;
-    if (map.tiles[y][x] !== FLOOR && map.tiles[y][x] !== FLOWERS) return false;
-    const s = map.subtypes[y]?.[x] ?? [];
-    if (s.includes(TileSubtype.LAVA) || s.includes(TileSubtype.OPEN_ABYSS)) return false;
-    if (s.includes(TileSubtype.DEEP_WATER) && !opts?.wadeable) return false;
-    return true;
-  };
+  const passable = (y: number, x: number) =>
+    isWalkable(map, y, x, opts?.wadeable === true);
   const seen = new Set<string>();
   if (!passable(sy, sx)) return seen;
   seen.add(`${sy},${sx}`);
   const q: Array<[number, number]> = [[sy, sx]];
   while (q.length) {
     const [y, x] = q.shift()!;
-    for (const [dy, dx] of [[-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>) {
+    for (const [dy, dx] of ORTHO) {
       const ny = y + dy;
       const nx = x + dx;
       const k = `${ny},${nx}`;
@@ -469,56 +480,188 @@ function stampCornerWaterPatch(map: MapData, hy: number, hx: number): void {
 }
 
 /**
- * Place the DARK_PORTAL on the reachable floor tile farthest from the hero that has
- * NO relight source (wall torch / lava) beside it, so once the hero douses their
- * torch it stays out and the portal remains visible + usable. Prefers tiles the hero
- * can only get to by wading (past the water).
+ * Would ending a move on (y,x) RELIGHT a doused torch? Mirrors the two relight rules in
+ * movePlayer exactly: orthogonally adjacent to a WALL_TORCH, or anywhere inside a LAVA
+ * tile's glow. Built on the same computeTorchGlow the relight check itself uses (the glow
+ * octagon is symmetric, so "lava in the hero's glow" and "hero in a lava tile's glow" are
+ * the same test), so the generator's idea of safe cannot drift from the engine's.
+ */
+function relightsTorchAt(map: MapData, y: number, x: number): boolean {
+  for (const [dy, dx] of ORTHO) {
+    if ((map.subtypes[y + dy]?.[x + dx] ?? []).includes(TileSubtype.WALL_TORCH)) return true;
+  }
+  for (const key of computeTorchGlow(y, x, map.tiles).keys()) {
+    const [ly, lx] = key.split(",").map(Number);
+    if ((map.subtypes[ly]?.[lx] ?? []).includes(TileSubtype.LAVA)) return true;
+  }
+  return false;
+}
+
+/**
+ * Does a doused torch STAY out when the hero ends a move here? Deep water snuffs it and
+ * overrides every relight source, so a water tile is dark whatever sits beside it.
+ */
+function staysDarkAt(map: MapData, y: number, x: number): boolean {
+  if ((map.subtypes[y]?.[x] ?? []).includes(TileSubtype.DEEP_WATER)) return true;
+  return !relightsTorchAt(map, y, x);
+}
+
+/** Tiles reachable from `seeds` WITHOUT ever ending a step somewhere that relights. */
+function floodDark(map: MapData, seeds: Array<[number, number]>): Set<string> {
+  const seen = new Set<string>();
+  const q: Array<[number, number]> = [];
+  for (const [y, x] of seeds) {
+    const k = `${y},${x}`;
+    if (seen.has(k) || !isWalkable(map, y, x, true) || !staysDarkAt(map, y, x)) continue;
+    seen.add(k);
+    q.push([y, x]);
+  }
+  while (q.length) {
+    const [y, x] = q.shift()!;
+    for (const [dy, dx] of ORTHO) {
+      const ny = y + dy;
+      const nx = x + dx;
+      const k = `${ny},${nx}`;
+      if (seen.has(k)) continue;
+      if (!isWalkable(map, ny, nx, true) || !staysDarkAt(map, ny, nx)) continue;
+      seen.add(k);
+      q.push([ny, nx]);
+    }
+  }
+  return seen;
+}
+
+/** Every deep-water tile the hero can actually get to — the day's douse sources. */
+function reachableWater(map: MapData, reachable: Set<string>): Array<[number, number]> {
+  const out: Array<[number, number]> = [];
+  for (let y = 0; y < map.tiles.length; y++) {
+    for (let x = 0; x < map.tiles[y].length; x++) {
+      if (!reachable.has(`${y},${x}`)) continue;
+      if ((map.subtypes[y][x] ?? []).includes(TileSubtype.DEEP_WATER)) out.push([y, x]);
+    }
+  }
+  return out;
+}
+
+/**
+ * Run the pool toward the nearest tile that DOES stay dark, one tile at a time, and return
+ * whether it got there.
+ *
+ * Only fires when every route out of the water passes a torch — i.e. when the day would
+ * otherwise be the unwinnable one this whole dance exists to prevent. Deterministic
+ * (breadth-first, no RNG) so it cannot disturb the daily stream's draw order, and it only
+ * ever converts BARE floor, so the exit, key, chests, pots and the hero's own tile survive.
+ */
+function extendWaterToDark(map: MapData, water: Array<[number, number]>): boolean {
+  const bare = (y: number, x: number) =>
+    isWalkable(map, y, x, true) && (map.subtypes[y]?.[x]?.length ?? 0) === 0;
+
+  // BFS out from the pool over bare floor, remembering each tile's parent so the winning
+  // route can be walked back and flooded.
+  const parent = new Map<string, string | null>();
+  const q: Array<[number, number]> = [];
+  for (const [y, x] of water) {
+    parent.set(`${y},${x}`, null);
+    q.push([y, x]);
+  }
+  let target: string | null = null;
+  while (q.length && !target) {
+    const [y, x] = q.shift()!;
+    for (const [dy, dx] of ORTHO) {
+      const ny = y + dy;
+      const nx = x + dx;
+      const k = `${ny},${nx}`;
+      if (parent.has(k) || !bare(ny, nx)) continue;
+      parent.set(k, `${y},${x}`);
+      if (staysDarkAt(map, ny, nx)) {
+        target = k;
+        break;
+      }
+      q.push([ny, nx]);
+    }
+  }
+  if (!target) return false;
+
+  // DEEP water only, with no shallow rim like a generated pool has: shallow water and
+  // stepping stones are "dry enough" and do NOT snuff the torch (see movePlayer), so an
+  // edged pool would relight the hero mid-crossing and undo the whole point of this.
+  //
+  // Flood the route BUT NOT the target itself: the target already stays dark, and it is
+  // where the portal is about to go.
+  for (let step = parent.get(target); step; step = parent.get(step) ?? null) {
+    const [sy, sx] = step.split(",").map(Number);
+    if (!bare(sy, sx)) continue; // the pool tiles the walk ends on
+    map.subtypes[sy][sx] = [TileSubtype.DEEP_WATER];
+  }
+  return true;
+}
+
+/**
+ * Place the DARK_PORTAL on the farthest tile the hero can reach FROM THE WATER WITHOUT
+ * RELIGHTING — so dousing in the pool and walking to the portal is actually possible.
+ *
+ * The old rule only checked the portal's own 3x3 for a relight source, which is not the
+ * invariant the entrance needs: the whole ROUTE has to stay dark. On a real daily floor 3
+ * (unlike the /test-boss-entrances harness, which used to build this room with zero wall
+ * torches) a single torch beside the only corridor back relights the torch and makes the
+ * portal inert — an unreachable secret on an otherwise normal day.
+ *
+ * The ghosts are not a substitute: an adjacent ghost snuffs the torch and VANISHES, so
+ * they are three one-shot douses that a player can spend anywhere on the floor. Only the
+ * pool is a repeatable source, so the pool is what the reachable-in-the-dark guarantee is
+ * anchored to.
  */
 function placeDarkPortal(map: MapData, hy: number, hx: number): void {
   const H = map.tiles.length;
   const W = map.tiles[0].length;
   const reachable = floodReachable(map, hy, hx, { wadeable: true });
-  const noRelightNear = (y: number, x: number) => {
-    for (let dy = -1; dy <= 1; dy++)
-      for (let dx = -1; dx <= 1; dx++) {
-        const s = map.subtypes[y + dy]?.[x + dx] ?? [];
-        if (s.includes(TileSubtype.WALL_TORCH) || s.includes(TileSubtype.LAVA)) return false;
-      }
-    return true;
-  };
-  let best: [number, number] | null = null;
-  let bestD = -1;
-  for (let y = 1; y < H - 1; y++) {
-    for (let x = 1; x < W - 1; x++) {
-      if (map.tiles[y][x] !== FLOOR) continue;
-      if ((map.subtypes[y][x]?.length ?? 0) !== 0) continue; // bare floor only
-      if (!reachable.has(`${y},${x}`)) continue;
-      if (!noRelightNear(y, x)) continue;
-      const d = Math.abs(y - hy) + Math.abs(x - hx);
-      if (d > bestD) {
-        bestD = d;
-        best = [y, x];
+  const water = reachableWater(map, reachable);
+  if (water.length === 0) return; // no douse source at all: nothing to anchor to
+
+  let dark = floodDark(map, water);
+  const candidates = () => {
+    let best: [number, number] | null = null;
+    let bestD = -1;
+    for (let y = 1; y < H - 1; y++) {
+      for (let x = 1; x < W - 1; x++) {
+        if (map.tiles[y][x] !== FLOOR) continue;
+        if ((map.subtypes[y][x]?.length ?? 0) !== 0) continue; // bare floor only
+        if (!dark.has(`${y},${x}`)) continue;
+        const d = Math.abs(y - hy) + Math.abs(x - hx);
+        if (d > bestD) {
+          bestD = d;
+          best = [y, x];
+        }
       }
     }
+    return best;
+  };
+
+  let best = candidates();
+  if (!best && extendWaterToDark(map, water)) {
+    // The pool now runs to dry dark ground; re-seed from the water it grew into.
+    dark = floodDark(map, reachableWater(map, floodReachable(map, hy, hx, { wadeable: true })));
+    best = candidates();
   }
   if (best) map.subtypes[best[0]][best[1]] = [TileSubtype.DARK_PORTAL];
 }
 
 /**
- * DOUSE approach, in a REAL Level-3-sized room. A dark dungeon (no wall torches, so
- * it stays black once doused) with a forced deep-water pool: wade it to snuff your
- * torch, and the DARK_PORTAL — invisible in the light — lights up as a beacon across
- * the dark and can be entered. Three ghosts prowl (and, being torch-snuffers, may
- * plunge you into the dark themselves).
+ * DOUSE approach, in a REAL Level-3-sized room with the floor's REAL wall torches: wade
+ * the deep-water pool to snuff your torch, and the DARK_PORTAL — invisible in the light —
+ * lights up as a beacon across the dark and can be entered. Three ghosts prowl (and, being
+ * torch-snuffers, may plunge you into the dark themselves).
+ *
+ * The torches are the point of the harness. This used to build the room with
+ * `{ wallTorches: 0 }`, which made the room dark-by-construction and so made it the one
+ * arrangement that CANNOT reproduce the failure that matters: a torch beside the only
+ * corridor back, relighting the hero and leaving the portal inert. placeDarkPortal now
+ * guarantees a route that stays dark, and this harness is where that gets played.
  */
 export function buildDousePortalApproach(): GameState {
-  // The GHOSTS are the way in: they snuff the torch when adjacent (and their presence
-  // signals the secret), revealing the DARK_PORTAL beacon. No wall torches, so it
-  // stays dark once snuffed. Just a few deep-water tiles sit in the far corner.
   const map = generateCompleteMapForFloor(
     { chests: 0, keys: 0, chestContents: [] },
-    3,
-    { wallTorches: 0 }
+    3
   );
   const [hy, hx] = findPlayerPos(map);
   stampCornerWaterPatch(map, hy, hx);

--- a/lib/map/rewind.ts
+++ b/lib/map/rewind.ts
@@ -9,8 +9,9 @@
  *    through — and only when the hero actually MOVED, so wall-bumps and standing
  *    actions never burn a history slot. "Rewind five steps" then means five real steps.
  *  - A rewind restores the whole world (map, enemies, NPCs, health, items) but
- *    deliberately does NOT restore cumulative stats or the charm's own charge. See
- *    CARRY_FORWARD_KEYS below for why each exception exists.
+ *    deliberately does NOT restore cumulative stats, the charm's own charge, or the
+ *    state of the hero's torch. See CARRY_FORWARD_KEYS below for why each exception
+ *    exists, and for the rule that decides whether a NEW field belongs there.
  *
  * This module imports the enemy/NPC serializers from ./utils directly and takes
  * GameState as a TYPE-only import, so game-state.ts -> rewind.ts stays a one-way edge
@@ -55,6 +56,15 @@ type RewindPayload = Omit<
 /**
  * Fields the present keeps when winding back. Everything else comes from the snapshot.
  *
+ * THE RULE, for whatever gets added next: **a condition carries forward, a quantity
+ * reverts.** A condition has no counter and no source sitting on the map, so keeping it
+ * cannot be farmed. A quantity does: the map rolls back with the snapshot, so a chest is
+ * closed and still holding its sword again (movePlayer only strips the CHEST marker and
+ * leaves the item subtype on the tile). Carry a quantity forward and every pickup inside
+ * the rewound window can be collected a second time — the same duplication hole
+ * recordRewindStep already guards for the charm itself. Anything with a number beside it
+ * in the HUD therefore stays OUT of this list.
+ *
  *  - `stats`: cumulative counters stay monotonic. The fiction says those steps never
  *    happened, but `steps` is the daily score and lib/endless_validation.ts shadow-flags
  *    any run whose steps/kills/damage regress (`stats:regressed`). Monotonic stats mean
@@ -62,12 +72,20 @@ type RewindPayload = Omit<
  *  - `rewindCharges`: the caller sets this explicitly to the post-spend value. Taking it
  *    from a snapshot recorded BEFORE the charm was spent would refund the charge and
  *    make the rewind infinitely reusable.
+ *  - `heroTorchLit`: a condition, not a possession — the amber rewinds the world, and a
+ *    moth cannot take your flame. Mechanically this is what makes the DOUSE boss entrance
+ *    playable: douse in the water, wind back to the portal, and arrive still dark. It
+ *    works in both directions (relight at a wall torch, wind back to where you wanted to
+ *    be lit) because a rewind restores POSITION from the past and torch state from the
+ *    present. Safe to carry because being dark twice is still just being dark: the douse
+ *    sources it re-exposes (a vanished ghost, the pool) have nothing to re-collect.
  *  - `lastCheckpoint`: a checkpoint is progress you earned; a rewind shouldn't revoke it.
  *  - The `reached*`/`bossDefeated` latches: run-level achievement flags. You did find the
  *    pink realm, whatever time says.
  */
 const CARRY_FORWARD_KEYS = [
   "stats",
+  "heroTorchLit",
   "lastCheckpoint",
   "reachedPinkRealm",
   "reachedOutsideWorld",


### PR DESCRIPTION
Today's daily shipped a douse-variant boss entrance that was **impossible to enter**: the DARK_PORTAL was visible from the water, but every route back to it passed a wall torch that relit the hero, and a DARK_PORTAL is inert in the light.

## The bug

`placeDarkPortal` only checked the portal's own 3x3 for a relight source. That is not the invariant the entrance needs — the whole **route** has to stay dark. Relighting fires on ending a move orthogonally adjacent to a `WALL_TORCH`, or anywhere inside a lava tile's glow octagon, so one torch beside the only corridor is a hard gate.

The ghosts are not a fallback: an adjacent ghost snuffs the torch and then **vanishes**, so the three ghosts are one-shot douses a player can spend anywhere on the floor. Spend them early and the pool is the only source left.

It shipped because `buildDousePortalApproach` built the `/test-boss-entrances` room with `wallTorches: 0` — dark by construction, and therefore the one arrangement that cannot reproduce this class of failure. The existing tests only asserted that a portal exists.

### Measured rate

Both placement rules run over the same 400 generated floor 3s, with the water and lava plans the daily actually passes:

| rule | portal unreachable in the dark |
|---|---|
| old | **24 / 400 (6.0%)** |
| new | **0 / 400** |

Douse is ~22% of days, so this was roughly **1 day in 75** shipping an unreachable secret.

## The fix

Placement now floods out from the reachable pool through only tiles where a doused torch *stays* doused, and takes the farthest tile in that component. The dark-safe predicate is built on the same `computeTorchGlow` the engine's relight check uses, so the generator's idea of "safe" cannot drift from the engine's.

If no dark pocket touches the pool at all, `extendWaterToDark` runs the pool one tile at a time toward the nearest tile that does stay dark — deterministic (no RNG, so the daily stream's draw order is untouched) and bare floor only, so the exit, key, chests and the hero's tile survive. Deep water with no shallow rim, deliberately: shallow water and stepping stones don't snuff, so an edged pool would relight the hero mid-crossing.

Placement never fails, which matters beyond this floor — `lib/stats/boss_day.ts` reads `entranceKind` off a regenerated floor, so a newly-bossless day would retroactively rewrite what past dates replay to.

## Torch state now survives a rewind

`heroTorchLit` joins `CARRY_FORWARD_KEYS`, so a rewind restores **position from the past and torch state from the present**. Douse in the pool, wind back to the portal, arrive still dark — and symmetrically: relight at a wall torch, wind back to where you wanted to be lit.

This is a gameplay change in its own right, not the fix for the bug above. It can't be the fix: the Amber Moth lands on ~51% of days, is one-use, and doubles as the death save, so gating the entrance behind it would trade "impossible on 1 day in 75" for "impossible on most days" — the same trap `rollBossEntranceKind`'s `bombAvailable` guard already exists to avoid.

The rule it establishes, written into `CARRY_FORWARD_KEYS`: **a condition carries forward, a quantity reverts.** Held items must not carry — the map rolls back with the snapshot, so a looted chest is closed and holding its sword again, and keeping the sword too would let every pickup inside the window be collected twice.

**Consequence worth a look:** dying in the dark now revives you in the dark. Kept consistent rather than special-casing the death save, since a torch that mysteriously comes back is more confusing than a dark revival you can walk off. Easy to split if it plays badly.

## Verification

- 5 new tests: torch carries both directions, quantities still revert (duplication guard), dark route holds on the harness room and on daily floor 3s with production water/lava, portal never sits on a relighting tile.
- The tests' dark-flood is an **independent restatement** of the relight rules rather than a call into the generator, so it fails if the generator's own predicate is wrong. Sweeps are 40 + 60 iterations because at a 6% base failure rate a short sweep would catch a regression only about half the time; this puts detection over 99%.
- `npm run test` 1238 passed / 131 suites, `npm run typecheck` clean, `npm run build` clean, `npm run lint` no new warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)