### PR TITLE
Never leave a cleared boss arena without its exit key

### DIFF
--- a/__tests__/lib/coilwyrm.test.ts
+++ b/__tests__/lib/coilwyrm.test.ts
@@ -459,9 +459,8 @@ describe("two hits kill a head, and the body grows another", () => {
     // A 5-segment coil filled all five slots of the "Enemies in sight" panel with identical
     // segment rows and pushed the head — the only part with meaningful hearts — off the list.
     expect(EnemyRegistry["coilwyrm-coil"].bodyPart).toBe(true);
-    expect(EnemyRegistry["coilwyrm"].bodyPart).toBeFalsy();
     // The core of a multi-part boss must stay listable, or the fight has no HUD presence.
-    expect(EnemyRegistry["coilwyrm"].boss).toBe(true);
+    expect(EnemyRegistry["coilwyrm"].bodyPart).toBeFalsy();
   });
 
   it("a headshot is BOUGHT with a bite — that is what stops head-grinding", () => {
@@ -640,6 +639,28 @@ describe("two hits kill a head, and the body grows another", () => {
       });
     const after = movePlayer(state, Direction.RIGHT);
     expect((after.enemies ?? []).some((e) => e.kind === "coilwyrm")).toBe(false);
+    expect(after.bossDefeated).toBe(true);
+    const keyed = after.mapData.subtypes.some((row) =>
+      row.some((cell) => cell.includes(TileSubtype.EXITKEY))
+    );
+    expect(keyed).toBe(true);
+  });
+
+  it("a headless body too short to regrow still pays out the exit key when it dies", () => {
+    // Regression: the head died on an earlier turn, so no turn from here on has a
+    // `coilwyrm` head in its pre-turn snapshot. If the snapshot only counted heads, the
+    // turn the leftover segments were reaped would skip the payout branch and the run
+    // would soft-lock — killed boss, no key, sealed exit.
+    const enemies = makeCoil([[5, 5], [5, 4], [5, 3], [5, 2]]);
+    enemies.splice(enemies.indexOf(headOf(enemies)), 1); // head already dead
+    expect(segmentsOf(enemies).length).toBeLessThan(COILWYRM_SPLIT_MIN);
+    const state = coilState(13, [9, 9], enemies, { inBossRoom: true });
+    // One in-game turn: segments notice the missing head, fail to promote, and are reaped.
+    let after = movePlayer(state, Direction.LEFT);
+    for (let t = 0; t < 3 && (after.enemies ?? []).length > 0; t++) {
+      after = movePlayer(after, Direction.RIGHT);
+    }
+    expect(after.enemies ?? []).toHaveLength(0);
     expect(after.bossDefeated).toBe(true);
     const keyed = after.mapData.subtypes.some((row) =>
       row.some((cell) => cell.includes(TileSubtype.EXITKEY))

--- a/__tests__/lib/endless_boss_floors.test.ts
+++ b/__tests__/lib/endless_boss_floors.test.ts
@@ -19,7 +19,7 @@ import {
 import { BOSS_KINDS, rollEndlessBossOrder } from "../../lib/bosses/boss_roster";
 import { Enemy } from "../../lib/enemy";
 import { Direction, TileSubtype } from "../../lib/map/constants";
-import { movePlayer } from "../../lib/map/game-state";
+import { movePlayer, performUseFood } from "../../lib/map/game-state";
 import type { GameState } from "../../lib/map/game-state";
 import { findPlayerPosition } from "../../lib/map/player";
 
@@ -259,6 +259,110 @@ describe("boss payout: key AND a heart", () => {
     expect(second.heroMaxHealth).toBe((first.heroMaxHealth ?? 5) + 1);
     expect(second.heroHealth).toBe(second.heroMaxHealth);
     expect(second.stats.bossesDefeated).toBe(2);
+  });
+
+  it("pays out on an item turn too, when a bomb's fuse lands the killing blow", () => {
+    // Using an item spends a turn, and a turn is all an armed bomb needs. These paths ran
+    // the enemy tick and the fuse without settling the boss, so a fuse kill paid nothing.
+    const state = duel({ mode: "endless", foodCount: 1 });
+    state.mapData.subtypes[2][2].push(TileSubtype.BOMB_LIVE);
+    const after = performUseFood(state);
+    expect((after.enemies ?? []).some((e) => e.kind === "quarrymaster")).toBe(false);
+    expect(after.bossDefeated).toBe(true);
+    expect(after.stats.bossesDefeated).toBe(1);
+  });
+});
+
+/**
+ * The floor under the per-boss payouts. Those are precise about which tile the drop lands on
+ * and which turn it lands, and precision is what leaked: a Coilwyrm killed a turn before its
+ * last body segment died skipped the payout entirely, leaving a player sealed in the arena
+ * with the boss dead, no key, and nothing left to hit. Enforced from the other end here, where
+ * it does not matter which kill path fired.
+ */
+describe("a cleared boss arena is never a dead end", () => {
+  /** An arena the hero is sealed inside: an EXIT that wants a key, and nothing left alive. */
+  function clearedArena(over: Partial<GameState> = {}): GameState {
+    const size = 5;
+    const tiles = Array.from({ length: size }, () =>
+      Array.from({ length: size }, () => 1)
+    );
+    for (let y = 1; y < size - 1; y++) for (let x = 1; x < size - 1; x++) tiles[y][x] = 0;
+    const subtypes: number[][][] = Array.from({ length: size }, () =>
+      Array.from({ length: size }, () => [] as number[])
+    );
+    subtypes[2][1].push(TileSubtype.PLAYER);
+    // Off the hero's path: these tests step RIGHT into (2,2), and stepping ONTO the exit is
+    // its own case below.
+    subtypes[1][3].push(TileSubtype.EXIT);
+    return {
+      hasKey: false,
+      hasExitKey: false,
+      hasSword: true,
+      mapData: { tiles, subtypes },
+      showFullMap: true,
+      win: false,
+      playerDirection: Direction.RIGHT,
+      enemies: [],
+      npcs: [],
+      heroHealth: 2,
+      heroMaxHealth: 5,
+      heroAttack: 1,
+      inBossRoom: true,
+      bossKind: "coilwyrm",
+      mode: "endless",
+      stats: { damageDealt: 0, damageTaken: 0, enemiesDefeated: 0, steps: 0 },
+      ...over,
+    } as GameState;
+  }
+
+  it("hands over the key when the boss is gone and none was ever dropped", () => {
+    const after = movePlayer(clearedArena(), Direction.RIGHT);
+    expect(after.hasExitKey).toBe(true);
+    // The rest of the missed payout comes with it.
+    expect(after.bossDefeated).toBe(true);
+    expect(after.heroMaxHealth).toBe(6);
+  });
+
+  it("leaves a dropped key alone rather than handing out a second one", () => {
+    const state = clearedArena();
+    state.mapData.subtypes[1][1].push(TileSubtype.EXITKEY);
+    const after = movePlayer(state, Direction.RIGHT);
+    expect(after.hasExitKey).toBe(false); // still on the floor, to be walked onto
+    expect(after.heroMaxHealth).toBe(5); // and no phantom heart
+  });
+
+  it("keeps quiet while any part of the boss is still standing", () => {
+    // The Coilwyrm case specifically: a headless body is still the boss.
+    const segment = new Enemy({ y: 2, x: 3 });
+    segment.kind = "coilwyrm-coil";
+    const after = movePlayer(clearedArena({ enemies: [segment] }), Direction.RIGHT);
+    expect(after.hasExitKey).toBe(false);
+    expect(after.bossDefeated).toBeFalsy();
+  });
+
+  it("covers a payout that ran but whose key went nowhere", () => {
+    // The other half of the leak: the branch fires, banks the kill, and drops the key on a
+    // tile that is not there (a death recorded off-map). bossDefeated is latched, so the
+    // per-boss branch will never run again — without the net the arena is just as dead.
+    const after = movePlayer(clearedArena({ bossDefeated: true }), Direction.RIGHT);
+    expect(after.hasExitKey).toBe(true);
+    expect(after.heroMaxHealth).toBe(5); // already paid: no second heart
+  });
+
+  it("does not fire outside a boss arena, where a locked exit is the actual puzzle", () => {
+    const after = movePlayer(clearedArena({ inBossRoom: false }), Direction.RIGHT);
+    expect(after.hasExitKey).toBe(false);
+  });
+
+  it("stays out of the way once the key has been spent on the exit", () => {
+    // Stepping onto the arena EXIT consumes the key; the net must not mint a replacement
+    // on the way out, in the daily (win) or in endless (floor transition).
+    const state = clearedArena({ mode: "daily", hasExitKey: true, bossDefeated: true });
+    state.mapData.subtypes[2][2].push(TileSubtype.EXIT); // one step RIGHT, onto the exit
+    const won = movePlayer(state, Direction.RIGHT);
+    expect(won.win).toBe(true);
+    expect(won.hasExitKey).toBe(false);
   });
 });
 

--- a/lib/enemies/registry.ts
+++ b/lib/enemies/registry.ts
@@ -126,12 +126,12 @@ export interface EnemyConfig {
    */
   movesInLockstep?: boolean;
   /**
-   * This kind IS the boss of its arena: its death drops the gold key that opens the
-   * arena exit (see dropBossKeyOnDefeat). Only the killable core gets this — a
-   * multi-part boss marks its head, never its limbs, or losing one piece would end
-   * the fight.
+   * NOTE: there is deliberately no `boss` flag here. Whether a kind IS the boss of its arena
+   * is answered by BOSS_KINDS in lib/bosses/boss_roster — the roster is already the one place
+   * a boss is declared, and a second list to keep in sync is how the Coilwyrm key-drop bug
+   * happened: a `boss` flag added for one fight reached only two of the four bosses, so
+   * "is the boss dead" quietly answered yes while a Fisher was still standing.
    */
-  boss?: boolean;
   /**
    * This kind is a PIECE of a larger creature, not an enemy in its own right. Roster-style UI
    * (the "Enemies in sight" panel) skips it and lists only the creature's core, because a
@@ -1317,7 +1317,6 @@ export const EnemyRegistry: Record<EnemyKind, EnemyConfig> = {
       back: assetUrl("/images/enemies/bosses/shaper/shaper-back.png"),
     },
     base: { health: SHAPER_HP, attack: 0 },
-    boss: true,
     // Standard melee: once you fight through its terrain and reach it, it dies
     // like anything else (low HP). The challenge is the crossing, not the kill.
     calcMeleeDamage: ({ heroAttack, swordBonus, variance }) =>
@@ -1340,7 +1339,6 @@ export const EnemyRegistry: Record<EnemyKind, EnemyConfig> = {
       back: assetUrl("/images/enemies/bosses/coilwyrm/coilwyrm-head-back.png"),
     },
     base: { health: COILWYRM_HEAD_HP, attack: COILWYRM_HEAD_ATTACK },
-    boss: true, // the head only — a severed segment must not end the fight
     // The head is ALWAYS killable: COILWYRM_HEADSHOT_DAMAGE per hit, so exactly two hits fell
     // it whatever you land them with. It used to be armored until the body was gone, which
     // played badly — see the write-up in .claude/features/boss-coilwyrm/index.md. Killing a

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -73,6 +73,7 @@ import {
   QUARRYMASTER_LAYOUTS,
 } from "../bosses/quarrymaster_arena";
 import {
+  BOSS_KINDS,
   rollDailyBossKind,
   type BossKind,
 } from "../bosses/boss_roster";
@@ -296,7 +297,21 @@ function recordEnemyDeathCause(
   }
 }
 
+/**
+ * Using an item spends a turn, and a turn inside a boss arena can kill the boss without the
+ * player swinging at anything: a bomb's fuse runs out (detonateLiveBombs, below), or a coil
+ * length cut off last turn is reaped by applyEnemyHazardDeaths. Both used to land here with no
+ * payout attached, so the kill paid nothing — see ensureBossArenaSolvable for what that cost.
+ * Wrapped like performThrowRock rather than hooked, for the same reason: many exits.
+ */
 export function performUseFood(gameState: GameState): GameState {
+  const bossesBefore = snapshotBosses(gameState);
+  const result = performUseFoodCore(gameState);
+  resolveBossDefeat(result, bossesBefore);
+  return result;
+}
+
+function performUseFoodCore(gameState: GameState): GameState {
   gameState = detonateLiveBombs(gameState);
   if (gameState.heroHealth <= 0) return gameState;
   const count = gameState.foodCount || 0;
@@ -363,6 +378,13 @@ export function performUseFood(gameState: GameState): GameState {
  * Use potion from inventory to heal 2 HP (costs a move like throwing rocks/runes)
  */
 export function performUsePotion(gameState: GameState): GameState {
+  const bossesBefore = snapshotBosses(gameState);
+  const result = performUsePotionCore(gameState);
+  resolveBossDefeat(result, bossesBefore);
+  return result;
+}
+
+function performUsePotionCore(gameState: GameState): GameState {
   gameState = detonateLiveBombs(gameState);
   if (gameState.heroHealth <= 0) return gameState;
   const count = gameState.potionCount || 0;
@@ -439,6 +461,13 @@ export const PINK_HEART_BONUS_HEARTS = 3;
  * potion). Does nothing if none are held.
  */
 export function performUsePinkHeart(gameState: GameState): GameState {
+  const bossesBefore = snapshotBosses(gameState);
+  const result = performUsePinkHeartCore(gameState);
+  resolveBossDefeat(result, bossesBefore);
+  return result;
+}
+
+function performUsePinkHeartCore(gameState: GameState): GameState {
   gameState = detonateLiveBombs(gameState);
   if (gameState.heroHealth <= 0) return gameState;
   const count = gameState.pinkHeartCount ?? 0;
@@ -504,6 +533,13 @@ export function performUsePinkHeart(gameState: GameState): GameState {
  * none are held.
  */
 export function performUseBerry(gameState: GameState): GameState {
+  const bossesBefore = snapshotBosses(gameState);
+  const result = performUseBerryCore(gameState);
+  resolveBossDefeat(result, bossesBefore);
+  return result;
+}
+
+function performUseBerryCore(gameState: GameState): GameState {
   gameState = detonateLiveBombs(gameState);
   if (gameState.heroHealth <= 0) return gameState;
   const count = gameState.berryCount ?? 0;
@@ -3317,11 +3353,22 @@ export function snapshotBosses(state: GameState): BossSnapshot {
     const e = (state.enemies ?? []).find((en) => en.kind === kind);
     return e ? [e.y, e.x] : null;
   };
+  // The Coilwyrm counts as "still here" while ANY of its parts stands, not just a head:
+  // a decapitated body can spend a turn (or more) headless before it promotes a replacement
+  // or is reaped, and if the snapshot only saw heads those turns would have coilwyrm: null —
+  // so the turn the last segment finally died would skip the payout branch entirely and the
+  // exit key would never drop. Registry-driven (bodyPart) so the next segmented boss inherits it.
+  const findCoilwyrm = (): [number, number] | null => {
+    const head = find("coilwyrm");
+    if (head) return head;
+    const part = (state.enemies ?? []).find((en) => EnemyRegistry[en.kind]?.bodyPart);
+    return part ? [part.y, part.x] : null;
+  };
   return {
     shaper: find("shaper"),
     fisher: find("fisher"),
     quarrymaster: find("quarrymaster"),
-    coilwyrm: find("coilwyrm"),
+    coilwyrm: findCoilwyrm(),
   };
 }
 
@@ -3361,8 +3408,75 @@ function settleBossKill(after: GameState): void {
  *             chamber switch thrown, which is a separate gate (see gateGroups).
  *
  * All four also hand over a heart — see settleBossKill.
+ *
+ * Whatever this decides, `ensureBossArenaSolvable` gets the last word — a boss arena with
+ * nothing left to kill and no way to the exit is a dead run, so the key is guaranteed there
+ * rather than here. Add new bosses to the branches below for the right drop in the right
+ * place; the net is what makes a mistake in one survivable.
  */
 function resolveBossDefeat(after: GameState, before: BossSnapshot): void {
+  awardBossDefeat(after, before);
+  ensureBossArenaSolvable(after);
+}
+
+/**
+ * Is this enemy the fight itself — the thing whose death ends the arena?
+ *
+ * Keyed off BOSS_KINDS, the roster that already defines what a boss IS, rather than the
+ * registry's `boss` flag: that flag was added for the Coilwyrm's regrow check and only ever
+ * reached the two kinds that needed it, so the Fisher and Quarrymaster read as ordinary
+ * enemies through it. Anything that asks "is the boss dead" and gets that wrong pays out
+ * mid-fight or not at all, so the question is asked in exactly one place.
+ *
+ * `bodyPart` comes along for segmented bosses: a headless length of Coilwyrm is still the boss,
+ * and it is registry-driven so the next segmented boss inherits this for free.
+ */
+function isBossPart(enemy: Enemy): boolean {
+  if (BOSS_KINDS.includes(enemy.kind as BossKind)) return true;
+  return Boolean(EnemyRegistry[enemy.kind]?.bodyPart);
+}
+
+/**
+ * Last-resort guarantee: you killed everything in a boss arena, so the exit must be openable.
+ *
+ * The per-boss payouts above are precise — right drop, right tile, right turn — and precision
+ * is exactly what leaks. It has already happened once: a Coilwyrm decapitated a turn earlier
+ * left only body segments, so the turn they finally died had no head in the pre-turn snapshot
+ * and the payout branch was skipped. The player had killed the boss and was sealed in the room
+ * with no key and nothing left to hit — an unwinnable run with no way to tell it was a bug.
+ *
+ * So the invariant is enforced from the other end, where it does not depend on knowing which
+ * kill path fired: in an arena, with no boss and no boss body still standing, if there is no
+ * key on the floor and none in the pack, hand it over. Granted straight to the pack rather than
+ * dropped as a tile because a drop still has to be walked onto, and the whole point here is that
+ * nothing further is required of the player.
+ *
+ * Fires at most once per arena by construction — afterwards `hasExitKey` is set, and on the turn
+ * it is spent the run is already leaving (win or floor transition, both excluded).
+ *
+ * `bossKind` is required alongside `inBossRoom` so this only ever speaks for a room the run
+ * actually entered to fight something. Both are set together (enterBossRoom, endlessBossStateFor),
+ * cleared together, and saved together, so requiring it costs nothing in real play — but a bare
+ * arena built straight from a builder for a test harness has no boss to be owed a key for.
+ */
+function ensureBossArenaSolvable(after: GameState): void {
+  if (!after.inBossRoom || !after.bossKind || after.hasExitKey) return;
+  if (after.win || after.needsFloorTransition) return;
+  if ((after.enemies ?? []).some(isBossPart)) return;
+  let hasExit = false;
+  for (const row of after.mapData.subtypes) {
+    for (const cell of row) {
+      if (cell.includes(TileSubtype.EXITKEY)) return; // reachable on the floor: nothing to do
+      if (cell.includes(TileSubtype.EXIT)) hasExit = true;
+    }
+  }
+  if (!hasExit) return; // no keyed door in here to be stuck behind
+  after.hasExitKey = true;
+  // The heart rides along: a payout this missed the key on missed the rest of the kill too.
+  if (!after.bossDefeated) settleBossKill(after);
+}
+
+function awardBossDefeat(after: GameState, before: BossSnapshot): void {
   if (!after.inBossRoom || after.bossDefeated) return;
   const alive = after.enemies ?? [];
   // Prefer the recorded death tile; fall back to where it stood before the killing blow.
@@ -3393,12 +3507,8 @@ function resolveBossDefeat(after: GameState, before: BossSnapshot): void {
     // at all — paying out there hands over the exit key mid-fight. Its body parts therefore
     // count as the boss still standing, which is correct for both endings: a body long enough
     // to promote produces a new head, and one too short marks itself severed and is reaped
-    // within a tick. `bodyPart` is registry-driven so the next segmented boss inherits this.
-    const standing = alive.some((e) => {
-      const cfg = EnemyRegistry[e.kind];
-      return Boolean(cfg?.boss || cfg?.bodyPart);
-    });
-    if (standing) return;
+    // within a tick. See isBossPart for what counts as still standing.
+    if (alive.some(isBossPart)) return;
     const [ky, kx] = deathTile(before.coilwyrm);
     const cell = after.mapData.subtypes[ky]?.[kx];
     if (cell && !cell.includes(TileSubtype.EXITKEY)) cell.push(TileSubtype.EXITKEY);


### PR DESCRIPTION
Reported from an endless floor 6 Coilwyrm fight: the boss died and dropped no key, sealing the run in the arena with nothing left to hit.

## The bug

The payout decides what a boss owes by comparing a pre-turn snapshot of where each boss stood against the resolved state. `snapshotBosses` only looked for a Coilwyrm **head** — but a decapitated body spends a turn or more headless before it promotes a replacement or marks itself severed and is reaped. On the turn the last segment finally died there was no coilwyrm in the pre-turn snapshot at all, so `before.coilwyrm` was `null` and the entire branch was skipped: no key, and `bossDefeated` never set. Body parts now count as the boss still being there, which is exactly what the branch already assumed.

Not endless-specific — a daily Coilwyrm day had the same hole.

## Two more leaks, found auditing the other turn paths

- **Item turns never paid out.** Food, potion, pink heart and berry each advance a full turn (enemy tick, hazard reap, bomb fuse) but none ran the payout, so a fuse or a coil reap that landed the killing blow paid nothing. For the Fisher that is worse than a missing key: its corpse *is* the bridge across the spikes, so the crossing would never open. All four are now wrapped the way `performThrowRock` already was.
- **The registry's `boss` flag was half-populated** — set on the Shaper and Coilwyrm, missing on the Fisher and Quarrymaster — so anything asking "is the boss dead" through it got a yes mid-fight. I hit this writing the fallback below and the suite caught it. The flag had no other readers, so it is gone; the question now goes to `BOSS_KINDS`, which the roster's own comments already establish as the one place a boss is declared.

## The fallback

`ensureBossArenaSolvable` runs at the end of every turn and does not care which kill path fired. In a boss arena with nothing boss-shaped left standing, a keyed exit, no key on the floor and none in the pack, it hands the key over — straight into the pack rather than as a dropped tile, since the point is that nothing further is required of the player. It brings the missed heart along if the kill was never banked, and it fires at most once per arena by construction. It also covers the other half of the leak: a payout that *did* run but dropped its key on a tile that was not there, where `bossDefeated` is latched and the per-boss branch can never retry.

## Verification

- 1267 tests pass. New coverage: the headless-body case, an item-turn fuse kill, and the net firing / staying quiet while a body still stands / leaving an already-dropped key alone / not firing outside an arena / not minting a replacement on the way out / covering a banked-but-swallowed key.
- Confirmed the regression test fails on the old code before the fix.
- `npm run typecheck` and `npm run build` clean. The standalone typecheck's only errors are pre-existing ones in its own `vite.config.ts`, verified by stashing this change.

Existing stuck runs should recover on their own: endless saves every turn and reloads on mount, so one more move in that room hands the player the key and the heart they were owed.