### PR TITLE
Give torch-lit wisps variable flee behavior

### DIFF
--- a/__tests__/lib/wisp.test.ts
+++ b/__tests__/lib/wisp.test.ts
@@ -7,6 +7,7 @@ import {
 import type { GameState } from "../../lib/map/game-state";
 import {
   WISP_DEFAULT_LIFESPAN,
+  WISP_FLEE_CHANCE,
   WISP_MAX_COMPANIONS,
   WISP_PITY_MAX_DIST,
   WISP_PITY_MIN_DIST,
@@ -128,11 +129,34 @@ describe("drift", () => {
       wispConfig: {},
       wisps: [wisp(5, 3)], // will be adjacent to the hero's landing tile (5,2)
     });
+    const random = jest
+      .spyOn(Math, "random")
+      .mockReturnValue(WISP_FLEE_CHANCE - 0.01);
     const after = movePlayer(state, Direction.RIGHT);
+    random.mockRestore();
     const w = after.wisps?.[0];
     expect(w).toBeDefined();
     const d = Math.max(Math.abs(w!.y - 5), Math.abs(w!.x - 2));
     expect(d).toBeGreaterThan(1);
+  });
+
+  it("an adjacent wisp sometimes hesitates instead of fleeing a lit torch", () => {
+    const before = baseState({
+      wispConfig: {},
+      wisps: [wisp(5, 3)],
+    });
+    const afterMove = movePlayer(
+      baseState({ wispConfig: {}, wisps: [] }),
+      Direction.RIGHT
+    );
+    afterMove.wisps = before.wisps;
+
+    // First draw declines the 75% flee; second draw selects the added hold option.
+    const draws = [WISP_FLEE_CHANCE, 0];
+    const after = advanceWispTurn(before, afterMove, () => draws.shift() ?? 0);
+
+    expect(after.wisps?.[0]).toMatchObject({ y: 5, x: 3 });
+    expect(after.wisps?.[0]?.movesLeft).toBe(WISP_DEFAULT_LIFESPAN - 1);
   });
 
   it("in the dark, a far wisp closes distance every step", () => {

--- a/lib/map/wisp.ts
+++ b/lib/map/wisp.ts
@@ -18,7 +18,8 @@
  *    `lifespan` steps — flashing for the last WISP_FLASH_MOVES so you know the
  *    window is closing.
  *  - Wisps are SHY OF FIRE. While the hero's torch is lit they wander aimlessly and
- *    bolt when you get adjacent — catching one means cornering it. Douse your torch
+ *    usually bolt when you get adjacent, though they sometimes hesitate or flutter
+ *    another way. Douse your torch
  *    and they invert: drawn to the dark hero, drifting closer each step until one
  *    settles on you and is caught. (Snakes also hunt you in the dark. That's the
  *    trade.)
@@ -49,6 +50,8 @@ export const WISP_MAX_COMPANIONS = 3;
 export const WISP_TRAIL_LENGTH = 3;
 /** A lit torch spooks wild wisps within this Chebyshev distance. */
 export const WISP_FLEE_RADIUS = 1;
+/** Chance a nearby wild wisp actively flees a lit torch on each drift step. */
+export const WISP_FLEE_CHANCE = 0.75;
 /** Chance a plain pot is stamped to hold a wisp at map generation (see stampWispPots). */
 export const WISP_POT_CHANCE = 0.03;
 /**
@@ -264,13 +267,36 @@ export function advanceWispTurn(
           } else if (
             chebyshev(w.y, w.x, heroPos[0], heroPos[1]) <= WISP_FLEE_RADIUS
           ) {
-            // Spooked by the flame: the step that opens the most distance.
-            target = options.reduce((best, cur) =>
-              chebyshev(cur[0], cur[1], heroPos[0], heroPos[1]) >
-              chebyshev(best[0], best[1], heroPos[0], heroPos[1])
-                ? cur
-                : best
+            const currentDistance = chebyshev(
+              w.y,
+              w.x,
+              heroPos[0],
+              heroPos[1]
             );
+            if (rng() < WISP_FLEE_CHANCE) {
+              // Usually spooked by the flame: take the step that opens the most
+              // distance, preserving the original flee behavior.
+              target = options.reduce((best, cur) =>
+                chebyshev(cur[0], cur[1], heroPos[0], heroPos[1]) >
+                chebyshev(best[0], best[1], heroPos[0], heroPos[1])
+                  ? cur
+                  : best
+              );
+            } else {
+              // Sometimes the wisp falters instead. Include its current tile and
+              // only moves that do not open distance, so this branch can hold,
+              // drift sideways, or even venture toward the hero without secretly
+              // increasing the effective flee chance above 75%.
+              const nonFleeOptions: ReadonlyArray<readonly [number, number]> = [
+                [w.y, w.x],
+                ...options.filter(
+                  ([y, x]) =>
+                    chebyshev(y, x, heroPos[0], heroPos[1]) <= currentDistance
+                ),
+              ];
+              target =
+                nonFleeOptions[Math.floor(rng() * nonFleeOptions.length)];
+            }
           } else {
             target = options[Math.floor(rng() * options.length)];
           }


### PR DESCRIPTION
### Motivation
- Wild wisps were deterministically fleeing any time the hero's torch was lit which made cornering them very brittle when the torch is on. 
- Introduce variability so a lit-torch wisp flees most of the time but occasionally hesitates or moves non-fleeing ways to make capture less binary.

### Description
- Add a new tuning constant `WISP_FLEE_CHANCE` (default `0.75`) and update the docs comment to reflect the probabilistic behavior in `lib/map/wisp.ts`.
- Modify `advanceWispTurn` in `lib/map/wisp.ts` so that when a wisp is within `WISP_FLEE_RADIUS` it flees only if `rng() < WISP_FLEE_CHANCE`, otherwise it may hold, drift sideways, or even move toward the hero by sampling from non-flee options. 
- Add deterministic regression coverage by importing `WISP_FLEE_CHANCE`, mocking randomness for the flee test, and adding a new test that asserts the wisp sometimes hesitates in `__tests__/lib/wisp.test.ts`.

### Testing
- Ran `npm test -- --runInBand __tests__/lib/wisp.test.ts` and all tests in that file passed (27 tests passed). 
- Ran `npm run typecheck` (`tsc --noEmit`) which completed successfully. 
- Ran `npm run lint` which completed (the repository shows pre-existing lint warnings but the command finished).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8610a53594832da19be99f460e1bf2)