### PR TITLE
Fix wisp pot "?" glyph + rock-smash release; ease the Shaper wall mode

### DIFF
--- a/__tests__/components/WispPotRender.test.tsx
+++ b/__tests__/components/WispPotRender.test.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { Tile } from "../../components/Tile";
+import { TileSubtype } from "../../lib/map/constants";
+
+/**
+ * Regression: a wisp is stamped onto a pot as [POT, WISP] (see stampWispPots). WISP is a
+ * hidden payload the smash consumes — it must never draw its own glyph. Before the fix it
+ * fell through getFilteredSubtypes to the generic renderer and painted a gray "?" box on the
+ * pot tile (seen on the 2026-08-14 daily, floor 2).
+ */
+describe("wisp pot rendering", () => {
+  it("does not draw a placeholder glyph for the hidden WISP payload", () => {
+    render(
+      <Tile
+        tileId={0}
+        tileType={{ id: 0, name: "floor", color: "#222", walkable: true }}
+        isVisible={true}
+        neighbors={{ top: 0, right: 0, bottom: 0, left: 0 }}
+        subtype={[TileSubtype.POT, TileSubtype.WISP] as unknown as number[]}
+      />
+    );
+    // The hidden WISP payload (72) must not draw its own glyph box.
+    expect(screen.queryByTestId(`subtype-icon-${TileSubtype.WISP}`)).toBeNull();
+    // The pot itself still renders (its sprite reuses the subtype-icon-12 testid).
+    expect(screen.getByTestId(`subtype-icon-${TileSubtype.POT}`)).toBeInTheDocument();
+  });
+});

--- a/__tests__/lib/shaper.test.ts
+++ b/__tests__/lib/shaper.test.ts
@@ -386,6 +386,47 @@ describe("Shaper WALL strategy", () => {
   });
 });
 
+describe("Shaper LOS gate + self-melting walls", () => {
+  test("once it loses sight of you it stops raining fire on your live tile", () => {
+    const { state, shaper } = openArena(13, [6, 6], [2, 6]);
+    // A full wall across row 4 permanently breaks line-of-sight between the boss
+    // (rows 1-3) and the hero (rows 6-7) — it can't pace around it to re-acquire you.
+    for (let x = 1; x <= 11; x++) state.mapData.tiles[4][x] = 1;
+    const mem = shaper.behaviorMemory as Record<string, unknown>;
+    mem.alerted = true; // it already spotted you earlier this fight...
+    mem.strategy = "wall";
+    state.combatRng = () => 0.5;
+    // Oscillate below the wall for several turns. It can't see the hero and has no
+    // last-seen tile, so it must never telegraph fire or lay down any lava.
+    let s = state;
+    for (let t = 0; t < 6; t++) {
+      s = movePlayer(s, t % 2 === 0 ? Direction.DOWN : Direction.UP);
+      expect(
+        shaperPendingFire(s.enemies![0].behaviorMemory as Record<string, unknown>)
+      ).toBeNull();
+    }
+    expect(countSubtype(s, TileSubtype.LAVA)).toBe(0);
+  });
+
+  test("a fire rain-down melts one of its OWN adjacent walls into charred floor", () => {
+    const { state, shaper } = openArena(13, [6, 6], [2, 6]);
+    const mem = shaper.behaviorMemory as Record<string, unknown>;
+    mem.alerted = true;
+    mem.strategy = "wall";
+    // It built a wall at (2,7); a fire is telegraphed on the floor tile beside it.
+    state.mapData.tiles[2][7] = 1;
+    mem.builtWalls = [[2, 7]];
+    mem.pendingFire = { tiles: [[3, 7]] };
+    state.combatRng = () => 0.5;
+    const s = movePlayer(state, Direction.DOWN); // the fire rains down this turn
+    // Its own wall came down to charred floor...
+    expect(s.mapData.tiles[2][7]).toBe(0);
+    expect(s.mapData.subtypes[2][7]).toContain(TileSubtype.SINGED);
+    // ...and the lava landed where it was telegraphed.
+    expect(s.mapData.subtypes[3][7]).toContain(TileSubtype.LAVA);
+  });
+});
+
 function forceStrat(s: GameState, strat: "drowning" | "wall"): void {
   (s.enemies![0].behaviorMemory as Record<string, unknown>).strategy = strat;
 }

--- a/__tests__/lib/wisp.test.ts
+++ b/__tests__/lib/wisp.test.ts
@@ -1,6 +1,7 @@
 import { TileSubtype, Direction } from "../../lib/map";
 import {
   movePlayer,
+  performThrowRock,
   initializeGameStateForMultiTier,
 } from "../../lib/map/game-state";
 import type { GameState } from "../../lib/map/game-state";
@@ -211,6 +212,22 @@ describe("spawning", () => {
     const after = movePlayer(state, Direction.RIGHT); // smash by walking in
     expect(after.wisps).toHaveLength(1);
     expect(after.mapData.subtypes[5][2]).not.toContain(TileSubtype.WISP);
+  });
+
+  it("a stamped wisp pot smashed by a THROWN ROCK also releases its wisp", () => {
+    // Regression: advanceWispTurn was wired only into movePlayer, so a rock-smashed
+    // wisp pot silently released nothing. The hero (5,1) faces RIGHT; the rock flies
+    // east and shatters the pot at (5,3).
+    const state = baseState({
+      wispConfig: {},
+      rockCount: 1,
+      combatRng: () => 0.5,
+    });
+    state.mapData.subtypes[5][3] = [TileSubtype.POT, TileSubtype.WISP];
+    const after = performThrowRock(state);
+    expect(after.wisps).toHaveLength(1);
+    expect(after.mapData.subtypes[5][3]).not.toContain(TileSubtype.WISP);
+    expect(after.mapData.subtypes[5][3]).not.toContain(TileSubtype.POT);
   });
 
   it("falling to exactly 1 heart draws a pity wisp out at the edge of view", () => {

--- a/components/Tile.tsx
+++ b/components/Tile.tsx
@@ -880,6 +880,11 @@ export const Tile: React.FC<TileProps> = ({
         subtype !== TileSubtype.MED &&
         subtype !== TileSubtype.RUNE &&
         subtype !== TileSubtype.SNAKE &&
+        // WISP rides on a pot as [POT, WISP] exactly like [POT, SNAKE] (see
+        // stampWispPots). It is a hidden payload the smash consumes, never drawn —
+        // without this it falls through to the generic renderer and paints a gray
+        // "?" glyph on the pot tile.
+        subtype !== TileSubtype.WISP &&
         subtype !== TileSubtype.WALL_TORCH &&
         subtype !== TileSubtype.TOWN_SIGN &&
         subtype !== TileSubtype.PORTAL &&

--- a/lib/bosses/shaper.ts
+++ b/lib/bosses/shaper.ts
@@ -50,8 +50,8 @@ const SHAPER_IDLE_MAX_TILES = 3;
 // into torch-snuffing DEEP water that slows your approach), then LAUNCH FIRE
 // (telegraphed — it rockets up, glowing target tiles appear), then next turn the
 // FIRE RAINS DOWN as lethal lava on those tiles. Fire actively avoids water.
-const SHAPER_FIRE_MIN_TILES = 4;
-const SHAPER_FIRE_MAX_TILES = 6;
+const SHAPER_FIRE_MIN_TILES = 3;
+const SHAPER_FIRE_MAX_TILES = 4;
 const SHAPER_FIRE_WATER_HIT_CHANCE = 0.15; // fire mostly avoids water tiles
 
 // Per-encounter STRATEGY, rolled once when it first spots you (a tendency, not a
@@ -63,6 +63,16 @@ export type ShaperStrategy = "drowning" | "wall";
 const SHAPER_WALL_STRATEGY_CHANCE = 0.45; // else drowning
 const SHAPER_WALL_LAVA_MIX = 0.3; // wall strategy: chance to lob fire instead of a wall
 const SHAPER_DROWNING_PILLAR_CHANCE = 0.15; // drowning strategy: chance of a lone pillar
+// Wall strategy: minimum turns between fire lobs. Without this, a losing wall race
+// (every blocked build fell straight through to a fire) blanketed the whole room in
+// lava — during the cooldown a blocked build paces/holds instead of adding a patch.
+const SHAPER_WALL_FIRE_COOLDOWN = 2;
+// Out of line-of-sight the boss can't rain fire on your live tile every turn. It
+// lobs the occasional splatter toward where it LAST saw you, this many turns apart.
+const SHAPER_SEARCH_FIRE_COOLDOWN = 3;
+// How many of its OWN walls a fire rain-down melts to charred floor, opening the maze
+// it built. Only its own tracked walls, never the arena structure or the map border.
+const SHAPER_FIRE_WALL_MELT = 1;
 
 export type ShaperElement = "lava" | "water";
 export type ShaperShape = "path" | "splatter";
@@ -100,6 +110,14 @@ interface ShaperMemory {
   // A wall it raised this turn (for the stone-rise flash + shake).
   lastWall?: { nonce: number; tiles: Array<[number, number]> } | null;
   lastAttack?: { nonce: number; element: ShaperElement; tiles: Array<[number, number]> } | null;
+  // Last tile it actually SAW the hero on (LOS). An out-of-sight boss aims its
+  // occasional searching fire here instead of tracking the live hero through walls.
+  lastSeen?: { y: number; x: number };
+  // Turns remaining before it may lob fire again (wall strategy + searching).
+  fireCooldown?: number;
+  // Every wall it has raised and not yet melted — so its own lava can bring them down
+  // (meltOwnWallsNearFire) without ever touching the arena's structural walls.
+  builtWalls?: Array<[number, number]>;
 }
 
 const FLOOR = 0;
@@ -511,6 +529,7 @@ function tryBuildWall(
     grid[y][x] = WALL;
     subs[y][x] = [];
     mem.lastWall = { nonce: mem.turn ?? 0, tiles: [[y, x]] };
+    (mem.builtWalls = mem.builtWalls ?? []).push([y, x]);
     return true;
   }
   return false;
@@ -530,6 +549,63 @@ function launchFire(
   const tiles = fireTargets(boss, aim, ctx.grid, subs, rng);
   mem.pendingFire = tiles.length > 0 ? { tiles } : null;
   if (tiles.length > 0) mem.fireLaunchNonce = mem.turn;
+}
+
+// Alerted but currently blind: lob an occasional fire toward the LAST tile it saw the
+// hero on (never the live hero — it can't see them), spaced by a cooldown, and pace
+// the chamber the rest of the time. This is the "don't rain lava on me through a wall"
+// behaviour that makes breaking line-of-sight actually mean something.
+function searchOutOfSight(
+  ctx: BehaviorContext,
+  mem: ShaperMemory,
+  boss: { y: number; x: number },
+  hero: { y: number; x: number },
+  heroNext: { y: number; x: number },
+  rng: () => number
+): void {
+  if ((mem.fireCooldown ?? 0) <= 0 && mem.lastSeen) {
+    launchFire(ctx, mem, boss, mem.lastSeen, rng);
+    mem.fireCooldown = SHAPER_SEARCH_FIRE_COOLDOWN;
+    return;
+  }
+  const dirs: Array<[number, number]> = [[-1, 0], [1, 0], [0, -1], [0, 1]];
+  const start = Math.floor(rng() * 4);
+  tryStep(ctx, mem, hero, heroNext, [0, 1, 2, 3].map((i) => dirs[(start + i) % 4]));
+}
+
+// A fire rain-down melts up to SHAPER_FIRE_WALL_MELT of the Shaper's OWN walls that
+// border the blast into charred floor — its lava opens the maze it built. Only its
+// tracked walls (never the arena's structural walls) and never the map border, so it
+// can neither breach the room nor seal itself in.
+function meltOwnWallsNearFire(
+  ctx: BehaviorContext,
+  mem: ShaperMemory,
+  fireTiles: Array<[number, number]>
+): void {
+  const subs = ctx.subtypes;
+  if (!subs || !mem.builtWalls || mem.builtWalls.length === 0) return;
+  const near = new Set<string>();
+  for (const [fy, fx] of fireTiles) {
+    for (const [dy, dx] of [[0, 0], [-1, 0], [1, 0], [0, -1], [0, 1]] as Array<[number, number]>) {
+      near.add(`${fy + dy},${fx + dx}`);
+    }
+  }
+  const melts: ShaperMutation[] = [];
+  const kept: Array<[number, number]> = [];
+  for (const [wy, wx] of mem.builtWalls) {
+    if (ctx.grid[wy]?.[wx] !== WALL) continue; // already gone
+    if (
+      melts.length < SHAPER_FIRE_WALL_MELT &&
+      near.has(`${wy},${wx}`) &&
+      !isBorder(ctx.grid, wy, wx)
+    ) {
+      melts.push({ y: wy, x: wx, sub: TileSubtype.SINGED });
+    } else {
+      kept.push([wy, wx]);
+    }
+  }
+  mem.builtWalls = kept;
+  if (melts.length > 0) executeShaperAttack(melts, ctx.grid, subs);
 }
 
 // A tile the boss may stand on while pacing/retreating: floor/flowers, safe
@@ -630,37 +706,67 @@ export function shaperUpdate(ctx: BehaviorContext): number {
   ctx.enemy.facing =
     Math.abs(dy) >= Math.abs(dx) ? (dy < 0 ? "UP" : "DOWN") : dx < 0 ? "LEFT" : "RIGHT";
 
-  // Latch the alert state once it gets line-of-sight within vision range, and
-  // roll a per-encounter strategy (unless one was pre-set).
-  if (!mem.alerted) {
-    const inRange = Math.abs(dy) + Math.abs(dx) <= SHAPER_VISION;
-    if (inRange && canSee(ctx.grid, [boss.y, boss.x], [hero.y, hero.x])) {
-      mem.alerted = true;
-      if (mem.strategy == null) {
-        mem.strategy = rng() < SHAPER_WALL_STRATEGY_CHANCE ? "wall" : "drowning";
-      }
+  // Current line-of-sight to the hero. It LATCHES `alerted` on the first sighting (so
+  // the boss never forgets you), but whether it actively presses the attack is
+  // re-decided every turn from `seesNow` — a hero who breaks sight is no longer rained
+  // on directly, which is what stops lava tracking you through walls.
+  const inVision = Math.abs(dy) + Math.abs(dx) <= SHAPER_VISION;
+  const seesNow = inVision && canSee(ctx.grid, [boss.y, boss.x], [hero.y, hero.x]);
+  if (!mem.alerted && seesNow) {
+    mem.alerted = true;
+    if (mem.strategy == null) {
+      mem.strategy = rng() < SHAPER_WALL_STRATEGY_CHANCE ? "wall" : "drowning";
     }
   }
+  if (seesNow) mem.lastSeen = { y: hero.y, x: hero.x };
 
   if (mem.alerted) {
-    // A fire launched last turn RAINS DOWN now (before the hero's move), turning
-    // the telegraphed tiles to lethal lava. The player had this turn's warning.
+    // A fire launched last turn RAINS DOWN now (before the hero's move), turning the
+    // telegraphed tiles to lethal lava. The player had this turn's warning. The same
+    // rain-down eats into the walls the Shaper itself built (meltOwnWallsNearFire), so
+    // a wall-mode fight can't be fenced into a permanent lava box.
     if (mem.pendingFire) {
-      const muts = floodTiles("lava", mem.pendingFire.tiles, ctx.grid, subs);
+      const fireTiles = mem.pendingFire.tiles;
+      const muts = floodTiles("lava", fireTiles, ctx.grid, subs);
       if (muts.length > 0) {
         executeShaperAttack(muts, ctx.grid, subs);
         mem.lastAttack = { nonce: (mem.turn ?? 0) * 100 + 9, element: "lava", tiles: muts.map((m) => [m.y, m.x]) };
       }
+      meltOwnWallsNearFire(ctx, mem, fireTiles);
       mem.pendingFire = null;
       return 0;
     }
 
+    // Fire is rate-limited now; tick its cooldown down each alerted turn.
+    if ((mem.fireCooldown ?? 0) > 0) mem.fireCooldown = (mem.fireCooldown ?? 0) - 1;
+
+    // OUT OF SIGHT: it can't see you, so it does NOT get to rain fire on your live
+    // tile. It lobs the occasional splatter toward where it LAST saw you (stale +
+    // jittered = spread out, never tracking) and paces the rest of the time.
+    if (!seesNow) {
+      searchOutOfSight(ctx, mem, boss, hero, heroNext, rng);
+      return 0;
+    }
+
     if (mem.strategy === "wall") {
-      // WALL: raise a wall to fence you off; if it can't extend one (would seal
-      // you out, or no dry ground) — or on its lava-mix tendency — it lobs fire.
-      const wantsFire = rng() < SHAPER_WALL_LAVA_MIX;
+      // WALL: raise a wall to fence you off; if it can't extend one (would seal you
+      // out, or no dry ground) — or on its lava-mix tendency — it lobs fire, but no
+      // more often than SHAPER_WALL_FIRE_COOLDOWN so it can't blanket the room.
+      const canFire = (mem.fireCooldown ?? 0) <= 0;
+      const wantsFire = canFire && rng() < SHAPER_WALL_LAVA_MIX;
       const built = wantsFire ? false : tryBuildWall(ctx, mem, hero, heroNext, boss);
-      if (!built) launchFire(ctx, mem, boss, heroNext, rng);
+      if (!built) {
+        if (canFire) {
+          launchFire(ctx, mem, boss, heroNext, rng);
+          mem.fireCooldown = SHAPER_WALL_FIRE_COOLDOWN;
+        } else {
+          // Can't build here and still cooling from the last fire — pace rather than
+          // lay down yet another lava patch.
+          const dirs: Array<[number, number]> = [[-1, 0], [1, 0], [0, -1], [0, 1]];
+          const start = Math.floor(rng() * 4);
+          tryStep(ctx, mem, hero, heroNext, [0, 1, 2, 3].map((i) => dirs[(start + i) % 4]));
+        }
+      }
       return 0;
     }
 

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -619,7 +619,12 @@ export function performThrowRock(gameState: GameState): GameState {
   const bossesBefore = snapshotBosses(gameState);
   const result = performThrowRockCore(gameState);
   resolveBossDefeat(result, bossesBefore);
-  return result;
+  // A thrown rock can smash a [POT, WISP] pot (or kill an enemy that drops a wisp) —
+  // both are wisp release sources. advanceWispTurn is otherwise wired only into
+  // movePlayer, so without this a rock-smashed wisp pot silently releases nothing.
+  // No hero step this turn, so its drift/pity legs are inert; only the smashed-pot
+  // and enemy-death release detection fires. Dormant (no wispConfig) => no-op.
+  return advanceWispTurn(gameState, result);
 }
 
 /**


### PR DESCRIPTION
Three daily-facing fixes (all reproduce on the live daily), each with tests. Full suite green (1296 passing), production build clean.

## 1. Wisp pot painted a gray "?" box
`WISP` (72) was missing from `getFilteredSubtypes` in `Tile.tsx`, so a stamped `[POT, WISP]` pot rendered the fallback "?" glyph (it's a hidden payload like `SNAKE`). Excluded it. Repro'd on 2026-08-14 L2 at grid (20,20).

## 2. Wisp pots smashed by a thrown rock released nothing
`advanceWispTurn` was wired only into `movePlayer`, so a rock-smashed wisp pot (or a rock kill) released no wisp. Now also runs after `performThrowRock`. No-op in modes without wisps.

## 3. The Shaper's wall strategy was near-unbeatable
- **LOS gate:** the every-turn assault now requires *current* line-of-sight — once you break sight it stops raining lava on your live tile (it lobs occasional, spread-out fire at your last-known spot instead). `mem.alerted` previously latched forever with no LOS re-check.
- **Less lava:** a fire cooldown ends the "wall race → fire every turn" runaway; each fire shrank from 4-6 to 3-4 tiles.
- **Self-melting walls:** rain-down lava now melts up to one of its *own* walls bordering the blast, so the arena can't fill with lava. Only its own walls, never arena structure or the border.

Existing wall-safety invariants (never seals the hero out, fire always leaves an escape) preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)