### PR TITLE
Add the wisp: a catchable light that spends itself to save the hero

### DIFF
--- a/__tests__/lib/wisp.test.ts
+++ b/__tests__/lib/wisp.test.ts
@@ -1,0 +1,374 @@
+import { TileSubtype, Direction } from "../../lib/map";
+import {
+  movePlayer,
+  initializeGameStateForMultiTier,
+} from "../../lib/map/game-state";
+import type { GameState } from "../../lib/map/game-state";
+import {
+  WISP_DEFAULT_LIFESPAN,
+  WISP_MAX_COMPANIONS,
+  WISP_PITY_MAX_DIST,
+  WISP_PITY_MIN_DIST,
+  WISP_RESTORE_HEARTS,
+  WISP_STANDARD_CONFIG,
+  WISP_TRAIL_LENGTH,
+  advanceWispTurn,
+  stampWispPots,
+  wispDeathSave,
+  type WildWisp,
+} from "../../lib/map/wisp";
+import { findPlayerPosition } from "../../lib/map/player";
+
+/**
+ * The wisp life-regen prototype. See lib/map/wisp.ts.
+ *
+ * The invariants each with a plausible wrong answer:
+ *  - the whole system is dormant (state untouched) without wispConfig or wisps
+ *  - stepping ONTO a wisp catches it — it never gets a flee step first
+ *  - torch state inverts the drift: lit = shy, dark = drawn to the hero
+ *  - wild wisps burn one move per hero step and gutter out at zero
+ *  - the death save consumes exactly one companion, restores hearts, clears the
+ *    death cause, and tugs the hero OFF lethal ground onto a safe recent tile
+ */
+
+function openRoom(size: number): {
+  tiles: number[][];
+  subtypes: number[][][];
+} {
+  const tiles = Array.from({ length: size }, () =>
+    new Array(size).fill(0)
+  );
+  const subtypes: number[][][] = Array.from({ length: size }, () =>
+    Array.from({ length: size }, () => [] as number[])
+  );
+  return { tiles, subtypes };
+}
+
+function baseState(overrides: Partial<GameState> = {}): GameState {
+  const { tiles, subtypes } = openRoom(12);
+  subtypes[5][1] = [TileSubtype.PLAYER];
+  return {
+    hasKey: false,
+    hasExitKey: false,
+    mapData: { tiles, subtypes },
+    showFullMap: true,
+    win: false,
+    playerDirection: Direction.RIGHT,
+    heroHealth: 5,
+    heroMaxHealth: 5,
+    heroAttack: 1,
+    heroTorchLit: true,
+    enemies: [],
+    npcs: [],
+    rockCount: 0,
+    runeCount: 0,
+    bombCount: 0,
+    currentFloor: 1,
+    stats: { damageDealt: 0, damageTaken: 0, enemiesDefeated: 0, steps: 0 },
+    ...overrides,
+  } as GameState;
+}
+
+function wisp(y: number, x: number, movesLeft = WISP_DEFAULT_LIFESPAN): WildWisp {
+  return { id: 1, y, x, movesLeft };
+}
+
+describe("dormancy", () => {
+  it("adds no wisp fields to a run that never touches the feature", () => {
+    const after = movePlayer(baseState(), Direction.RIGHT);
+    expect(after.wisps).toBeUndefined();
+    expect(after.wispCompanions).toBeUndefined();
+    expect(after.heroTrail).toBeUndefined();
+    expect(after.wispPos).toBeUndefined();
+  });
+});
+
+describe("catching", () => {
+  it("catches a wisp by stepping onto its tile — no flee step first", () => {
+    const state = baseState({
+      wispConfig: {},
+      wisps: [wisp(5, 2)], // directly east of the hero at (5,1)
+    });
+    const after = movePlayer(state, Direction.RIGHT);
+    expect(after.wispCompanions).toBe(1);
+    expect(after.wisps).toBeUndefined();
+  });
+
+  it("a dark-drawn wisp that drifts onto the hero is also caught", () => {
+    const state = baseState({
+      heroTorchLit: false,
+      wispConfig: {},
+      // Two east of where the hero LANDS (5,2): after the step it closes to (5,3)?
+      // No — attraction moves it a full diagonal-capable step toward the hero, so
+      // from (5,3) it lands exactly on (5,2).
+      wisps: [wisp(5, 3)],
+    });
+    const after = movePlayer(state, Direction.RIGHT);
+    expect(findPlayerPosition(after.mapData)).toEqual([5, 2]);
+    expect(after.wispCompanions).toBe(1);
+    expect(after.wisps).toBeUndefined();
+  });
+
+  it("caps companions at WISP_MAX_COMPANIONS", () => {
+    const state = baseState({
+      wispConfig: {},
+      wispCompanions: WISP_MAX_COMPANIONS,
+      wisps: [wisp(5, 2)],
+    });
+    const after = movePlayer(state, Direction.RIGHT);
+    expect(after.wispCompanions).toBe(WISP_MAX_COMPANIONS);
+    expect(after.wisps).toHaveLength(1); // still wild, though it may have drifted
+  });
+});
+
+describe("drift", () => {
+  it("a lit torch spooks an adjacent wisp into opening distance", () => {
+    const state = baseState({
+      wispConfig: {},
+      wisps: [wisp(5, 3)], // will be adjacent to the hero's landing tile (5,2)
+    });
+    const after = movePlayer(state, Direction.RIGHT);
+    const w = after.wisps?.[0];
+    expect(w).toBeDefined();
+    const d = Math.max(Math.abs(w!.y - 5), Math.abs(w!.x - 2));
+    expect(d).toBeGreaterThan(1);
+  });
+
+  it("in the dark, a far wisp closes distance every step", () => {
+    const state = baseState({
+      heroTorchLit: false,
+      wispConfig: {},
+      wisps: [wisp(5, 8)],
+    });
+    const after = movePlayer(state, Direction.RIGHT); // hero lands (5,2)
+    expect(after.wisps?.[0]).toMatchObject({ y: 5, x: 7 });
+  });
+
+  it("burns one move per hero step and gutters out at zero", () => {
+    let cur = baseState({
+      heroTorchLit: false, // deterministic drift (attraction)
+      wispConfig: {},
+      wisps: [wisp(1, 10, 2)],
+    });
+    cur = movePlayer(cur, Direction.RIGHT);
+    expect(cur.wisps?.[0]?.movesLeft).toBe(1);
+    cur = movePlayer(cur, Direction.RIGHT);
+    expect(cur.wisps).toBeUndefined();
+  });
+
+  it("does not burn a move on a wall bump", () => {
+    const state = baseState({
+      heroTorchLit: false,
+      wispConfig: {},
+      wisps: [wisp(1, 10, 2)],
+    });
+    const bumped = movePlayer(state, Direction.LEFT); // (5,1) -> map edge... (5,0) is floor
+    // (5,0) is actually walkable in an open room, so bump into the edge instead:
+    const cornered = movePlayer(bumped, Direction.LEFT);
+    expect(cornered.stats.steps).toBe(1);
+    expect(cornered.wisps?.[0]?.movesLeft).toBe(1);
+  });
+});
+
+describe("spawning", () => {
+  it("a walked-into pot releases a wisp beside the pot, never under the hero", () => {
+    const state = baseState({ wispConfig: { potChance: 1 } });
+    state.mapData.subtypes[5][2] = [TileSubtype.POT];
+    const after = movePlayer(state, Direction.RIGHT); // smash by walking in
+    expect(after.wisps).toHaveLength(1);
+    const w = after.wisps![0];
+    const hero = findPlayerPosition(after.mapData)!;
+    expect([w.y, w.x]).not.toEqual([hero[0], hero[1]]);
+    expect(Math.max(Math.abs(w.y - 5), Math.abs(w.x - 2))).toBeLessThanOrEqual(1);
+  });
+
+  it("potChance=0 releases nothing", () => {
+    const state = baseState({ wispConfig: { potChance: 0 } });
+    state.mapData.subtypes[5][2] = [TileSubtype.POT];
+    const after = movePlayer(state, Direction.RIGHT);
+    expect(after.wisps).toBeUndefined();
+  });
+
+  it("a defeated enemy leaves a wisp near its death tile", () => {
+    // Driven through advanceWispTurn directly: a movePlayer bump-kill depends on
+    // the goblin's AI holding its tile through the enemy turn, which is
+    // rng-driven. recentDeaths is the engine's own per-tick kill record, so
+    // feeding it is exactly what the movePlayer wrapper does.
+    const before = baseState({ wispConfig: { enemyDropChance: 1 } });
+    const after = baseState({
+      wispConfig: { enemyDropChance: 1 },
+      recentDeaths: [[5, 8]],
+    });
+    const result = advanceWispTurn(before, after, () => 0.3);
+    expect(result.wisps).toHaveLength(1);
+    const w = result.wisps![0];
+    expect(Math.max(Math.abs(w.y - 5), Math.abs(w.x - 8))).toBeLessThanOrEqual(1);
+  });
+
+  it("a stamped wisp pot is guaranteed even at potChance 0, and consumes its marker", () => {
+    const state = baseState({ wispConfig: { potChance: 0 } });
+    state.mapData.subtypes[5][2] = [TileSubtype.POT, TileSubtype.WISP];
+    const after = movePlayer(state, Direction.RIGHT); // smash by walking in
+    expect(after.wisps).toHaveLength(1);
+    expect(after.mapData.subtypes[5][2]).not.toContain(TileSubtype.WISP);
+  });
+
+  it("falling to exactly 1 heart draws a pity wisp out at the edge of view", () => {
+    const before = baseState({ heroHealth: 2, wispConfig: { pity: true } });
+    const after = baseState({ heroHealth: 1, wispConfig: { pity: true } });
+    const result = advanceWispTurn(before, after, () => 0.85);
+    expect(result.wisps).toHaveLength(1);
+    const w = result.wisps![0];
+    const d = Math.max(Math.abs(w.y - 5), Math.abs(w.x - 1));
+    expect(d).toBeGreaterThanOrEqual(WISP_PITY_MIN_DIST);
+    expect(d).toBeLessThanOrEqual(WISP_PITY_MAX_DIST);
+    expect(result.wispPityFloors).toEqual([1]);
+  });
+
+  it("pity fires once per floor, and again on the next floor", () => {
+    // Floor 1's latch is set: the same dip spawns nothing.
+    const before = baseState({ heroHealth: 2, wispConfig: { pity: true } });
+    const again = baseState({
+      heroHealth: 1,
+      wispConfig: { pity: true },
+      wispPityFloors: [1],
+    });
+    expect(advanceWispTurn(before, again, () => 0.85).wisps).toBeUndefined();
+
+    // The same dip on floor 2 fires and extends the latch.
+    const before2 = baseState({
+      heroHealth: 2,
+      wispConfig: { pity: true },
+      currentFloor: 2,
+    });
+    const after2 = baseState({
+      heroHealth: 1,
+      wispConfig: { pity: true },
+      currentFloor: 2,
+      wispPityFloors: [1],
+    });
+    const result2 = advanceWispTurn(before2, after2, () => 0.85);
+    expect(result2.wisps).toHaveLength(1);
+    expect(result2.wispPityFloors).toEqual([1, 2]);
+  });
+});
+
+describe("stampWispPots", () => {
+  it("stamps only plain pots, and never double-stamps", () => {
+    const state = baseState();
+    state.mapData.subtypes[2][2] = [TileSubtype.POT];
+    state.mapData.subtypes[2][3] = [TileSubtype.POT, TileSubtype.SNAKE];
+    state.mapData.subtypes[2][4] = [TileSubtype.POT, TileSubtype.RUNE];
+    expect(stampWispPots(state.mapData, 0.03, () => 0)).toBe(1);
+    expect(state.mapData.subtypes[2][2]).toContain(TileSubtype.WISP);
+    expect(state.mapData.subtypes[2][3]).not.toContain(TileSubtype.WISP);
+    expect(state.mapData.subtypes[2][4]).not.toContain(TileSubtype.WISP);
+    expect(stampWispPots(state.mapData, 0.03, () => 0)).toBe(0);
+  });
+
+  it("stamps nothing when the roll misses", () => {
+    const state = baseState();
+    state.mapData.subtypes[2][2] = [TileSubtype.POT];
+    expect(stampWispPots(state.mapData, 0.03, () => 0.5)).toBe(0);
+    expect(state.mapData.subtypes[2][2]).not.toContain(TileSubtype.WISP);
+  });
+});
+
+describe("real-mode wiring", () => {
+  it("daily runs carry the standard wisp config (cap 1, 2% drops, pity on)", () => {
+    const s = initializeGameStateForMultiTier(1, {});
+    expect(s.wispConfig).toEqual(WISP_STANDARD_CONFIG);
+    expect(WISP_STANDARD_CONFIG.maxCompanions).toBe(1);
+    expect(WISP_STANDARD_CONFIG.potChance).toBeUndefined(); // pots are baked, not rolled
+  });
+
+  it("the real-mode cap holds carrying at one", () => {
+    const state = baseState({
+      wispConfig: { maxCompanions: 1 },
+      wispCompanions: 1,
+      wisps: [wisp(5, 2)],
+    });
+    const after = movePlayer(state, Direction.RIGHT);
+    expect(after.wispCompanions).toBe(1);
+    expect(after.wisps).toHaveLength(1); // still wild
+  });
+});
+
+describe("the trail and the perch", () => {
+  it("records vacated tiles newest-last, capped at WISP_TRAIL_LENGTH", () => {
+    let cur = baseState({ wispConfig: {}, wispCompanions: 1 });
+    for (let i = 0; i < 5; i++) cur = movePlayer(cur, Direction.RIGHT);
+    expect(cur.heroTrail).toEqual([
+      [5, 3],
+      [5, 4],
+      [5, 5],
+    ]);
+    expect(cur.heroTrail).toHaveLength(WISP_TRAIL_LENGTH);
+  });
+
+  it("perches the companion on a trail tile", () => {
+    let cur = baseState({ wispConfig: {}, wispCompanions: 1 });
+    for (let i = 0; i < 4; i++) cur = movePlayer(cur, Direction.RIGHT);
+    expect(cur.wispPos).toBeDefined();
+    expect(cur.heroTrail).toContainEqual(cur.wispPos);
+  });
+});
+
+describe("the death save", () => {
+  it("returns null for a live hero or an empty-handed dead one", () => {
+    expect(wispDeathSave(baseState({ wispCompanions: 1 }))).toBeNull();
+    expect(wispDeathSave(baseState({ heroHealth: 0 }))).toBeNull();
+  });
+
+  it("spends one companion, restores hearts, clears the cause", () => {
+    const state = baseState({
+      heroHealth: 0,
+      heroMaxHealth: 8,
+      wispCompanions: 2,
+      deathCause: { type: "enemy", enemyKind: "goblin" },
+    });
+    const saved = wispDeathSave(state)!;
+    expect(saved.heroHealth).toBe(WISP_RESTORE_HEARTS);
+    expect(saved.wispCompanions).toBe(1);
+    expect(saved.deathCause).toBeUndefined();
+  });
+
+  it("clamps the restore to a small max health", () => {
+    const saved = wispDeathSave(
+      baseState({ heroHealth: 0, heroMaxHealth: 2, wispCompanions: 1 })
+    )!;
+    expect(saved.heroHealth).toBe(2);
+  });
+
+  it("tugs the hero off lava onto the wisp's perch", () => {
+    const state = baseState({
+      heroHealth: 0,
+      wispCompanions: 1,
+      deathCause: { type: "lava" },
+      wispPos: [5, 3],
+      heroTrail: [[5, 3]],
+    });
+    // Hero stands at (5,1); make it lava (death by stepping in).
+    state.mapData.subtypes[5][1] = [TileSubtype.LAVA, TileSubtype.PLAYER];
+    const saved = wispDeathSave(state)!;
+    expect(findPlayerPosition(saved.mapData)).toEqual([5, 3]);
+    expect(
+      saved.mapData.subtypes[5][1].includes(TileSubtype.PLAYER)
+    ).toBe(false);
+    expect(saved.heroHealth).toBe(WISP_RESTORE_HEARTS);
+  });
+
+  it("revives in place when no safe perch exists", () => {
+    const state = baseState({
+      heroHealth: 0,
+      wispCompanions: 1,
+      // Trail tile is itself lava — unusable as a landing.
+      wispPos: [5, 3],
+      heroTrail: [[5, 3]],
+    });
+    state.mapData.subtypes[5][3] = [TileSubtype.LAVA];
+    const saved = wispDeathSave(state)!;
+    expect(findPlayerPosition(saved.mapData)).toEqual([5, 1]);
+    expect(saved.heroHealth).toBe(WISP_RESTORE_HEARTS);
+  });
+});

--- a/app/test-wisp/page.tsx
+++ b/app/test-wisp/page.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import React, { Suspense } from "react";
+import { TilemapGrid } from "../../components/TilemapGrid";
+import {
+  tileTypes,
+  TileSubtype,
+  type GameState,
+  Direction,
+} from "../../lib/map";
+import { Enemy } from "../../lib/enemy";
+import {
+  WISP_DEFAULT_LIFESPAN,
+  WISP_FLASH_MOVES,
+  WISP_MAX_COMPANIONS,
+  WISP_RESTORE_HEARTS,
+  type WildWisp,
+} from "../../lib/map/wisp";
+
+const FLOOR = 0;
+const WALL = 1;
+
+const ROOM_W = 26;
+const ROOM_H = 12;
+/** Hero's row. */
+const LANE = 6;
+
+/** Fixed perches for the ?wisps=N pre-spawned wild wisps, spread around the room. */
+const PRESPAWN_SPOTS: Array<[number, number]> = [
+  [3, 10],
+  [9, 16],
+  [2, 20],
+  [10, 6],
+  [4, 23],
+];
+
+function makeGoblin(y: number, x: number, kind: string): Enemy {
+  const g = new Enemy({ y, x });
+  g.kind = kind as Enemy["kind"];
+  return g;
+}
+
+/**
+ * Sandbox for the wisp life-regen prototype. See lib/map/wisp.ts and
+ * .claude/features/wisp-life-regen/index.md.
+ *
+ * The room stages every spawn source and both halves of the mechanic:
+ *
+ *  - WEST: a pot cluster. Walking into a pot smashes it; with the default
+ *    potChance=1 every pot releases a wisp that drifts away and gutters out after
+ *    its lifespan, flashing for the last few steps.
+ *  - MIDDLE: goblins. Kills can leave the enemy's spark behind as a wisp
+ *    (sparkChance, default 0.5) at the death tile.
+ *  - SOUTH-WEST: a pond with a deep core. Swimming the deep water SNUFFS THE
+ *    TORCH — and dark inverts every wild wisp: instead of wandering (and bolting
+ *    when you get adjacent), they drift toward you each step until one settles on
+ *    you and is caught. Relight at a north-wall torch to watch them turn shy again.
+ *  - EAST: a lava pool. Instant death — walk in carrying a wisp to watch the save:
+ *    the wisp whirls, restores hearts, and tugs you back off the lava onto its
+ *    perch. It also beats goblin deaths, and fires BEFORE an Amber Moth would.
+ *  - PITY: with ?pity=1 (default on here), dropping to exactly 1 heart draws a
+ *    wisp out of the walls a few tiles away.
+ */
+function buildWispRoom(opts?: {
+  torchLit?: boolean;
+  showFullMap?: boolean;
+  includeEnemies?: boolean;
+  heroHealth?: number;
+  heroAt?: [number, number];
+  /** Wild wisps already drifting when the room loads. */
+  prespawn?: number;
+  /** Companions already caught when the room loads. */
+  held?: number;
+  potChance?: number;
+  enemyDropChance?: number;
+  pity?: boolean;
+  lifespan?: number;
+}): GameState {
+  const height = ROOM_H + 2;
+  const width = ROOM_W + 2;
+
+  const tiles: number[][] = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => WALL)
+  );
+  const subtypes: number[][][] = Array.from({ length: height }, () =>
+    Array.from({ length: width }, () => [] as number[])
+  );
+
+  for (let y = 1; y <= ROOM_H; y++) {
+    for (let x = 1; x <= ROOM_W; x++) {
+      tiles[y][x] = FLOOR;
+    }
+  }
+
+  // West: the pot cluster.
+  for (const [y, x] of [
+    [4, 4],
+    [5, 3],
+    [5, 5],
+    [7, 4],
+    [8, 3],
+  ] as Array<[number, number]>) {
+    subtypes[y][x] = [TileSubtype.POT];
+  }
+  // One pot STAMPED the way real dailies bake them (3% of plain pots, seeded, the
+  // same pots for everyone). With ?pot=0 the cluster above goes quiet but this one
+  // still releases its wisp — that's the baked path.
+  subtypes[8][5] = [TileSubtype.POT, TileSubtype.WISP];
+
+  // South-west: pond with a deep core — swim it to snuff the torch.
+  for (let y = 9; y <= 11; y++) {
+    for (let x = 8; x <= 11; x++) {
+      subtypes[y][x] = [TileSubtype.SHALLOW_WATER];
+    }
+  }
+  subtypes[10][9] = [TileSubtype.DEEP_WATER];
+  subtypes[10][10] = [TileSubtype.DEEP_WATER];
+
+  // North wall torches: relight spots after a swim.
+  for (const x of [6, 12, 18, 24]) {
+    subtypes[0][x] = [TileSubtype.WALL_TORCH];
+  }
+
+  // East: the lava pool for death-save tests.
+  for (let y = LANE - 2; y <= LANE + 2; y++) {
+    subtypes[y][ROOM_W - 1] = [TileSubtype.LAVA];
+    subtypes[y][ROOM_W] = [TileSubtype.LAVA];
+  }
+
+  const py = opts?.heroAt?.[0] ?? LANE;
+  const px = opts?.heroAt?.[1] ?? 2;
+  subtypes[py][px] = subtypes[py][px].concat([TileSubtype.PLAYER]);
+
+  const enemies: Enemy[] = [];
+  if (opts?.includeEnemies ?? true) {
+    enemies.push(makeGoblin(LANE - 3, 14, "fire-goblin"));
+    enemies.push(makeGoblin(LANE + 3, 16, "earth-goblin"));
+    enemies.push(makeGoblin(LANE - 2, 19, "water-goblin"));
+  }
+
+  const lifespan = opts?.lifespan ?? WISP_DEFAULT_LIFESPAN;
+  const prespawnCount = Math.min(
+    opts?.prespawn ?? 2,
+    PRESPAWN_SPOTS.length
+  );
+  const wisps: WildWisp[] = PRESPAWN_SPOTS.slice(0, prespawnCount).map(
+    // fresh: they spiral up out of their tiles as the room loads.
+    ([y, x], i) => ({ id: 9000 + i, y, x, movesLeft: lifespan, fresh: true })
+  );
+
+  const hp = opts?.heroHealth ?? 8;
+  const held = Math.min(opts?.held ?? 0, WISP_MAX_COMPANIONS);
+
+  return {
+    hasKey: false,
+    hasExitKey: false,
+    hasSword: true,
+    hasShield: true,
+    showFullMap: opts?.showFullMap ?? true,
+    win: false,
+    playerDirection: Direction.RIGHT,
+    enemies,
+    heroHealth: hp,
+    heroMaxHealth: hp,
+    heroAttack: 1,
+    heroTorchLit: opts?.torchLit ?? true,
+    rockCount: 10,
+    runeCount: 0,
+    bombCount: 0,
+    foodCount: 0,
+    potionCount: 0,
+    currentFloor: 1,
+    stats: {
+      damageDealt: 0,
+      damageTaken: 0,
+      enemiesDefeated: 0,
+      steps: 0,
+    },
+    mapData: { tiles, subtypes, environment: "cave" },
+    recentDeaths: [],
+    mode: "normal",
+    wispConfig: {
+      // Cranked well above the real-mode numbers (baked 3% pots, 2% drops, cap 1)
+      // so every mechanic is easy to reach in a single test session.
+      potChance: opts?.potChance ?? 1,
+      enemyDropChance: opts?.enemyDropChance ?? 0.5,
+      pity: opts?.pity ?? true,
+      lifespan,
+      maxCompanions: WISP_MAX_COMPANIONS,
+    },
+    wisps: wisps.length > 0 ? wisps : undefined,
+    wispCompanions: held > 0 ? held : undefined,
+  } as GameState;
+}
+
+function TestWispInner() {
+  const params =
+    typeof window !== "undefined"
+      ? new URLSearchParams(window.location.search)
+      : null;
+
+  const forceDaylight = params?.get("daylight") !== "0";
+  const heroParam = params?.get("hero")?.split(",").map(Number);
+  const num = (key: string): number | undefined => {
+    const v = Number(params?.get(key));
+    return params?.get(key) !== null && Number.isFinite(v) ? v : undefined;
+  };
+
+  const initialState = buildWispRoom({
+    torchLit: params?.get("torch") !== "0",
+    showFullMap: params?.get("fullmap") !== "0",
+    includeEnemies: params?.get("enemies") !== "0",
+    heroHealth: num("hp"),
+    heroAt:
+      heroParam && heroParam.length === 2 && heroParam.every(Number.isFinite)
+        ? [heroParam[0], heroParam[1]]
+        : undefined,
+    prespawn: num("wisps"),
+    held: num("held"),
+    potChance: num("pot"),
+    enemyDropChance: num("drop"),
+    pity: params?.get("pity") !== "0",
+    lifespan: num("life"),
+  });
+
+  return (
+    <div
+      className="min-h-screen flex flex-col items-center justify-center p-4 text-white relative"
+      style={{
+        backgroundImage: "url(/images/presentational/wall-up-close.png)",
+        backgroundRepeat: "repeat",
+        backgroundSize: "auto",
+      }}
+    >
+      <div className="absolute inset-0 bg-black/40 pointer-events-none"></div>
+      <div className="relative z-10 flex flex-col items-center gap-4">
+        <div className="text-center bg-black/70 rounded-lg p-4 backdrop-blur-sm max-w-2xl">
+          <h1 className="text-2xl font-bold mb-2">Wisp — Life Regen Test</h1>
+          <div className="text-xs text-gray-300 mt-1 space-y-1 text-left">
+            <p>
+              <b>Two wild wisps</b> are already drifting. They move one tile per
+              step you take, float over anything walkable, and gutter out after{" "}
+              {WISP_DEFAULT_LIFESPAN} of your steps — flashing for the last{" "}
+              {WISP_FLASH_MOVES} as a warning.
+            </p>
+            <p>
+              <b>1. Catch one lit.</b> They&apos;re shy of fire: aimless wandering
+              until you&apos;re adjacent, then they bolt. Corner one against a wall
+              and step onto it.
+            </p>
+            <p>
+              <b>2. Catch one dark.</b> Swim the pond&apos;s deep middle
+              (south-west) — the water snuffs your torch, and dark wisps invert:
+              they drift <i>toward</i> you every step until one settles on you.
+              Relight at a north-wall torch and watch survivors turn shy again.
+              (In real floors dark also means snakes hunt you — that&apos;s the
+              intended trade.)
+            </p>
+            <p>
+              <b>3. Smash the pots</b> (west cluster): every pot releases a wisp
+              here (?pot=1; real dailies instead BAKE wisps into 3% of pots at
+              generation, seeded — same pots for everyone. One pot in the cluster
+              is baked that way: with ?pot=0 it still delivers). <b>Kill the
+              goblins</b>: half of kills leave a wisp at the death tile here
+              (?drop=0.5; 2% in real games).
+            </p>
+            <p>
+              <b>4. Pity.</b> The first time each floor you fall to exactly 1
+              heart, a wisp is drawn out 4-8 tiles away — at the edge of view, so
+              you glimpse it and must choose to chase it while nearly dead.
+              Guaranteed, but once per floor.
+            </p>
+            <p>
+              <b>5. The save.</b> Carrying a wisp (a small light trailing your last
+              few tiles), walk into the <b>lava</b> east: no death screen, no
+              banner — the wisp just spins around you three times, restores{" "}
+              {WISP_RESTORE_HEARTS} hearts (a full heal at base health), and tugs
+              you back onto its perch so the lava can&apos;t re-kill you. Consumes
+              one companion (cap {WISP_MAX_COMPANIONS} here, 1 in real modes);
+              fires before an Amber Moth would.
+            </p>
+            <p className="text-gray-400 pt-1">
+              URL knobs: <b>?wisps=N</b> pre-spawned wild wisps (default 2, max{" "}
+              {PRESPAWN_SPOTS.length}) · <b>?held=N</b> start carrying N ·{" "}
+              <b>?pot=0..1</b> / <b>?drop=0..1</b> spawn chances ·{" "}
+              <b>?pity=0</b> off · <b>?life=N</b> wild lifespan · <b>?hp=N</b>{" "}
+              starting HP (default 8) · <b>?hero=y,x</b> spawn tile ·{" "}
+              <b>?torch=0</b> start dark · <b>?enemies=0</b> clear the room.
+              Reload to reset.
+            </p>
+          </div>
+        </div>
+        <TilemapGrid
+          tileTypes={tileTypes}
+          initialGameState={initialState}
+          forceDaylight={forceDaylight}
+          storageSlot="test"
+        />
+      </div>
+    </div>
+  );
+}
+
+export default function TestWispPage() {
+  return (
+    <Suspense fallback={null}>
+      <TestWispInner />
+    </Suspense>
+  );
+}

--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -25,6 +25,8 @@ import {
   rewindStateBy,
 } from "../lib/map/rewind";
 import { RewindOverlay } from "./RewindOverlay";
+import { wispDeathSave } from "../lib/map/wisp";
+import { WispLayer, type WispBurst } from "./WispOverlay";
 import type { Enemy } from "../lib/enemy";
 import { rehydrateEnemies } from "../lib/enemy";
 import type { NPC, NPCInteractionEvent } from "../lib/npc";
@@ -96,6 +98,8 @@ import {
   trackUse,
   trackPickup,
   trackRewindUsed,
+  trackWispCaught,
+  trackWispSave,
   trackPinkRealmReached,
   trackOutsideWorldReached,
   trackOutsideTreeDestroyed,
@@ -412,6 +416,44 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
   const [rewindDeathBeat, setRewindDeathBeat] = useState<null | { depth: number }>(
     null
   );
+  // One-shot wisp spins around the hero: "catch" when a wild wisp is caught,
+  // "rescue" when a carried one spends itself on a death save. Rendered by
+  // WispLayer at the given tile; each removes itself when its animation is done.
+  const [wispBursts, setWispBursts] = useState<WispBurst[]>([]);
+  const wispBurstSeq = useRef(0);
+  const spawnWispBurst = useCallback(
+    (y: number, x: number, kind: WispBurst["kind"]) => {
+      const key = ++wispBurstSeq.current;
+      setWispBursts((list) => [...list, { key, y, x, kind }]);
+      // Slightly past the CSS animation (800ms catch / 1250ms rescue) so the
+      // fade completes before unmount.
+      const ttl = kind === "rescue" ? 1350 : 900;
+      setTimeout(() => {
+        setWispBursts((list) => list.filter((b) => b.key !== key));
+      }, ttl);
+    },
+    []
+  );
+  // The catch spin: fires whenever the carried count goes UP (a wild wisp was
+  // caught). Rescue spins fire explicitly from the death-save intercept — that
+  // path DECREASES the count, so it can never double-fire this.
+  const prevWispCompanions = useRef(gameState.wispCompanions ?? 0);
+  useEffect(() => {
+    const cur = gameState.wispCompanions ?? 0;
+    const prev = prevWispCompanions.current;
+    prevWispCompanions.current = cur;
+    if (cur > prev) {
+      const pos = findPlayerPosition(gameState.mapData);
+      if (pos) spawnWispBurst(pos[0], pos[1], "catch");
+      try {
+        trackWispCaught({
+          mode: isDailyChallenge ? "daily" : isEndless ? "endless" : "normal",
+          floor: gameState.currentFloor,
+          dateSeed: isDailyChallenge ? DateUtils.getTodayString() : undefined,
+        });
+      } catch {}
+    }
+  }, [gameState, spawnWispBurst, isDailyChallenge, isEndless]);
   /**
    * How far back the charm can currently reach. While a preview is open the board holds a
    * PAST state whose buffer is already truncated, so read the depth from the stashed
@@ -3170,6 +3212,34 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
      * repeat. If it somehow restores a state that is still dead, the charge is gone and
      * the ordinary death path takes over on the next pass — no loop either way.
      */
+    /**
+     * A carried wisp is the FIRST save consulted, ahead of the Amber Moth: it is the
+     * cheaper rescue (heal in place + a one-tile tug back onto its perch, world
+     * untouched) so it spends itself before the charm's full five-step rewind is
+     * touched. Same placement rules as the moth below — above the death animation,
+     * analytics, and redirects, so a saved run is never recorded as a death.
+     * Self-limiting the same way too: each save consumes a companion.
+     */
+    {
+      const saved = wispDeathSave(gameState);
+      if (saved && saved.heroHealth > 0) {
+        // The spin happens on the board, centered where the hero wakes up
+        // (the tug may have moved them off the lethal tile).
+        const revivedAt = findPlayerPosition(saved.mapData);
+        if (revivedAt) spawnWispBurst(revivedAt[0], revivedAt[1], "rescue");
+        setGameState(saved);
+        CurrentGameStorage.saveCurrentGame(saved, resolvedStorageSlot);
+        try {
+          trackWispSave({
+            mode: isDailyChallenge ? "daily" : isEndless ? "endless" : "normal",
+            floor: gameState.currentFloor,
+            dateSeed: isDailyChallenge ? DateUtils.getTodayString() : undefined,
+          });
+        } catch {}
+        return;
+      }
+    }
+
     if ((gameState.rewindCharges ?? 0) > 0) {
       const depth = Math.min(REWIND_DEATH_DEPTH, rewindDepthAvailable(gameState));
       const saved = depth > 0 ? rewindStateBy(gameState, depth) : null;
@@ -3438,6 +3508,7 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
     onDeath,
     router,
     resolvedStorageSlot,
+    spawnWispBurst,
     heroDeathPhase,
     shouldAnimateHeroDeath,
   ]);
@@ -5659,6 +5730,27 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
                       );
                     });
                   })()}
+                {/* Wisp prototype: wild wisps drifting the floor + the caught
+                    companion(s) perched on the hero's trail. Pure CSS glow orbs,
+                    positioned like the beams/spirits above. */}
+                {((gameState.wisps?.length ?? 0) > 0 ||
+                  (gameState.wispCompanions ?? 0) > 0 ||
+                  wispBursts.length > 0) && (
+                  <WispLayer
+                    wisps={gameState.wisps ?? []}
+                    // While a catch spin is playing, the newest companion IS the
+                    // spinning orb — hold it out of the trailing cluster until
+                    // the loops finish, then it joins.
+                    companions={Math.max(
+                      0,
+                      (gameState.wispCompanions ?? 0) -
+                        wispBursts.filter((b) => b.kind === "catch").length
+                    )}
+                    wispPos={gameState.wispPos}
+                    playerPosition={playerPosition}
+                    bursts={wispBursts}
+                  />
+                )}
                 {heartEffect && (() => {
                   const tileSize = 40;
                   const pxLeft = (heartEffect.x + 0.5) * tileSize;

--- a/components/WispOverlay.tsx
+++ b/components/WispOverlay.tsx
@@ -1,0 +1,303 @@
+import React from "react";
+import type { WildWisp } from "../lib/map/wisp";
+import { WISP_FLASH_MOVES } from "../lib/map/wisp";
+
+const TILE = 40; // px — matches the grid's fixed tile size
+
+/**
+ * Wisp visuals — pure CSS, no art assets while the mechanic is a prototype.
+ *
+ * Everything renders as absolutely positioned siblings of the tile grid (like the
+ * pink beams and death spirits), drifting between tiles on a transform transition.
+ *
+ * Three kinds of element:
+ *  - wild wisps: tiny glow orbs. A freshly released one (w.fresh) plays an emerge
+ *    animation — it rises out of its source tile (w.bornFrom: the smashed pot, the
+ *    dying enemy) in a little spiral that widens and brightens on the way up.
+ *  - the carried companion(s): slightly smaller orb perched on the hero's trail.
+ *  - bursts: one-shot spins around the hero, spawned by TilemapGrid. "catch" is
+ *    the moment of capture (two quick loops, then it joins you); "rescue" is the
+ *    death save (three brighter loops closing in as the hearts come back). These
+ *    replaced a full-screen banner: the spin just happens on the board.
+ */
+
+export interface WispBurst {
+  key: number;
+  y: number;
+  x: number;
+  kind: "catch" | "rescue";
+}
+
+export function WispLayer({
+  wisps,
+  companions,
+  wispPos,
+  playerPosition,
+  bursts = [],
+}: {
+  wisps: WildWisp[];
+  companions: number;
+  wispPos?: [number, number];
+  playerPosition: [number, number] | null;
+  bursts?: WispBurst[];
+}) {
+  // Carried wisps perch at wispPos (a recently-vacated tile); before the first step
+  // after a catch there may be no perch yet, so hover over the hero.
+  const perch = wispPos ?? playerPosition;
+  return (
+    <>
+      {wisps.map((w) => {
+        const from = w.fresh ? w.bornFrom ?? [w.y, w.x] : null;
+        return (
+          <div
+            key={`wild-${w.id}`}
+            aria-hidden="true"
+            data-testid="wild-wisp"
+            className="wispCell"
+            style={{
+              transform: `translate3d(${w.x * TILE}px, ${w.y * TILE}px, 0)`,
+            }}
+          >
+            <div
+              className={from ? "wispEmergeMove" : undefined}
+              style={
+                from
+                  ? ({
+                      "--emerge-dx": `${(from[1] - w.x) * TILE}px`,
+                      "--emerge-dy": `${(from[0] - w.y) * TILE}px`,
+                    } as React.CSSProperties)
+                  : undefined
+              }
+            >
+              <div className={from ? "wispEmergeSpiral" : undefined}>
+                <div
+                  className={`wispBob ${
+                    w.movesLeft <= WISP_FLASH_MOVES ? "wispFlash" : ""
+                  }`}
+                >
+                  <div className="wispOrb wispWild" />
+                </div>
+              </div>
+            </div>
+          </div>
+        );
+      })}
+      {perch &&
+        Array.from({ length: companions }, (_, i) => (
+          <div
+            key={`held-${i}`}
+            aria-hidden="true"
+            data-testid="companion-wisp"
+            className="wispCell wispHeldDrift"
+            style={{
+              transform: `translate3d(${perch[1] * TILE}px, ${
+                perch[0] * TILE
+              }px, 0)`,
+            }}
+          >
+            <div
+              className="wispBob"
+              style={{ animationDelay: `${i * -0.7}s` }}
+            >
+              <div
+                className="wispOrb wispHeld"
+                style={{
+                  // Fan multiple companions out so they read as a small cluster.
+                  marginLeft: (i % 3) * 7 - 7,
+                  marginTop: Math.floor(i / 2) * 6 - 3,
+                  animationDelay: `${i * -0.5}s`,
+                }}
+              />
+            </div>
+          </div>
+        ))}
+      {bursts.map((b) => (
+        <div
+          key={`burst-${b.key}`}
+          aria-hidden="true"
+          data-testid={`wisp-burst-${b.kind}`}
+          className="wispCell"
+          style={{
+            transform: `translate3d(${b.x * TILE}px, ${b.y * TILE}px, 0)`,
+          }}
+        >
+          {b.kind === "rescue" && <div className="wispRescueRing" />}
+          <div
+            className={
+              b.kind === "rescue" ? "wispSpin wispSpinRescue" : "wispSpin"
+            }
+          >
+            <div className="wispOrb wispWild wispBright" />
+          </div>
+        </div>
+      ))}
+      <style jsx>{`
+        .wispCell {
+          position: absolute;
+          left: 0;
+          top: 0;
+          width: ${TILE}px;
+          height: ${TILE}px;
+          pointer-events: none;
+          z-index: 11800; /* above the hero (11000), under wall tops (12000) */
+          transition: transform 300ms ease-in-out;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+        }
+        .wispHeldDrift {
+          transition: transform 480ms ease-in-out; /* lazier, trailing feel */
+        }
+        .wispBob {
+          animation: wispBob 2.2s ease-in-out infinite;
+        }
+        .wispOrb {
+          width: 5px;
+          height: 5px;
+          border-radius: 50%;
+          animation: wispPulse 1.6s ease-in-out infinite;
+        }
+        .wispWild {
+          background: #d9fffb;
+          box-shadow: 0 0 2px 1px rgba(140, 255, 240, 0.9),
+            0 0 6px 3px rgba(64, 224, 208, 0.55),
+            0 0 11px 5px rgba(32, 178, 170, 0.25);
+        }
+        .wispHeld {
+          width: 4px;
+          height: 4px;
+          background: #eafffa;
+          box-shadow: 0 0 2px 1px rgba(190, 255, 244, 0.95),
+            0 0 5px 2px rgba(110, 240, 220, 0.6),
+            0 0 9px 4px rgba(64, 224, 208, 0.3);
+        }
+        .wispBright {
+          box-shadow: 0 0 3px 2px rgba(190, 255, 244, 0.95),
+            0 0 8px 4px rgba(110, 240, 220, 0.7),
+            0 0 16px 8px rgba(64, 224, 208, 0.4);
+        }
+        .wispFlash {
+          animation: wispBob 2.2s ease-in-out infinite,
+            wispVanishFlash 0.45s steps(2, jump-none) infinite;
+        }
+        /* Emerge: travel from the source tile (pot / spark) to the spawn tile... */
+        .wispEmergeMove {
+          animation: wispEmergeMove 750ms cubic-bezier(0.22, 1, 0.36, 1) both;
+        }
+        /* ...while spiraling upward, the loop widening as it rises, then settling. */
+        .wispEmergeSpiral {
+          animation: wispEmergeSpiral 750ms ease-out both;
+        }
+        /* Catch: two quick loops around the hero, tightening, then it joins you. */
+        .wispSpin {
+          animation: wispSpinCatch 800ms ease-in-out both;
+        }
+        /* Rescue: three slower, brighter loops closing in as the hearts return. */
+        .wispSpinRescue {
+          animation: wispSpinRescue 1250ms ease-in-out both;
+        }
+        .wispRescueRing {
+          position: absolute;
+          left: 50%;
+          top: 50%;
+          width: 34px;
+          height: 34px;
+          margin: -17px 0 0 -17px;
+          border-radius: 50%;
+          border: 2px solid rgba(140, 255, 240, 0.8);
+          box-shadow: 0 0 10px 3px rgba(64, 224, 208, 0.45);
+          animation: wispRescueRing 900ms ease-out both;
+        }
+        @keyframes wispBob {
+          0%,
+          100% {
+            transform: translateY(-2px);
+          }
+          50% {
+            transform: translateY(3px);
+          }
+        }
+        @keyframes wispPulse {
+          0%,
+          100% {
+            filter: brightness(1);
+          }
+          50% {
+            filter: brightness(1.5);
+          }
+        }
+        @keyframes wispVanishFlash {
+          0% {
+            opacity: 1;
+          }
+          100% {
+            opacity: 0.15;
+          }
+        }
+        @keyframes wispEmergeMove {
+          from {
+            transform: translate(
+              var(--emerge-dx, 0px),
+              calc(var(--emerge-dy, 0px) + 10px)
+            );
+          }
+          to {
+            transform: translate(0px, 0px);
+          }
+        }
+        @keyframes wispEmergeSpiral {
+          0% {
+            transform: rotate(0deg) translateX(2px) scale(0.15);
+            opacity: 0;
+          }
+          25% {
+            opacity: 1;
+          }
+          60% {
+            transform: rotate(430deg) translateX(10px) scale(0.7);
+          }
+          100% {
+            transform: rotate(720deg) translateX(0px) scale(1);
+            opacity: 1;
+          }
+        }
+        @keyframes wispSpinCatch {
+          0% {
+            transform: rotate(0deg) translateX(15px) scale(0.9);
+            opacity: 1;
+          }
+          85% {
+            opacity: 1;
+          }
+          100% {
+            transform: rotate(720deg) translateX(4px) scale(1);
+            opacity: 0;
+          }
+        }
+        @keyframes wispSpinRescue {
+          0% {
+            transform: rotate(0deg) translateX(17px) scale(1.1);
+            opacity: 1;
+          }
+          88% {
+            opacity: 1;
+          }
+          100% {
+            transform: rotate(1080deg) translateX(3px) scale(1);
+            opacity: 0;
+          }
+        }
+        @keyframes wispRescueRing {
+          0% {
+            transform: scale(0.3);
+            opacity: 0.9;
+          }
+          100% {
+            transform: scale(1.7);
+            opacity: 0;
+          }
+        }
+      `}</style>
+    </>
+  );
+}

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -87,6 +87,14 @@ export function trackRewindUsed(params: {
   posthogAnalytics.trackRewindUsed(params);
 }
 
+export function trackWispCaught(params?: { mode?: "daily" | "normal" | "endless"; floor?: number; dateSeed?: string }) {
+  posthogAnalytics.trackWispCaught(params);
+}
+
+export function trackWispSave(params?: { mode?: "daily" | "normal" | "endless"; floor?: number; dateSeed?: string }) {
+  posthogAnalytics.trackWispSave(params);
+}
+
 export function trackPinkRealmReached(params?: { mode?: "daily" | "normal" | "endless"; floor?: number; dateSeed?: string }) {
   posthogAnalytics.trackPinkRealmReached(params);
 }

--- a/lib/map/constants.ts
+++ b/lib/map/constants.ts
@@ -177,6 +177,11 @@ export enum TileSubtype {
   // organic-mystical, and amber is literally preserved time. See lib/map/rewind.ts for the
   // snapshot ring buffer and .claude/features/amber-moth-rewind/index.md for the design.
   AMBER_MOTH = 71,
+  // A wisp curled up inside a pot, stamped at map generation (lib/map/wisp.ts
+  // stampWispPots) so the SAME pots hold wisps for every player on a daily seed.
+  // Never rendered — the marker only means "this pot releases a wisp when smashed";
+  // the wisp turn hook consumes it. Rides on [POT, WISP] like [POT, SNAKE] does.
+  WISP = 72,
 }
 
 /**

--- a/lib/map/endless.ts
+++ b/lib/map/endless.ts
@@ -7,6 +7,7 @@ import type { GateGroup, MapData } from "./types";
 import { findPlayerPosition } from "./player";
 import { addRunePotsForStoneExciters, generateCompleteMapForFloor } from "./map-features";
 import { addSnakesPerRules } from "./enemy-features";
+import { stampWispPots, WISP_STANDARD_CONFIG } from "./wisp";
 import { mulberry32, withPatchedMathRandom } from "../rng";
 import { rollEndlessBossOrder, type BossKind } from "../bosses/boss_roster";
 import { buildShaperArena, SHAPER_ENTRIES, SHAPER_LAYOUTS } from "../bosses/shaper_arena";
@@ -417,6 +418,9 @@ function buildEndlessFloor(
       e.kind = "fire-goblin";
     });
     placeCornerGhosts(mapData, enemies, DARK_FLOOR_GHOST_COUNT);
+    // Wisp pots exist on the blind floor too — a stamped pot's glow spilling out
+    // in the dark is the best sighting the mechanic has. Last in the stream.
+    stampWispPots(mapData);
     return { mapData, enemies };
   }
 
@@ -460,6 +464,8 @@ function buildEndlessFloor(
   const withRunes = addRunePotsForStoneExciters(mapData, enemies);
   // Snakes get the REAL floor: their spawn rules already scale past floor 6.
   const snakesAdded = addSnakesPerRules(withRunes, enemies, { floor });
+  // Wisp pots last in the seeded stream (same contract as the daily generators).
+  stampWispPots(withRunes);
   return { mapData: withRunes, enemies: snakesAdded };
 }
 
@@ -486,6 +492,9 @@ export function initializeGameStateForEndless(): GameState {
     chestKeyCount: 0,
     mode: "endless",
     allowCheckpoints: false,
+    // Wisps are live in endless: seeded pot stamps in buildEndlessFloor, plus the
+    // runtime enemy-drop and once-per-floor pity sources this config switches on.
+    wispConfig: WISP_STANDARD_CONFIG,
     currentFloor: 1,
     maxFloors: ENDLESS_MAX_FLOORS,
     endlessSeed,
@@ -556,6 +565,11 @@ export function advanceToNextEndlessFloor(currentState: GameState): GameState {
     hasExitKey: false, // Reset exit key for new floor
     portalLocation: undefined, // Reset placed portal — no backtracking between floors
     win: false,
+    // Wild wisps, trail and perch are positions on the floor being left behind;
+    // carried companions and the per-floor pity latch ride along via the spread.
+    wisps: undefined,
+    heroTrail: undefined,
+    wispPos: undefined,
     recentDeaths: [],
     recentBombBlasts: [],
     defeatedEnemies: [],

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -55,6 +55,13 @@ import {
 } from "./utils";
 import { addPlayerToMap, findPlayerPosition, removePlayerFromMapData } from "./player";
 import { recordRewindStep, type RewindSnapshot } from "./rewind";
+import {
+  advanceWispTurn,
+  stampWispPots,
+  WISP_STANDARD_CONFIG,
+  type WildWisp,
+  type WispConfig,
+} from "./wisp";
 import { computeTorchGlow } from "../torch_glow";
 import { addRunePotsForStoneExciters, generateCompleteMap, generateCompleteMapForFloor, allocateChestsAndKeys, rollWaterPlan } from "./map-features";
 import { addSnakesPerRules, addStaticGuardNearKey } from "./enemy-features";
@@ -1812,6 +1819,15 @@ export interface GameState {
   // only recorded while a charge is held. See lib/map/rewind.ts.
   rewindCharges?: number;
   rewindHistory?: RewindSnapshot[];
+  // Wisp life-regen companion (see lib/map/wisp.ts). Live in daily + endless
+  // (WISP_STANDARD_CONFIG) and the /test-wisp room; absent wispConfig keeps the whole
+  // system dormant in story/tutorial/legacy modes.
+  wispConfig?: WispConfig;
+  wisps?: WildWisp[]; // Wild, uncaught wisps drifting on the map
+  wispCompanions?: number; // Caught wisps carried as extra lives
+  wispPos?: [number, number]; // Carried wisp's current perch (render + rescue tug target)
+  heroTrail?: Array<[number, number]>; // Last few tiles the hero vacated, newest last
+  wispPityFloors?: number[]; // Floors whose once-per-floor pity wisp already appeared
   stats: {
     damageDealt: number;
     damageTaken: number;
@@ -2387,6 +2403,15 @@ export function initializeGameStateForMultiTier(
     gateGroups?: GateGroup[];
     switchGate?: DailySwitchGate;
   } = { mapData: withRunes };
+  // The day's wisp pots, baked into the map so the SAME pots hold wisps for every
+  // player on this seed. Placed after every other generation draw but immediately
+  // BEFORE the switch gate: the gate must stay the floor's final — and only
+  // conditional — draw, so its on/off toggle can never shift these stamps (the
+  // gates suite pins "enabling gates changes NOTHING else on the floor"). The
+  // draws /stats replays historically (chest allocation, boss kind) all happen
+  // earlier or on separate streams, so they stay true.
+  stampWispPots(withRunes);
+
   if (opts.switchGates) {
     maybePlaceSwitchGate(gateWiring, floor, findPlayerPosition(withRunes), {
       avoid: occupiedTiles(snakesAdded),
@@ -2406,6 +2431,9 @@ export function initializeGameStateForMultiTier(
     maxFloors: 3,
     mapData: withRunes,
     sealPayloads,
+    // Wisps are live in the daily: seeded pot stamps above, plus the runtime
+    // enemy-drop and once-per-floor pity sources this config switches on.
+    wispConfig: WISP_STANDARD_CONFIG,
     // Carried across floors: whether the feature is on for this run, and whether the day's one
     // gate has already been spent. advanceToNextFloor reads both.
     switchGatesEnabled: opts.switchGates ? true : undefined,
@@ -2688,6 +2716,14 @@ export function advanceToNextFloor(currentState: GameState, dailySeed: number): 
     mapData: withRunes,
     switchGate: currentState.switchGate,
   };
+  // Wisp pots for this floor. Immediately BEFORE the switch gate for the same reason
+  // as in initializeGameStateForMultiTier: the gate must stay the floor's final,
+  // conditional draw so its toggle never shifts these stamps. Gated on the run
+  // carrying a wisp config so legacy multi-floor modes don't grow markers.
+  if (currentState.wispConfig) {
+    withPatchedMathRandom(rng, () => stampWispPots(withRunes));
+  }
+
   if (currentState.switchGatesEnabled) {
     withPatchedMathRandom(rng, () =>
       maybePlaceSwitchGate(gateWiring, nextFloor, findPlayerPosition(withRunes), {
@@ -2719,6 +2755,12 @@ export function advanceToNextFloor(currentState: GameState, dailySeed: number): 
     bossArenaSeed: bossEntrance ? arenaSeedForEntrance(bossEntrance) : undefined,
     sealPayloads,
     dailyBossKind,
+    // Wild wisps, the hero's trail and the companion's perch are positions on the
+    // floor being left behind — reset. Carried companions and the per-floor pity
+    // latch (wispPityFloors, keyed by floor number) ride along via the spread.
+    wisps: undefined,
+    heroTrail: undefined,
+    wispPos: undefined,
     recentDeaths: [],
     recentBombBlasts: [], // don't carry a blast's VFX/shake into the next floor
     defeatedEnemies: [],
@@ -3727,12 +3769,15 @@ export function movePlayer(
   // Standing actions (throwing, using items) blind mist-covered enemies but deliberately
   // don't shift the cloud; the hero stirs it by walking through it.
   if (gameState.inPinkRealm && detonated.inPinkRealm) {
-    return withRewindStep(gameState, {
-      ...detonated,
-      mist: advanceMist(detonated.mist ?? [], detonated.mapData),
-    });
+    return withRewindStep(
+      gameState,
+      advanceWispTurn(gameState, {
+        ...detonated,
+        mist: advanceMist(detonated.mist ?? [], detonated.mapData),
+      })
+    );
   }
-  return withRewindStep(gameState, detonated);
+  return withRewindStep(gameState, advanceWispTurn(gameState, detonated));
 }
 
 /**

--- a/lib/map/wisp.ts
+++ b/lib/map/wisp.ts
@@ -1,0 +1,470 @@
+/**
+ * Wisps: little glowing lights that can be coaxed out of the dungeon, caught, and
+ * carried as a silent companion that trails the hero's footsteps. A carried wisp is a
+ * life: when the hero would die, one wisp spends itself — it whirls around the body,
+ * restores WISP_RESTORE_HEARTS hearts, and tugs the hero back onto the tile it was
+ * hovering over (which is always a tile the hero recently stood on, so a lava or
+ * spike death doesn't just re-kill them on the spot).
+ *
+ * PROTOTYPE STATUS: nothing spawns wisps outside /test-wisp. Every spawn source is
+ * gated on GameState.wispConfig, which only the test room sets. See
+ * .claude/features/wisp-life-regen/index.md for the brainstorm this is exploring.
+ *
+ * The core loop being tested:
+ *
+ *  - WILD wisps appear from a spawn source (smashed pot, a defeated enemy's spark,
+ *    or "pity" — one senses a hero at their last heart). They drift one tile per
+ *    hero step, floating 8-directionally over any floor tile, and gutter out after
+ *    `lifespan` steps — flashing for the last WISP_FLASH_MOVES so you know the
+ *    window is closing.
+ *  - Wisps are SHY OF FIRE. While the hero's torch is lit they wander aimlessly and
+ *    bolt when you get adjacent — catching one means cornering it. Douse your torch
+ *    and they invert: drawn to the dark hero, drifting closer each step until one
+ *    settles on you and is caught. (Snakes also hunt you in the dark. That's the
+ *    trade.)
+ *  - Catching = sharing a tile, from either side. Carried wisps cap at
+ *    WISP_MAX_COMPANIONS.
+ *
+ * Like rewind.ts, this module takes GameState as a TYPE-only import so
+ * game-state.ts -> wisp.ts stays a one-way edge with no runtime cycle.
+ */
+
+import { TileSubtype } from "./constants";
+import { findPlayerPosition } from "./player";
+import type { GameState } from "./game-state";
+
+/**
+ * Hearts a spent wisp restores (clamped to heroMaxHealth). 5 = a full heal for a
+ * base-health hero: three sometimes wasn't enough to survive the very next turn
+ * depending on what was killing you, and a rarer thing deserves a bigger reward.
+ */
+export const WISP_RESTORE_HEARTS = 5;
+/** Hero steps a wild wisp survives before guttering out. */
+export const WISP_DEFAULT_LIFESPAN = 12;
+/** A wild wisp flashes for its last N steps as a vanish warning. */
+export const WISP_FLASH_MOVES = 3;
+/** Hard ceiling on carried wisps (real modes cap lower via config). */
+export const WISP_MAX_COMPANIONS = 3;
+/** How many recently-vacated tiles the companion drifts between. */
+export const WISP_TRAIL_LENGTH = 3;
+/** A lit torch spooks wild wisps within this Chebyshev distance. */
+export const WISP_FLEE_RADIUS = 1;
+/** Chance a plain pot is stamped to hold a wisp at map generation (see stampWispPots). */
+export const WISP_POT_CHANCE = 0.03;
+/**
+ * Pity spawn distance band (Chebyshev): far enough to never be "right in front of
+ * you", close enough to be ON SCREEN — a 75%-that-fires-across-the-map would be a
+ * roll nobody ever witnesses. The glimpse at the edge of view, and the choice to
+ * chase it at one heart, is the whole moment.
+ */
+export const WISP_PITY_MIN_DIST = 4;
+export const WISP_PITY_MAX_DIST = 8;
+
+export interface WildWisp {
+  id: number;
+  y: number;
+  x: number;
+  /** Hero steps remaining before it gutters out. */
+  movesLeft: number;
+  /** Just spawned, hasn't drifted yet — the render layer plays its emerge spiral. */
+  fresh?: boolean;
+  /** Source tile it burst out of (a pot, a dying enemy) for the emerge animation. */
+  bornFrom?: [number, number];
+}
+
+/**
+ * Spawn-source tuning. A state with no wispConfig has the whole system dormant —
+ * that is what keeps story/tutorial/legacy modes untouched.
+ */
+export interface WispConfig {
+  /**
+   * TEST-ROOM ONLY: runtime chance [0..1] that any smashed pot releases a wisp.
+   * Real modes leave this unset — their wisp pots are STAMPED at map generation
+   * (stampWispPots) so the same pots hold wisps for every player on a daily seed.
+   */
+  potChance?: number;
+  /** Chance [0..1] that a defeated enemy leaves a wisp behind at its death tile. */
+  enemyDropChance?: number;
+  /**
+   * When true, the FIRST time each floor the hero falls to exactly 1 heart, a
+   * wisp is drawn out at the edge of view (4-8 tiles). Guaranteed, once per
+   * floor: deterministic (nothing to seed, fair across players) and a hard cap
+   * against yo-yo farming.
+   */
+  pity?: boolean;
+  /** Wild lifespan override in hero steps. */
+  lifespan?: number;
+  /** Carry cap for this mode (clamped to WISP_MAX_COMPANIONS). */
+  maxCompanions?: number;
+}
+
+/**
+ * The real-mode tuning (daily + endless), from the 2026-08-10 balance pass. With
+ * ~13 pots and ~27 enemies per daily run this lands around 1-1.5 wisp sightings
+ * per run, weighted toward the pity rescue; carrying one is roughly a coin flip
+ * on top (they expire and flee the torch), safely below Amber Moth frequency.
+ */
+export const WISP_STANDARD_CONFIG: WispConfig = {
+  enemyDropChance: 0.02,
+  pity: true,
+  maxCompanions: 1,
+};
+
+/** True when a wisp may float over this tile: any in-bounds floor tile. */
+function isFloatable(state: GameState, y: number, x: number): boolean {
+  const row = state.mapData.tiles[y];
+  return row !== undefined && row[x] === 0;
+}
+
+/** Safe to STAND on after a rescue tug: floatable and not lethal ground. */
+function isSafeLanding(state: GameState, y: number, x: number): boolean {
+  if (!isFloatable(state, y, x)) return false;
+  const subs = state.mapData.subtypes[y]?.[x] ?? [];
+  if (subs.includes(TileSubtype.LAVA) && !subs.includes(TileSubtype.OBSIDIAN))
+    return false;
+  if (subs.includes(TileSubtype.POT)) return false;
+  return !(state.enemies ?? []).some((e) => e.y === y && e.x === x);
+}
+
+const DIRS8: ReadonlyArray<readonly [number, number]> = [
+  [-1, -1], [-1, 0], [-1, 1],
+  [0, -1], [0, 1],
+  [1, -1], [1, 0], [1, 1],
+];
+
+function chebyshev(ay: number, ax: number, by: number, bx: number): number {
+  return Math.max(Math.abs(ay - by), Math.abs(ax - bx));
+}
+
+let nextWispId = 1;
+
+function spawnAt(y: number, x: number, lifespan: number): WildWisp {
+  return { id: nextWispId++, y, x, movesLeft: lifespan, fresh: true };
+}
+
+/**
+ * Stamp WISP markers into a floor's pots at map-generation time, so which pots
+ * hold wisps is part of the map itself — same pots for every player on the same
+ * seed. Plain pots only: snake and rune pots already have contents, and a pot
+ * should hold one surprise.
+ *
+ * MUST be called LAST in the floor's seeded RNG stream (after the map, seals,
+ * enemies, runes, snakes and switch gate), exactly like maybePlaceSwitchGate and
+ * for the same reason: every draw it makes lands after the existing draws, so
+ * turning wisps on cannot change what any past date replays to — the historical
+ * answers /stats gets by re-running the generators stay true.
+ *
+ * Mutates mapData in place (matching the other stamp* passes). Returns how many
+ * pots were stamped.
+ */
+export function stampWispPots(
+  mapData: GameState["mapData"],
+  chance: number = WISP_POT_CHANCE,
+  rng: () => number = Math.random
+): number {
+  let stamped = 0;
+  for (const row of mapData.subtypes) {
+    for (let x = 0; x < row.length; x++) {
+      const subs = row[x] ?? [];
+      if (!subs.includes(TileSubtype.POT)) continue;
+      if (
+        subs.includes(TileSubtype.SNAKE) ||
+        subs.includes(TileSubtype.RUNE) ||
+        subs.includes(TileSubtype.WISP)
+      ) {
+        continue;
+      }
+      if (rng() < chance) {
+        row[x] = [...subs, TileSubtype.WISP];
+        stamped++;
+      }
+    }
+  }
+  return stamped;
+}
+
+/**
+ * One wisp turn, run from the movePlayer wrapper against the pre-move and fully
+ * resolved post-move states. Returns `after` untouched (same reference) when the
+ * feature is dormant, so every ordinary run pays nothing.
+ *
+ * Order matters and mirrors how the play should read:
+ *  1. anything the hero just STEPPED ONTO is caught (walking onto a wisp is the
+ *     catch — it must not get a flee step first),
+ *  2. surviving wild wisps take their drift step and burn a move,
+ *  3. anything that drifted onto the hero is caught (the dark-attraction catch),
+ *  4. the world's events release new wisps (pots, sparks, pity) — they appear
+ *     beside their source and hold still for a beat before drifting,
+ *  5. the carried companion picks a new perch on the hero's trail.
+ */
+export function advanceWispTurn(
+  before: GameState,
+  after: GameState,
+  rng: () => number = Math.random
+): GameState {
+  const dormant =
+    !after.wispConfig &&
+    (after.wisps?.length ?? 0) === 0 &&
+    (after.wispCompanions ?? 0) === 0;
+  if (dormant) return after;
+
+  const moved = (after.stats?.steps ?? 0) > (before.stats?.steps ?? 0);
+  const heroPos = findPlayerPosition(after.mapData);
+  const config = after.wispConfig ?? {};
+  const lifespan = config.lifespan ?? WISP_DEFAULT_LIFESPAN;
+
+  // Positions are only meaningful on the map they were spawned on: drop any wisp
+  // whose tile stopped being floor (floor swap, wall bombed in reverse, etc.).
+  let wisps = (after.wisps ?? []).filter((w) =>
+    isFloatable(after, w.y, w.x)
+  );
+  let companions = after.wispCompanions ?? 0;
+
+  // Sharing the hero's tile = caught, from either side of the chase.
+  const carryCap = Math.min(
+    config.maxCompanions ?? WISP_MAX_COMPANIONS,
+    WISP_MAX_COMPANIONS
+  );
+  const catchOnHero = () => {
+    if (!heroPos) return;
+    const kept: WildWisp[] = [];
+    for (const w of wisps) {
+      if (companions < carryCap && w.y === heroPos[0] && w.x === heroPos[1]) {
+        companions += 1;
+      } else {
+        kept.push(w);
+      }
+    }
+    wisps = kept;
+  };
+
+  // --- 1. The hero stepped onto a wisp: caught before it can take a flee step.
+  catchOnHero();
+
+  // --- 2. Drift + burn (only when the hero actually stepped) -------------------
+  if (moved && heroPos) {
+    const torchLit = after.heroTorchLit !== false;
+    wisps = wisps
+      .map((w) => {
+        const options = DIRS8.map(([oy, ox]) => [w.y + oy, w.x + ox] as const)
+          .filter(([y, x]) => isFloatable(after, y, x));
+        let target: readonly [number, number] | undefined;
+        if (options.length > 0) {
+          if (!torchLit) {
+            // Drawn to the dark hero: the step that closes the most distance.
+            // Chebyshev first (that's what a caught-up wisp reads as), manhattan
+            // as the tie-break so the approach beelines instead of zig-zagging.
+            const score = ([y, x]: readonly [number, number]) =>
+              chebyshev(y, x, heroPos[0], heroPos[1]) * 100 +
+              Math.abs(y - heroPos[0]) +
+              Math.abs(x - heroPos[1]);
+            target = options.reduce((best, cur) =>
+              score(cur) < score(best) ? cur : best
+            );
+          } else if (
+            chebyshev(w.y, w.x, heroPos[0], heroPos[1]) <= WISP_FLEE_RADIUS
+          ) {
+            // Spooked by the flame: the step that opens the most distance.
+            target = options.reduce((best, cur) =>
+              chebyshev(cur[0], cur[1], heroPos[0], heroPos[1]) >
+              chebyshev(best[0], best[1], heroPos[0], heroPos[1])
+                ? cur
+                : best
+            );
+          } else {
+            target = options[Math.floor(rng() * options.length)];
+          }
+        }
+        return {
+          ...w,
+          y: target ? target[0] : w.y,
+          x: target ? target[1] : w.x,
+          movesLeft: w.movesLeft - 1,
+          // Its first drift step ends the emerge animation for good.
+          fresh: undefined,
+          bornFrom: undefined,
+        };
+      })
+      .filter((w) => w.movesLeft > 0);
+  }
+
+  // --- 3. A dark-drawn wisp drifted onto the hero: also caught. ----------------
+  catchOnHero();
+
+  // --- 4. Spawn sources --------------------------------------------------------
+  // New wisps appear NEXT TO their source tile (a pot bursts, the wisp flits out;
+  // and a walk-in smash must not drop it under the hero's feet for a free catch),
+  // and hold still until the next step.
+  const spawnBeside = (sy: number, sx: number) => {
+    const spots = DIRS8.map(([oy, ox]) => [sy + oy, sx + ox] as const).filter(
+      ([y, x]) =>
+        isFloatable(after, y, x) &&
+        !(heroPos && y === heroPos[0] && x === heroPos[1])
+    );
+    const [y, x] =
+      spots.length > 0 ? spots[Math.floor(rng() * spots.length)] : [sy, sx];
+    wisps = [...wisps, { ...spawnAt(y, x, lifespan), bornFrom: [sy, sx] }];
+  };
+
+  // Smashed pots: any tile that carried POT before the turn and doesn't after.
+  // Two ways a smashed pot releases a wisp:
+  //  - it was STAMPED at generation ([POT, WISP], the seeded 3%): guaranteed, and
+  //    the marker is consumed here (the smash paths only strip the POT tag);
+  //  - the test room's runtime potChance roll (real modes leave it unset).
+  const potChance = config.potChance ?? 0;
+  {
+    const beforeSubs = before.mapData.subtypes;
+    const afterSubs = after.mapData.subtypes;
+    for (let y = 0; y < beforeSubs.length; y++) {
+      for (let x = 0; x < beforeSubs[y].length; x++) {
+        const was = beforeSubs[y][x];
+        if (!was?.includes(TileSubtype.POT)) continue;
+        if (afterSubs[y]?.[x]?.includes(TileSubtype.POT)) continue;
+        if (was.includes(TileSubtype.WISP)) {
+          afterSubs[y][x] = (afterSubs[y][x] ?? []).filter(
+            (s) => s !== TileSubtype.WISP
+          );
+          spawnBeside(y, x);
+        } else if (potChance > 0 && rng() < potChance) {
+          spawnBeside(y, x);
+        }
+      }
+    }
+  }
+
+  // Enemy drops: recentDeaths is this tick's kill VFX list — the exact tiles.
+  const enemyDropChance = config.enemyDropChance ?? 0;
+  if (enemyDropChance > 0) {
+    for (const [dy, dx] of after.recentDeaths ?? []) {
+      if (rng() < enemyDropChance) spawnBeside(dy, dx);
+    }
+  }
+
+  // Pity: the FIRST time each floor the hero falls to exactly one heart,
+  // something small and bright notices — guaranteed, once per floor (see
+  // WispConfig.pity), spawning at the edge of view so you glimpse it and have to
+  // decide whether to chase a light while nearly dead. Latched only on a
+  // successful spawn, so a cramped map can retry on a later dip.
+  let wispPityFloors = after.wispPityFloors;
+  if (
+    config.pity &&
+    before.heroHealth > 1 &&
+    after.heroHealth === 1 &&
+    heroPos &&
+    !(wispPityFloors ?? []).includes(after.currentFloor ?? 1)
+  ) {
+    const span = WISP_PITY_MAX_DIST * 2 + 1;
+    for (let attempt = 0; attempt < 40; attempt++) {
+      const y = heroPos[0] + Math.floor(rng() * span) - WISP_PITY_MAX_DIST;
+      const x = heroPos[1] + Math.floor(rng() * span) - WISP_PITY_MAX_DIST;
+      const d = chebyshev(y, x, heroPos[0], heroPos[1]);
+      if (
+        d >= WISP_PITY_MIN_DIST &&
+        d <= WISP_PITY_MAX_DIST &&
+        isFloatable(after, y, x)
+      ) {
+        wisps = [...wisps, spawnAt(y, x, lifespan)];
+        wispPityFloors = [...(wispPityFloors ?? []), after.currentFloor ?? 1];
+        break;
+      }
+    }
+  }
+
+  // --- 5. Trail + companion perch ----------------------------------------------
+  // The trail is the last few tiles the hero VACATED, newest last — where the
+  // companion is allowed to hover. It reads as the wisp lagging half a beat behind.
+  let trail = after.heroTrail ?? [];
+  if (moved && heroPos) {
+    const beforePos = findPlayerPosition(before.mapData);
+    if (
+      beforePos &&
+      (beforePos[0] !== heroPos[0] || beforePos[1] !== heroPos[1])
+    ) {
+      const last = trail[trail.length - 1];
+      if (!last || last[0] !== beforePos[0] || last[1] !== beforePos[1]) {
+        trail = [...trail, [beforePos[0], beforePos[1]] as [number, number]].slice(
+          -WISP_TRAIL_LENGTH
+        );
+      }
+    }
+  }
+
+  let wispPos = after.wispPos;
+  if (companions > 0) {
+    const perches = trail.filter(([y, x]) => isFloatable(after, y, x));
+    if (perches.length > 0) {
+      wispPos = perches[Math.floor(rng() * perches.length)];
+    } else if (heroPos) {
+      wispPos = [heroPos[0], heroPos[1]];
+    }
+  } else {
+    wispPos = undefined;
+  }
+
+  return {
+    ...after,
+    wisps: wisps.length > 0 ? wisps : undefined,
+    wispCompanions: companions > 0 ? companions : undefined,
+    heroTrail: trail.length > 0 ? trail : undefined,
+    wispPos,
+    wispPityFloors,
+  };
+}
+
+/**
+ * The save itself. Non-null only when the hero is dead AND carrying a wisp: one
+ * companion is spent, WISP_RESTORE_HEARTS come back, and the hero is tugged onto
+ * the wisp's perch (or the nearest safe trail tile) so a ground-hazard death can't
+ * immediately repeat. Returns a fresh state object for React.
+ *
+ * Runs BEFORE the Amber Moth's death rewind in the component: the wisp is the
+ * cheaper save, so it goes first and the charm is preserved.
+ */
+export function wispDeathSave(state: GameState): GameState | null {
+  if (state.heroHealth > 0) return null;
+  const companions = state.wispCompanions ?? 0;
+  if (companions <= 0) return null;
+
+  const heroPos = findPlayerPosition(state.mapData);
+  if (!heroPos) return null;
+
+  const candidates: Array<[number, number]> = [];
+  if (state.wispPos) candidates.push(state.wispPos);
+  for (const t of [...(state.heroTrail ?? [])].reverse()) candidates.push(t);
+  const landing =
+    candidates.find(
+      ([y, x]) =>
+        (y !== heroPos[0] || x !== heroPos[1]) && isSafeLanding(state, y, x)
+    ) ?? null;
+
+  // Rebuild only the rows the tug touches; every other row is shared.
+  let subtypes = state.mapData.subtypes;
+  if (landing) {
+    subtypes = subtypes.map((row, y) => {
+      if (y !== heroPos[0] && y !== landing[0]) return row;
+      return row.map((subs, x) => {
+        if (y === heroPos[0] && x === heroPos[1]) {
+          return subs.filter((s) => s !== TileSubtype.PLAYER);
+        }
+        if (y === landing[0] && x === landing[1]) {
+          return subs.includes(TileSubtype.PLAYER)
+            ? subs
+            : [...subs, TileSubtype.PLAYER];
+        }
+        return subs;
+      });
+    });
+  }
+
+  const remaining = companions - 1;
+  return {
+    ...state,
+    mapData: { ...state.mapData, subtypes },
+    heroHealth: Math.min(WISP_RESTORE_HEARTS, state.heroMaxHealth ?? 5),
+    wispCompanions: remaining > 0 ? remaining : undefined,
+    // The spent wisp's perch is where the hero now stands; the survivors re-perch
+    // on the next step.
+    wispPos: remaining > 0 ? state.wispPos : undefined,
+    deathCause: undefined,
+  };
+}

--- a/lib/posthog_analytics.ts
+++ b/lib/posthog_analytics.ts
@@ -296,6 +296,23 @@ export function trackRewindUsed(params: {
   captureEvent('rewind_used', { ...params });
 }
 
+/**
+ * The wisp life-regen companion (lib/map/wisp.ts). Two events, one funnel:
+ * `wisp_caught` is a wild wisp joining the hero; `wisp_save` is a carried one
+ * spending itself on the death that would have ended the run. caught vs saved
+ * says how often the insurance is actually cashed in — the first number to watch
+ * when tuning rarity (target was ~1-1.5 sightings/run, carry in ~1/3 of runs).
+ * Sightings themselves aren't tracked: no reliable client signal for "the player
+ * noticed it" exists, so the funnel starts at the catch.
+ */
+export function trackWispCaught(params?: { mode?: "daily" | "normal" | "endless"; floor?: number; dateSeed?: string }) {
+  captureEvent('wisp_caught', { ...params });
+}
+
+export function trackWispSave(params?: { mode?: "daily" | "normal" | "endless"; floor?: number; dateSeed?: string }) {
+  captureEvent('wisp_save', { ...params });
+}
+
 export function trackPinkRealmReached(params?: { mode?: "daily" | "normal" | "endless"; floor?: number; dateSeed?: string }) {
   captureEvent('pink_realm_reached', { ...params });
 }


### PR DESCRIPTION
A non-chest revive companion, live in daily and endless.

**The mechanic**
- Wild wisps drift one tile per hero step, expire after 12 steps (flashing the last 3), and are shy of fire: they wander and bolt from a lit torch, but a dark hero draws them in — douse your torch and they come to you (while snakes hunt you; that's the trade).
- Sharing a tile catches one: it spins twice around the hero, then joins as a small light trailing your last few tiles. Carry cap 1 in real modes.
- When the hero would die, a carried wisp whirls around the body, restores 5 hearts, and tugs the hero back onto its perch so a lava/hazard death can't instantly repeat. Fires before the Amber Moth, so the cheaper save spends first. No splash screen — the spin happens on the board.

**Sources (~1–1.5 sightings per run)**
- 3% of plain pots, stamped at map generation (`[POT, WISP]`) so the same pots hold wisps for every player on a daily seed
- 2% of enemy kills leave a wisp at the death tile
- Guaranteed once-per-floor pity wisp, 4–8 tiles out at the edge of view, the first time each floor the hero falls to one heart

**Guardrails**
- The pot stamp draws immediately BEFORE the switch gate, keeping the gate the floor's final conditional draw (switch_gates suite pins this); historical /stats replays (chests, boss kind) are unaffected
- Story/tutorial stay dormant (no `wispConfig`)
- Pure CSS visuals, no art assets; `assetUrl` not needed. Sandbox at `/test-wisp`; `wisp_caught` / `wisp_save` analytics

Tests: 25 new in `__tests__/lib/wisp.test.ts`; full suite green (1,292); production build verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)