### PR TITLE
Add melee-exchange risk to close the kite exploit

### DIFF
--- a/__tests__/components/FloatingDamage.test.tsx
+++ b/__tests__/components/FloatingDamage.test.tsx
@@ -77,8 +77,15 @@ describe('Floating combat damage numbers', () => {
   it('shows a non-green hero damage number when enemies hit the hero on their turn', async () => {
     jest.useFakeTimers();
     // Player at (5,5), enemy adjacent at (5,6). Do not move into enemy; move up to trigger enemy attack phase.
+    // Stepping away is now a retreat, so the enemy's swing rolls a parting shot first: feed
+    // [0.1, 0.9] -> 0.1 < 0.4 connects, then 0.9 -> +1 variance (base 1 + 1 = 2 damage).
     const base = makeBaseState(5, 5);
-    const state: GameState = withEnemy(base, 5, 6);
+    let i = 0;
+    const seq = [0.1, 0.9];
+    const state: GameState = {
+      ...withEnemy(base, 5, 6),
+      combatRng: () => seq[Math.min(i++, seq.length - 1)],
+    };
 
     render(<TilemapGrid tileTypes={{}} initialGameState={state} />);
 

--- a/__tests__/lib/combat_kite_exploit.test.ts
+++ b/__tests__/lib/combat_kite_exploit.test.ts
@@ -1,0 +1,141 @@
+import { Direction, TileSubtype, type GameState, movePlayer } from "../../lib/map";
+import { Enemy } from "../../lib/enemy";
+
+// Regression coverage for the melee-kite exploit: a player who stepped away from an adjacent
+// enemy took zero damage, and a player who closed a one-tile gap struck for free while the
+// enemy walked into the blow. Both are now risky (see RETREAT_PARTING_HIT_CHANCE /
+// CLOSE_IN_COUNTER_CHANCE in lib/map/game-state.ts). Combat variance is driven by combatRng,
+// so each test feeds an explicit draw sequence to make the rolls deterministic.
+
+// Returns each value in order, repeating the last forever.
+function seqRng(values: number[]): () => number {
+  let i = 0;
+  return () => values[Math.min(i++, values.length - 1)];
+}
+
+function makeState(y: number, x: number, opts?: Partial<GameState>): GameState {
+  const size = 25;
+  const tiles = Array.from({ length: size }, () => Array(size).fill(0)); // all FLOOR
+  const subtypes = Array.from({ length: size }, () =>
+    Array.from({ length: size }, () => [] as number[])
+  );
+  subtypes[y][x].push(TileSubtype.PLAYER);
+  const base: GameState = {
+    hasKey: false,
+    hasExitKey: false,
+    hasSword: false,
+    hasShield: false,
+    mapData: { tiles, subtypes },
+    showFullMap: false,
+    win: false,
+    playerDirection: Direction.DOWN,
+    enemies: [] as Enemy[],
+    heroHealth: 5,
+    heroMaxHealth: 5,
+    heroAttack: 1,
+    stats: { damageDealt: 0, damageTaken: 0, enemiesDefeated: 0, steps: 0 },
+  } as unknown as GameState;
+  return { ...base, ...(opts || {}) } as GameState;
+}
+
+describe("melee-kite exploit is closed", () => {
+  describe("retreating from an adjacent enemy is no longer free", () => {
+    test("a connecting parting shot wounds the hero as they step away", () => {
+      // A heavy hitter to the right; the hero steps LEFT (directly away). Draw order for an
+      // aligned adjacent enemy is [parting-shot, attack-variance].
+      const gs = makeState(5, 5, { combatRng: seqRng([0.1, 0.5]) });
+      const e = new Enemy({ y: 5, x: 6 });
+      e.kind = "fire-goblin";
+      e.attack = 5; // stone-goblin-class damage
+      e.health = 8;
+      gs.enemies!.push(e);
+
+      const after = movePlayer(gs, Direction.LEFT);
+
+      // 0.1 < 0.4 connects; 0.5 -> +0 variance -> 5 damage, capped at the 4/turn ceiling.
+      expect(after.heroHealth).toBe(1);
+      expect(after.stats.damageTaken).toBe(4);
+      // The enemy took no damage — retreating never was the hero's attack.
+      expect(after.enemies![0].health).toBe(8);
+    });
+
+    test("the parting shot can still miss, so retreat stays the safer option", () => {
+      const gs = makeState(5, 5, { combatRng: seqRng([0.9]) });
+      const e = new Enemy({ y: 5, x: 6 });
+      e.kind = "fire-goblin";
+      e.attack = 5;
+      e.health = 8;
+      gs.enemies!.push(e);
+
+      const after = movePlayer(gs, Direction.LEFT);
+
+      // 0.9 >= 0.4 -> suppressed -> no damage.
+      expect(after.heroHealth).toBe(5);
+      expect(after.stats.damageTaken).toBe(0);
+    });
+  });
+
+  describe("closing a one-tile gap to strike is no longer free", () => {
+    test("an enemy that walks into the gap counters the hero's blow", () => {
+      // Enemy two tiles to the right with one open tile between. The hero steps RIGHT into the
+      // gap; the enemy (ticking against the hero's old tile, distance 2) closes into that same
+      // tile, so the hero's move resolves as a melee strike. Draw order: [hero-melee-variance,
+      // counter-roll, counter-variance].
+      const gs = makeState(5, 5, { combatRng: seqRng([0.5, 0.1, 0.5]) });
+      const e = new Enemy({ y: 5, x: 7 });
+      e.kind = "fire-goblin";
+      e.attack = 3;
+      e.health = 5; // survives the hero's 1-damage hit, so the counter is allowed
+      gs.enemies!.push(e);
+
+      const after = movePlayer(gs, Direction.RIGHT);
+
+      // The enemy closed into (5,6) and got struck (5 -> 4), then countered: 0.1 < 0.6 connects,
+      // 0.5 -> +0 variance -> 3 damage.
+      const enemy = after.enemies![0];
+      expect(enemy.y).toBe(5);
+      expect(enemy.x).toBe(6);
+      expect(enemy.health).toBe(4);
+      expect(after.stats.damageDealt).toBe(1);
+      expect(after.heroHealth).toBe(5 - 3);
+      expect(after.stats.damageTaken).toBe(3);
+    });
+
+    test("the counter can miss, keeping closing-in the lower-risk option", () => {
+      const gs = makeState(5, 5, { combatRng: seqRng([0.5, 0.9]) });
+      const e = new Enemy({ y: 5, x: 7 });
+      e.kind = "fire-goblin";
+      e.attack = 3;
+      e.health = 5;
+      gs.enemies!.push(e);
+
+      const after = movePlayer(gs, Direction.RIGHT);
+
+      // 0.9 >= 0.6 -> no counter. Hero still lands the strike.
+      expect(after.enemies![0].health).toBe(4);
+      expect(after.heroHealth).toBe(5);
+      expect(after.stats.damageTaken).toBe(0);
+    });
+
+    test("a killing blow avoids the counter (the enemy is cut down mid-lunge)", () => {
+      // Same close-in, but the hero one-shots the closing enemy, so no counter is rolled even
+      // though the RNG would otherwise connect.
+      const gs = makeState(5, 5, {
+        hasSword: true,
+        combatRng: seqRng([0.9, 0.1, 0.5]),
+      });
+      const e = new Enemy({ y: 5, x: 7 });
+      e.kind = "fire-goblin";
+      e.attack = 3;
+      e.health = 1; // dies to the hero's blow
+      gs.enemies!.push(e);
+
+      const after = movePlayer(gs, Direction.RIGHT);
+
+      expect(after.enemies!.length).toBe(0);
+      expect(after.stats.enemiesDefeated).toBe(1);
+      expect(after.heroHealth).toBe(5);
+      expect(after.stats.damageTaken).toBe(0);
+    });
+  });
+});

--- a/__tests__/lib/combat_variance.test.ts
+++ b/__tests__/lib/combat_variance.test.ts
@@ -1,6 +1,15 @@
 import { Direction, TileSubtype, type GameState, movePlayer } from "../../lib/map";
 import { Enemy } from "../../lib/enemy";
 
+// A combatRng that returns each value in order, repeating the last one forever.
+// Stepping AWAY from an adjacent enemy now rolls a "parting shot" first (connects when
+// the draw is < 0.4), then the usual attack-variance draw — so a retreating hit needs a
+// low first value followed by the variance value.
+function seqRng(values: number[]): () => number {
+  let i = 0;
+  return () => values[Math.min(i++, values.length - 1)];
+}
+
 function makeState(y: number, x: number, opts?: Partial<GameState>): GameState {
   const size = 25;
   const tiles = Array.from({ length: size }, () => Array(size).fill(0)); // FLOOR
@@ -27,15 +36,16 @@ function makeState(y: number, x: number, opts?: Partial<GameState>): GameState {
 describe("Combat variance and equipment", () => {
   test("enemy attack uses ±1 variance around strength (no shield)", () => {
     const gs = makeState(2, 2, {
-      combatRng: () => 0.8, // +1 variance for goblin-weighted (>= 0.75)
+      // parting shot connects (0.1 < 0.4), then +1 variance for goblin-weighted (>= 0.8)
+      combatRng: seqRng([0.1, 0.8]),
     });
-    const e = new Enemy({ y: 2, x: 1 }); // left of player, will attempt to move into player when we tick
+    const e = new Enemy({ y: 2, x: 1 }); // left of player; hero steps away (UP) so it gets a parting shot
     e.attack = 1;
     gs.enemies!.push(e);
 
     const before = gs.heroHealth;
     const after = movePlayer(gs, Direction.UP);
-    // damage = 1 base + 1 variance = 2 (goblin-weighted: >= 0.75 gives +1)
+    // damage = 1 base + 1 variance = 2 (goblin-weighted: >= 0.8 gives +1)
     expect(after.heroHealth).toBe(before - 2);
     expect(after.stats.damageTaken).toBe(2);
   });
@@ -79,7 +89,8 @@ describe("Combat variance and equipment", () => {
   test("shield gives +1 damage reduction (protection)", () => {
     const gs = makeState(2, 2, {
       hasShield: true,
-      combatRng: () => 0.8, // +1 variance for goblin-weighted (>= 0.75)
+      // parting shot connects (0.1 < 0.4), then +1 variance for goblin-weighted (>= 0.8)
+      combatRng: seqRng([0.1, 0.8]),
     });
     const e = new Enemy({ y: 2, x: 1 });
     e.attack = 1;
@@ -87,7 +98,7 @@ describe("Combat variance and equipment", () => {
 
     const before = gs.heroHealth;
     const after = movePlayer(gs, Direction.UP);
-    // incoming = 1 + 1 = 2; defense = 1; net = 1 (goblin-weighted: >= 0.75 gives +1)
+    // incoming = 1 + 1 = 2; defense = 1; net = 1 (goblin-weighted: >= 0.8 gives +1)
     expect(after.heroHealth).toBe(before - 1);
     expect(after.stats.damageTaken).toBe(1);
   });

--- a/__tests__/lib/health.test.ts
+++ b/__tests__/lib/health.test.ts
@@ -1,6 +1,14 @@
 import { initializeGameState, movePlayer, Direction, TileSubtype, type GameState } from "../../lib/map";
 import { Enemy, placeEnemies } from "../../lib/enemy";
 
+// combatRng that returns each value in order, repeating the last forever. Retreating from
+// an adjacent enemy now rolls a "parting shot" first (connects when the draw is < 0.4),
+// then the attack-variance draw, so a connecting retreat hit needs [low, variance].
+function seqRng(values: number[]): () => number {
+  let i = 0;
+  return () => values[Math.min(i++, values.length - 1)];
+}
+
 describe("Health system - initial hero health", () => {
   test("hero starts with 5 health", () => {
     const gs = initializeGameState();
@@ -9,17 +17,38 @@ describe("Health system - initial hero health", () => {
   });
 
 describe("Combat - running away behavior", () => {
-  test("when adjacent and the player increases distance in same tick, hero takes no damage", () => {
+  test("running away is no longer free: a connecting parting shot still wounds the hero", () => {
     const gs = makeEmptyStateWithPlayer(2, 2);
     // Enemy to the right (adjacent)
     const e = new Enemy({ y: 2, x: 3 });
     e.health = 3;
     e.attack = 1;
+    // Parting shot connects (0.1 < 0.4), then 0-variance (0.5) -> 1 damage.
+    gs.combatRng = seqRng([0.1, 0.5]);
     gs.enemies!.push(e);
 
     const before = { health: gs.heroHealth, taken: gs.stats.damageTaken };
 
     // Run away: move LEFT to increase distance from 1 to 2
+    const after = movePlayer(gs, Direction.LEFT);
+
+    expect(after.heroHealth).toBe(before.health - 1);
+    expect(after.stats.damageTaken).toBe(before.taken + 1);
+    // Enemy stayed put (it swung rather than chased).
+    expect(after.enemies![0].y).toBe(2);
+    expect(after.enemies![0].x).toBe(3);
+  });
+
+  test("the parting shot can miss, so retreat is safer than standing (not a guaranteed hit)", () => {
+    const gs = makeEmptyStateWithPlayer(2, 2);
+    const e = new Enemy({ y: 2, x: 3 });
+    e.health = 3;
+    e.attack = 1;
+    // Parting shot rolls a miss (0.9 >= 0.4) -> the enemy's attack is suppressed.
+    gs.combatRng = seqRng([0.9]);
+    gs.enemies!.push(e);
+
+    const before = { health: gs.heroHealth, taken: gs.stats.damageTaken };
     const after = movePlayer(gs, Direction.LEFT);
 
     expect(after.heroHealth).toBe(before.health);
@@ -36,6 +65,9 @@ describe("Combat - enemy attacks when attempting to step onto player", () => {
     e.attack = 1;
     gs.enemies!.push(e);
 
+    // Stepping to the side is still a retreat, so force the parting shot to connect
+    // (0.1 < 0.4) with 0-variance (0.5) -> 1 damage.
+    gs.combatRng = seqRng([0.1, 0.5]);
     const beforeHealth = gs.heroHealth;
     const after = movePlayer(gs, Direction.UP); // any move to tick enemies
 

--- a/__tests__/lib/pink_mist.test.ts
+++ b/__tests__/lib/pink_mist.test.ts
@@ -164,11 +164,15 @@ describe("pink mist — enemy blinding", () => {
   it("the same adjacent enemy attacks when NOT in mist", () => {
     const map = arena(12, 5, 5);
     const enemy = goblinAt(5, 4);
+    // Hero steps UP (a retreat), so the enemy's swing now rolls a parting shot first.
+    // Feed [0.1, 0.5]: 0.1 < 0.4 connects, 0.5 -> 0-variance, so its base hit lands.
+    let i = 0;
+    const seq = [0.1, 0.5];
     const state = baseState(map, {
       inPinkRealm: true,
       mist: [], // no mist
       enemies: [enemy],
-      combatRng: () => 0.5,
+      combatRng: () => seq[Math.min(i++, seq.length - 1)],
     });
     const after = movePlayer(state, Direction.UP);
     expect(after.heroHealth).toBeLessThan(5); // took a hit

--- a/lib/enemy.ts
+++ b/lib/enemy.ts
@@ -604,6 +604,26 @@ export type EnemyAttackInfo = {
   ranged: boolean;
 };
 
+// The +/- swing applied to an enemy's base attack, given a single rng roll in [0,1).
+// Goblins (and the two bosses that share their feel) roll a gentle -1/0/+1 weighted
+// toward their base; everything else can land a +2 crit. Extracted so the melee
+// counter-hit in game-state (a closing enemy that clashes onto the hero's sword)
+// uses the exact same model as the enemy turn — see updateEnemies below.
+export function enemyAttackVariance(kind: EnemyKind, r: number): number {
+  const goblinBucket =
+    kind === "fire-goblin" ||
+    kind === "water-goblin" ||
+    kind === "water-goblin-spear" ||
+    kind === "earth-goblin" ||
+    kind === "earth-goblin-knives" ||
+    kind === "pink-goblin" ||
+    kind === "white-goblin" ||
+    kind === "coilwyrm" ||
+    kind === "quarrymaster";
+  if (goblinBucket) return r < 0.4 ? -1 : r < 0.8 ? 0 : 1;
+  return r >= 0.75 ? 2 : r < 1 / 3 ? -1 : r < 2 / 3 ? 0 : 1;
+}
+
 export function updateEnemies(
   grid: number[][],
   enemies: Enemy[],
@@ -841,23 +861,13 @@ export function updateEnemies(
     // Optionally suppress this enemy's attack for this tick
     if (base > 0 && !suppress?.(e)) {
       // Variance: goblins weighted toward base damage (50% 0, 25% -1, 25% +1). Other enemies keep 25% crit (+2).
-      let variance = 0;
-      let rVal: number | null = null;
-      if (rng) {
-        rVal = rng();
-        // Both bosses sit in the goblin bucket deliberately, for the same reason: the
-        // 'other' branch below hands out a 25% +2 crit. On the Coilwyrm's head that made
-        // its base-2 bite roll 4 — the entire per-turn cap — so two bites killed a
-        // full-health hero with no tell; here it reads 1-3 and a bite is a mistake you can
-        // survive learning from. The Quarrymaster is meant to hit like a spear goblin, and
-        // the crit would make him spikier than his design brief allows.
-        if (e.kind === 'fire-goblin' || e.kind === 'water-goblin' || e.kind === 'water-goblin-spear' || e.kind === 'earth-goblin' || e.kind === 'earth-goblin-knives' || e.kind === 'pink-goblin' || e.kind === 'white-goblin' || e.kind === 'coilwyrm' || e.kind === 'quarrymaster') {
-          // Weighted: 40% chance -1, 40% chance 0, 20% chance +1
-          variance = rVal < 0.40 ? -1 : rVal < 0.80 ? 0 : 1;
-        } else {
-          variance = rVal >= 0.75 ? 2 : rVal < 1/3 ? -1 : rVal < 2/3 ? 0 : 1;
-        }
-      }
+      // Both bosses sit in the goblin bucket deliberately (see enemyAttackVariance): the
+      // 'other' branch hands out a 25% +2 crit. On the Coilwyrm's head that made its base-2
+      // bite roll 4 — the entire per-turn cap — so two bites killed a full-health hero with
+      // no tell; there it reads 1-3 and a bite is a mistake you can survive learning from.
+      // The Quarrymaster is meant to hit like a spear goblin, and the crit would make him
+      // spikier than his design brief allows.
+      const variance = rng ? enemyAttackVariance(e.kind, rng()) : 0;
       const effective = Math.max(0, base + variance - defense);
       // debug log removed
       totalDamage += effective;

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -3,6 +3,7 @@ import {
   placeEnemies,
   updateEnemies,
   rehydrateEnemies,
+  enemyAttackVariance,
   type PlainEnemy,
   type EnemyAttackInfo,
 } from "../enemy";
@@ -369,6 +370,33 @@ export const SPIKES_BUMP_DAMAGE = 1;
 const PINK_REALM_DAMAGE_CAP = 6;
 function perTurnDamageCap(state: { inPinkRealm?: boolean }): number {
   return state.inPinkRealm ? PINK_REALM_DAMAGE_CAP : 4;
+}
+
+// --- Melee-exchange risk (anti-kite balance) --------------------------------
+// Two moves used to be entirely risk-free, which let a patient player melee down
+// even a stone goblin with zero danger (step away, step back, repeat):
+//
+//   1. Retreating from an adjacent enemy. The enemy's attack was fully cancelled
+//      whenever the hero stepped off (see the `suppress` hook in movePlayerCore).
+//   2. Closing a one-tile gap and striking. The enemy spent its turn walking into
+//      the gap (no attack), then the hero's move resolved as a free melee hit.
+//
+// Both now carry a chance the enemy still lands its blow, restoring a risk gradient:
+// standing toe-to-toe (attack an already-adjacent enemy) is the riskiest — the enemy
+// always gets its swing; closing in to strike is a bit safer; retreating is the safest
+// but no longer free. Rolled against the run's combat RNG (Math.random in real play, so
+// daily-seed reconstruction is unaffected — combat variance is already non-deterministic).
+const RETREAT_PARTING_HIT_CHANCE = 0.4;
+const CLOSE_IN_COUNTER_CHANCE = 0.6;
+
+// Damage a single enemy's contact hit lands right now, using the same variance model as
+// the enemy turn (see enemyAttackVariance) and subtracting the hero's shield defense.
+function enemyContactDamage(
+  enemy: Enemy,
+  rng: () => number,
+  defense: number
+): number {
+  return Math.max(0, enemy.attack + enemyAttackVariance(enemy.kind, rng()) - defense);
 }
 
 /**
@@ -4243,6 +4271,14 @@ function movePlayerCore(
   let moved = false;
   let checkpointTouched = false;
 
+  // Carried from the enemy tick to the melee block below (which lives outside the
+  // enemy-turn `if`): who attacked, how much cap the tick already spent, and where every
+  // enemy stood BEFORE it moved — the last one lets the melee resolver tell a "closing"
+  // enemy (walked into the hero's path this turn) from one that was already adjacent.
+  let enemyTurnDamageApplied = 0;
+  let enemyAttacksThisTurn: EnemyAttackInfo[] = [];
+  const prevEnemyPositions = new Map<Enemy, { y: number; x: number }>();
+
   // Tick enemies BEFORE resolving player movement so adjacent enemies can attack
   const playerPosNow = [currentY, currentX] as [number, number];
   // Predict where the hero will stand once this move resolves, so ranged attackers
@@ -4282,6 +4318,8 @@ function movePlayerCore(
         ) ?? null
       : null;
   if (newGameState.enemies && Array.isArray(newGameState.enemies)) {
+    // Snapshot pre-move positions so the melee resolver can detect a "closing" enemy.
+    for (const e of newGameState.enemies) prevEnemyPositions.set(e, { y: e.y, x: e.x });
     // console.log(`[ENEMY TURN] Starting enemy turn. Player at (${currentY},${currentX}), moving ${direction}. Enemies:`, newGameState.enemies.map(e => `${e.kind} at (${e.y},${e.x})`).join(', '));
     const result = updateEnemies(
       newMapData.tiles,
@@ -4303,24 +4341,42 @@ function movePlayerCore(
         // behavior can see where the mist is.
         skipEnemy: mistBlindSkip(gameState, true),
         mist: gameState.mist,
-        // Suppress only when the player moves directly away from an adjacent enemy along the same axis
+        // Retreat parting shot: an adjacent enemy the hero steps away from (any direction,
+        // not just directly-away) used to have its attack fully cancelled — the free retreat
+        // that let a player kite anything to death. Now it lands a reduced-chance parting hit
+        // instead. Stepping INTO the enemy to strike it is unchanged: that enemy still gets its
+        // full swing (toe-to-toe is the riskiest option). Snakes always bite when adjacent, and
+        // non-adjacent (e.g. ranged) attacks are never suppressed here.
         suppress: (e: Enemy) => {
-          const dy = newY - currentY;
-          const dx = newX - currentX;
           const adj = Math.abs(e.y - currentY) + Math.abs(e.x - currentX) === 1;
-          const movingAway =
-            (dy !== 0 && Math.sign(dy) === Math.sign(currentY - e.y)) ||
-            (dx !== 0 && Math.sign(dx) === Math.sign(currentX - e.x));
-          // Do not suppress snakes; they should bite if adjacent
-          if (e.kind === 'snake') return false;
-          return adj && movingAway;
+          if (!adj) return false;
+          const attackingThisEnemy = newY === e.y && newX === e.x;
+          if (attackingThisEnemy) return false;
+          if (e.kind === "snake") return false;
+          // Bosses keep their own bespoke anti-kite tuning (the Coilwyrm's split-on-cut, the
+          // Fisher's spike moat, ...) and their deterministic policy sims, so leave them on the
+          // original rule: a retreat is only free when moving directly away, never a parting
+          // shot. The general risk is for ordinary enemies — the ones the kite exploit trivialized.
+          if (isBossPart(e)) {
+            const dy = newY - currentY;
+            const dx = newX - currentX;
+            const movingAway =
+              (dy !== 0 && Math.sign(dy) === Math.sign(currentY - e.y)) ||
+              (dx !== 0 && Math.sign(dx) === Math.sign(currentX - e.x));
+            return movingAway;
+          }
+          const rng = newGameState.combatRng ?? Math.random;
+          // Suppress (the enemy misses) unless the parting-shot roll connects.
+          return rng() >= RETREAT_PARTING_HIT_CHANCE;
         },
       }
     );
     // Transient: expose this tick's attacks for render-layer VFX (pink beam etc.)
     newGameState.recentEnemyAttacks = result.attackingEnemies;
+    enemyAttacksThisTurn = result.attackingEnemies ?? [];
     if (result.damage > 0) {
       const applied = Math.min(perTurnDamageCap(newGameState), result.damage);
+      enemyTurnDamageApplied = applied;
       applyHeroDamage(newGameState, applied);
       newGameState.stats.damageTaken += applied;
 
@@ -4926,6 +4982,76 @@ function movePlayerCore(
           )
         ) {
           newGameState.heroTorchLit = true;
+        }
+
+        // Closing-enemy counter (anti-kite): a struck enemy that walked into the hero's
+        // path THIS turn — it wasn't already adjacent, and it spent its move closing rather
+        // than attacking — used to eat the hero's blow for free (the one-tile-gap exploit).
+        // Now that clash carries a chance it lands a hit too. A killing blow avoids the
+        // counter (the enemy is cut down mid-lunge), so one-shotting weak enemies stays safe
+        // while a tanky one like a stone goblin, which survives the hero's chip damage, bites
+        // back. Already-adjacent enemies are handled by the enemy turn (they got their swing),
+        // and a blinded/suppressed one never counts as "closing" since it couldn't move here.
+        if (enemy.health > 0) {
+          const prev = prevEnemyPositions.get(enemy);
+          const wasAdjacentBefore =
+            !!prev &&
+            Math.abs(prev.y - currentY) + Math.abs(prev.x - currentX) === 1;
+          const attackedThisTurn = enemyAttacksThisTurn.some(
+            (a) => a.y === enemy.y && a.x === enemy.x
+          );
+          // Bosses are exempt (see the suppress hook): their fights are tuned and sim-tested
+          // on their own terms, so the general closing-counter does not apply to them.
+          const isClosingEnemy =
+            !wasAdjacentBefore && !attackedThisTurn && !isBossPart(enemy);
+          if (isClosingEnemy && rng() < CLOSE_IN_COUNTER_CHANCE) {
+            const defense = newGameState.hasShield ? 1 : 0;
+            const remainingCap = Math.max(
+              0,
+              perTurnDamageCap(newGameState) - enemyTurnDamageApplied
+            );
+            const counter = Math.min(
+              remainingCap,
+              enemyContactDamage(enemy, rng, defense)
+            );
+            if (counter > 0) {
+              applyHeroDamage(newGameState, counter);
+              newGameState.stats.damageTaken += counter;
+              enemyTurnDamageApplied += counter;
+              // Tutorial guardrail: mirror the enemy-turn floor (never die in the tutorial).
+              if (newGameState.mode === "tutorial" && newGameState.heroHealth < 1) {
+                newGameState.heroHealth = 1;
+              }
+              // Surface the counter to the render layer so the hit is visible.
+              newGameState.recentEnemyAttacks = [
+                ...(newGameState.recentEnemyAttacks ?? []),
+                {
+                  kind: enemy.kind,
+                  damage: counter,
+                  y: enemy.y,
+                  x: enemy.x,
+                  ranged: false,
+                },
+              ];
+              // A closing snake still delivers venom.
+              if (enemy.kind === "snake") {
+                if (!newGameState.conditions) newGameState.conditions = {};
+                if (!newGameState.conditions.poisoned) {
+                  newGameState.conditions.poisoned = {
+                    active: true,
+                    stepsSinceLastDamage: 0,
+                    damagePerInterval: 1,
+                    stepInterval: 8,
+                  };
+                } else {
+                  newGameState.conditions.poisoned.active = true;
+                }
+              }
+              if (newGameState.heroHealth <= 0 && !newGameState.deathCause) {
+                newGameState.deathCause = { type: "enemy", enemyKind: enemy.kind };
+              }
+            }
+          }
         }
 
         if (enemy.health <= 0) {


### PR DESCRIPTION
## Problem
Two melee moves were 100% risk-free, so a patient player could beat almost any enemy — including a stone goblin (8 HP, attack 5, but the hero only does 1 dmg/hit, meant to require a rune) — by "stepping away and back":
- **Retreat** fully cancelled an adjacent enemy's attack when the hero stepped directly away.
- **Gap-close** let an enemy spend its turn walking into a one-tile gap (no attack), after which the hero's move resolved as a free melee strike.

## Fix — a risk gradient (stand-and-trade > close-in > retreat)
- **Retreat parting shot** — an adjacent enemy the hero steps away from (any direction) now connects with `RETREAT_PARTING_HIT_CHANCE = 0.4`.
- **Closing counter** — a struck enemy that closed into the hero's path this turn counters with `CLOSE_IN_COUNTER_CHANCE = 0.6`; a killing blow avoids it (one-shotting weak enemies stays safe).
- **Snakes** always bite on retreat (unchanged). **Bosses exempt** from both — they keep their bespoke anti-kite tuning and deterministic policy sims (`isBossPart`).
- Uses the run's combat RNG (`Math.random` in real play), so **daily-seed /stats reconstruction is unaffected**.
- Extracted `enemyAttackVariance()` so the counter and the enemy turn share one variance model.

## Tests
- New `combat_kite_exploit.test.ts` pins both exploits closed (plus miss cases and the killing-blow exemption).
- Updated 4 tests that had encoded the old free-retreat behavior.
- Full suite green; `npm run build` and `typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)