### PR TITLE
Enforce a 3-4 tile lava buffer around boss entrances

### DIFF
--- a/__tests__/lib/boss_entrances.test.ts
+++ b/__tests__/lib/boss_entrances.test.ts
@@ -197,6 +197,52 @@ describe("moat approach in a real Level-3 room", () => {
       }
     }
   });
+
+  test("entrance keeps a 3+ tile lava buffer on every accessible side", () => {
+    const dirs: Array<[number, number]> = [[-1, 0], [1, 0], [0, -1], [0, 1]];
+    for (let i = 0; i < 8; i++) {
+      const s = buildMoatApproach("lava");
+      const entrance = findSubtype(s, TileSubtype.BOSS_ENTRANCE);
+      if (!entrance) continue; // corner-moat fallback day — no spur to measure
+      const [ey, ex] = entrance;
+      const subs = s.mapData.subtypes;
+      const isLava = (y: number, x: number) => subs[y]?.[x]?.includes(TileSubtype.LAVA) ?? false;
+      if (!dirs.some(([dy, dx]) => isLava(ey + dy, ex + dx))) continue; // fallback moat
+      // BFS through lava from the entrance: dist = rocks needed to stand there.
+      const dist = new Map<string, number>();
+      let frontier: Array<[number, number]> = [];
+      for (const [dy, dx] of dirs) {
+        if (isLava(ey + dy, ex + dx)) {
+          dist.set(`${ey + dy},${ex + dx}`, 1);
+          frontier.push([ey + dy, ex + dx]);
+        }
+      }
+      while (frontier.length) {
+        const next: Array<[number, number]> = [];
+        for (const [fy, fx] of frontier) {
+          const d = dist.get(`${fy},${fx}`)!;
+          for (const [dy, dx] of dirs) {
+            const key = `${fy + dy},${fx + dx}`;
+            if (!isLava(fy + dy, fx + dx) || dist.has(key)) continue;
+            dist.set(key, d + 1);
+            next.push([fy + dy, fx + dx]);
+          }
+        }
+        frontier = next;
+      }
+      // Any lava tile bordering dry-reachable ground must be >= 3 rocks from the entrance.
+      const dry = dryReachableFrom(s, findHero(s));
+      for (const [key, d] of dist) {
+        const [ly, lx] = key.split(",").map(Number);
+        const bordersDry = dirs.some(
+          ([dy, dx]) => dry.has(`${ly + dy},${lx + dx}`) && !isLava(ly + dy, lx + dx)
+        );
+        if (bordersDry) {
+          expect(d).toBeGreaterThanOrEqual(3);
+        }
+      }
+    }
+  });
 });
 
 describe("outside world is no longer a boss route", () => {

--- a/lib/bosses/boss_entrances.ts
+++ b/lib/bosses/boss_entrances.ts
@@ -307,6 +307,96 @@ function growLavaPool(
 }
 
 /**
+ * After the pool is grown, guarantee a MINIMUM lava buffer around the entrance:
+ * every reachable dry tile must be at least `minBuffer` lava tiles away from the
+ * entrance (measured 4-directionally, the way rocks cool a path). The organic pool
+ * growth alone can leave 1-2 tile-thick sides that turn the intended 4-6 rock
+ * crossing into a 1-2 rock shortcut. Thin spots are fixed by converting the
+ * offending dry tiles to lava (connectivity-checked); returns false if any thin
+ * spot can't be thickened, so the caller rejects this placement.
+ */
+function enforceLavaBuffer(
+  trial: MapData,
+  ey: number,
+  ex: number,
+  before: Set<string>,
+  carved: Set<string>,
+  keepDry: Set<string>,
+  hy: number,
+  hx: number,
+  minBuffer: number
+): boolean {
+  const H = trial.tiles.length;
+  const W = trial.tiles[0].length;
+  const dirs4: Array<[number, number]> = [[-1, 0], [1, 0], [0, -1], [0, 1]];
+  const isLava = (y: number, x: number): boolean =>
+    (trial.subtypes[y]?.[x] ?? []).includes(TileSubtype.LAVA);
+  // Each pass may push the lava boundary one ring outward, so a few passes settle it.
+  for (let pass = 0; pass < minBuffer + 2; pass++) {
+    // BFS through lava from the entrance: dist = rocks needed to reach that tile.
+    const dist = new Map<string, number>();
+    let frontier: Array<[number, number]> = [];
+    for (const [dy, dx] of dirs4) {
+      const ny = ey + dy;
+      const nx = ex + dx;
+      if (isLava(ny, nx)) {
+        dist.set(`${ny},${nx}`, 1);
+        frontier.push([ny, nx]);
+      }
+    }
+    while (frontier.length) {
+      const next: Array<[number, number]> = [];
+      for (const [fy, fx] of frontier) {
+        const d = dist.get(`${fy},${fx}`)!;
+        for (const [dy, dx] of dirs4) {
+          const ny = fy + dy;
+          const nx = fx + dx;
+          const key = `${ny},${nx}`;
+          if (!isLava(ny, nx) || dist.has(key)) continue;
+          dist.set(key, d + 1);
+          next.push([ny, nx]);
+        }
+      }
+      frontier = next;
+    }
+    // Dry reachable tiles touching lava closer than the buffer = shortcut spots.
+    const reach = floodReachable(trial, hy, hx);
+    const thin = new Set<string>();
+    for (const [key, d] of dist) {
+      if (d >= minBuffer) continue;
+      const [ly, lx] = key.split(",").map(Number);
+      for (const [dy, dx] of dirs4) {
+        const ny = ly + dy;
+        const nx = lx + dx;
+        const nkey = `${ny},${nx}`;
+        if (reach.has(nkey) && !isLava(ny, nx)) thin.add(nkey);
+      }
+    }
+    if (thin.size === 0) return true;
+    for (const key of thin) {
+      const [y, x] = key.split(",").map(Number);
+      if (y < 1 || x < 1 || y >= H - 1 || x >= W - 1) return false;
+      if (keepDry.has(key)) return false;
+      const t = trial.tiles[y][x];
+      if (t !== WALL && t !== FLOOR) return false;
+      const s = trial.subtypes[y][x] ?? [];
+      if (s.some((sv) => PROTECTED_SUBS.includes(sv) || ELEMENTAL_SUBS.includes(sv))) {
+        return false;
+      }
+      trial.tiles[y][x] = FLOOR;
+      trial.subtypes[y][x] = [TileSubtype.LAVA];
+      carved.add(key);
+      const after = floodReachable(trial, hy, hx);
+      for (const k of before) {
+        if (carved.has(k)) continue;
+        if (!after.has(k)) return false; // walled something off — reject placement
+      }
+    }
+  }
+  return false;
+}
+
+/**
  * Carve a STRAIGHT, 1-wide lava channel as a dead-end spur ending in the boss
  * entrance, so the hero crosses it in a single straight line (cool the tile ahead,
  * step onto it, repeat — never turning, which over lava = instant death). Only
@@ -387,6 +477,13 @@ function stampStraightLavaSpur(map: MapData, channelLen: number): boolean {
         `${ty - 2 * dy},${tx - 2 * dx}`,
       ]);
       growLavaPool(trial, channel, before, carved, keepDry, hy, hx);
+      // The grown pool can still leave 1-2 tile-thick sides near the entrance — a
+      // cheap shortcut past the intended 4-6 rock crossing. Guarantee a 3-4 tile
+      // lava buffer on every accessible side, or reject this placement.
+      const minBuffer = 3 + Math.floor(Math.random() * 2);
+      if (!enforceLavaBuffer(trial, ey, ex, before, carved, keepDry, hy, hx, minBuffer)) {
+        continue;
+      }
       map.tiles = trial.tiles;
       map.subtypes = trial.subtypes;
       return true;


### PR DESCRIPTION
Lava boss entrances were supposed to cost 5-6 rocks to reach, but commonly had 1-2 tile-wide sides that let you cross in 1-2 rocks.

**Cause:** the straight spur only guaranteed the 4-6 rock cost along its own axis. The pool-dressing pass grows at most 2 rings outward and randomly skips tiles for a ragged edge, so the entrance often ended up 1-2 lava tiles from dry floor on a side.

**Fix:** `enforceLavaBuffer` runs after the pool is grown. It BFS-walks the lava from the entrance 4-directionally (distance = rocks needed) and converts any dry-reachable tile within 3-4 tiles of the entrance to lava, using the same connectivity check as the rest of the generator so it can never wall off a legitimate part of the room. If a thin spot can't be thickened, the placement is rejected and the generator retries — placement rate stays >90% over a 40-floor sweep.

Typecheck + build clean; all 25 boss-entrance tests pass, including a new test asserting every dry-adjacent lava tile is >=3 rocks from the entrance.