### PR TITLE
Hearth & Home: family party combat + intro scenario

### DIFF
--- a/__tests__/lib/follow_behavior.test.ts
+++ b/__tests__/lib/follow_behavior.test.ts
@@ -1,0 +1,81 @@
+import { updateFollowBehavior } from "../../lib/npc_behaviors";
+import { NPC } from "../../lib/npc";
+import { Direction, FLOOR, WALL } from "../../lib/map";
+
+function makeFollower(
+  id: string,
+  y: number,
+  x: number,
+  followOrder: number,
+  extraMetadata: Record<string, unknown> = {}
+): NPC {
+  return new NPC({
+    id,
+    name: id,
+    sprite: "/images/family/test.png",
+    y,
+    x,
+    facing: Direction.DOWN,
+    canMove: true,
+    metadata: { behavior: "follow", followOrder, ...extraMetadata },
+  });
+}
+
+function makeGrid(size = 6): number[][] {
+  return Array.from({ length: size }, () =>
+    Array.from({ length: size }, () => FLOOR)
+  );
+}
+
+function ctx(npc: NPC, npcs: NPC[], grid: number[][], player = { y: 5, x: 1 }) {
+  return { npc, grid, subtypes: undefined, player, npcs, enemies: [] };
+}
+
+describe("updateFollowBehavior", () => {
+  it("steps toward the player and turns to face the step", () => {
+    const a = makeFollower("a", 1, 1, 0, {
+      directionalSprites: { back: "b.png", side: "s.png" },
+    });
+    const result = updateFollowBehavior(ctx(a, [a], makeGrid()));
+    expect(result.moved).toBe(true);
+    expect([a.y, a.x]).toEqual([2, 1]);
+    expect(a.facing).toBe(Direction.DOWN);
+  });
+
+  it("holds position once adjacent to its leader", () => {
+    const a = makeFollower("a", 4, 1, 0);
+    const result = updateFollowBehavior(ctx(a, [a], makeGrid()));
+    expect(result.moved).toBe(false);
+    expect([a.y, a.x]).toEqual([4, 1]);
+  });
+
+  it("chains: later followers trail the one ahead, not the player", () => {
+    const a = makeFollower("a", 4, 1, 0); // adjacent to player already
+    const b = makeFollower("b", 4, 4, 1);
+    const result = updateFollowBehavior(ctx(b, [a, b], makeGrid()));
+    expect(result.moved).toBe(true);
+    // Steps toward a at (4,1), not the player at (5,1).
+    expect([b.y, b.x]).toEqual([4, 3]);
+  });
+
+  it("routes around walls via the other axis", () => {
+    const grid = makeGrid();
+    grid[2][1] = WALL; // block the straight path down
+    const a = makeFollower("a", 1, 1, 0);
+    const result = updateFollowBehavior(ctx(a, [a], grid, { y: 5, x: 2 }));
+    expect(result.moved).toBe(true);
+    expect([a.y, a.x]).toEqual([1, 2]); // sidestep instead
+  });
+
+  it("never steps onto the player or another NPC", () => {
+    const blocker = makeFollower("blocker", 3, 1, 5);
+    const a = makeFollower("a", 2, 1, 0);
+    // Straight down is blocked by an NPC; a's column is also the player's, so
+    // the only legal step is sideways or nothing — verify no overlap happens.
+    const result = updateFollowBehavior(ctx(a, [a, blocker], makeGrid()));
+    const landed = [a.y, a.x].join(",");
+    expect(landed).not.toBe("3,1");
+    expect(landed).not.toBe("5,1");
+    expect(result.moved).toBe(false);
+  });
+});

--- a/__tests__/lib/hearth_home_mode.test.ts
+++ b/__tests__/lib/hearth_home_mode.test.ts
@@ -1,4 +1,7 @@
-import { buildHearthHomeState } from "../../lib/story/hearth_home_mode";
+import {
+  buildHearthHomeState,
+  switchPartyMember,
+} from "../../lib/story/hearth_home_mode";
 import {
   FAMILY_HOUSE_ROOM_ID,
   FAMILY_HOUSE_SPAWN,
@@ -127,6 +130,20 @@ describe("directional sprites", () => {
     expect(resolveHeroSpriteOverride(Direction.UP, {})).toBeUndefined();
   });
 
+  it("puts the whole family in the party line, in roster order", () => {
+    const state = buildHearthHomeState("chris");
+    const party = (state.npcs ?? []).map((npc) => [
+      npc.metadata?.behavior,
+      npc.metadata?.followOrder,
+    ]);
+    expect(party).toEqual([
+      ["follow", 0],
+      ["follow", 1],
+      ["follow", 2],
+      ["follow", 3],
+    ]);
+  });
+
   it("gives family NPCs their directional art via metadata", () => {
     const state = buildHearthHomeState("chris");
     const annie = (state.npcs ?? []).find((npc) => npc.id === "npc-annie");
@@ -137,10 +154,86 @@ describe("directional sprites", () => {
   });
 });
 
+describe("possession (switchPartyMember)", () => {
+  it("initializes the full party roster", () => {
+    const state = buildHearthHomeState("chris");
+    expect(state.party?.map((p) => p.id)).toEqual([
+      "chris",
+      "annie",
+      "emerson",
+      "claire",
+      "opal",
+    ]);
+    expect(state.party?.every((p) => p.alive && p.health === 5)).toBe(true);
+  });
+
+  it("swaps control to a living member where they stand", () => {
+    const state = buildHearthHomeState("chris");
+    const annie = (state.npcs ?? []).find((n) => n.id === "npc-annie")!;
+    const next = switchPartyMember(state, "annie");
+
+    expect(next.activeHeroId).toBe("annie");
+    expect(next.mapData.subtypes[annie.y][annie.x]).toContain(
+      TileSubtype.PLAYER
+    );
+    expect(
+      next.mapData.subtypes[FAMILY_HOUSE_SPAWN[0]][FAMILY_HOUSE_SPAWN[1]]
+    ).not.toContain(TileSubtype.PLAYER);
+
+    // The ex-hero re-enters the world standing where the hero was.
+    const chrisNpc = (next.npcs ?? []).find((n) => n.id === "npc-chris")!;
+    expect([chrisNpc.y, chrisNpc.x]).toEqual(FAMILY_HOUSE_SPAWN);
+    expect((next.npcs ?? []).some((n) => n.id === "npc-annie")).toBe(false);
+
+    expect(next.heroSprite).toBe("/images/family/annie-front.png");
+    expect(next.playerDirection).toBe(annie.facing);
+    expect((next.npcs ?? []).map((n) => n.metadata?.followOrder)).toEqual([
+      0, 1, 2, 3,
+    ]);
+  });
+
+  it("round-trips stats and inventory through the roster", () => {
+    let state = buildHearthHomeState("chris");
+    state = { ...state, heroHealth: 3, rockCount: 2, hasSword: true };
+
+    state = switchPartyMember(state, "opal");
+    const chris = state.party!.find((p) => p.id === "chris")!;
+    expect([chris.health, chris.rockCount, chris.hasSword]).toEqual([
+      3, 2, true,
+    ]);
+    expect(state.heroHealth).toBe(5); // Opal's own fresh stats
+    expect(state.hasSword).toBe(false);
+
+    state = switchPartyMember(state, "chris");
+    expect(state.heroHealth).toBe(3);
+    expect(state.rockCount).toBe(2);
+    expect(state.hasSword).toBe(true);
+  });
+
+  it("refuses no-op and dead-member switches", () => {
+    const state = buildHearthHomeState("claire");
+    expect(switchPartyMember(state, "claire")).toBe(state);
+    const withDeadOpal = {
+      ...state,
+      party: state.party!.map((p) =>
+        p.id === "opal" ? { ...p, alive: false } : p
+      ),
+    };
+    expect(switchPartyMember(withDeadOpal, "opal")).toBe(withDeadOpal);
+  });
+});
+
 describe("hero-aware dialogue", () => {
   it("kids call you Dad only when Chris is playing", () => {
-    const asChris = buildHearthHomeState("chris");
-    const asClaire = buildHearthHomeState("claire");
+    // Past the intro's chest-hint stage, so the everyday lines resolve.
+    const asChris = {
+      ...buildHearthHomeState("chris"),
+      scenarioFlags: { hearthKeysFound: true },
+    };
+    const asClaire = {
+      ...buildHearthHomeState("claire"),
+      scenarioFlags: { hearthKeysFound: true },
+    };
 
     expect(
       resolveNpcDialogueScript("npc-emerson", asChris.storyFlags, asChris)

--- a/__tests__/lib/hearth_scenario.test.ts
+++ b/__tests__/lib/hearth_scenario.test.ts
@@ -1,0 +1,125 @@
+import { buildHearthHomeState } from "../../lib/story/hearth_home_mode";
+import { runHearthScenario } from "../../lib/story/hearth_scenario";
+import { resolveNpcDialogueScript } from "../../lib/story/npc_script_registry";
+import {
+  Direction,
+  FLOOR,
+  TileSubtype,
+  findPlayerPosition,
+  movePlayer,
+  type GameState,
+} from "../../lib/map";
+
+const HERO_POS: [number, number] = [15, 4];
+const CHEST_TILES: Array<[number, number]> = [
+  [7, 10],
+  [11, 9],
+  [15, 9],
+];
+
+function teleportHero(state: GameState, y: number, x: number) {
+  const pos = findPlayerPosition(state.mapData)!;
+  state.mapData.subtypes[pos[0]][pos[1]] = state.mapData.subtypes[pos[0]][
+    pos[1]
+  ].filter((t) => t !== TileSubtype.PLAYER);
+  state.mapData.subtypes[y][x] = [
+    ...(state.mapData.subtypes[y][x] ?? []),
+    TileSubtype.PLAYER,
+  ];
+}
+
+describe("hearth intro scenario", () => {
+  it("places a locked chest with a sword in every bedroom", () => {
+    const state = buildHearthHomeState("chris");
+    for (const [y, x] of CHEST_TILES) {
+      const subtypes = state.mapData.subtypes[y][x];
+      expect(subtypes).toContain(TileSubtype.CHEST);
+      expect(subtypes).toContain(TileSubtype.LOCK);
+      expect(subtypes).toContain(TileSubtype.SWORD);
+    }
+  });
+
+  it("the bookshelf gives up the chest keys (and never opens the library)", () => {
+    const state = buildHearthHomeState("chris");
+    state.bookshelfInteractionQueue = [
+      { bookshelfId: "home-shelf", position: [13, 1] },
+    ];
+    runHearthScenario(state, HERO_POS);
+    expect(state.hasKey).toBe(true);
+    expect(state.scenarioFlags?.hearthKeysFound).toBe(true);
+    expect(state.bookshelfInteractionQueue).toHaveLength(0);
+  });
+
+  it("Opal leads to the bookshelf until the keys are found, then falls in line", () => {
+    const state = buildHearthHomeState("chris");
+    runHearthScenario(state, HERO_POS);
+    const opal = state.npcs!.find((n) => n.id === "npc-opal")!;
+    expect(opal.metadata?.behavior).toBe("goto");
+    expect(opal.metadata?.gotoTarget).toEqual({ y: 14, x: 1 });
+
+    state.scenarioFlags!.hearthKeysFound = true;
+    runHearthScenario(state, HERO_POS);
+    expect(opal.metadata?.behavior).toBe("follow");
+  });
+
+  it("the first sword springs the break-in, exactly once", () => {
+    const state = buildHearthHomeState("chris");
+    state.hasSword = true;
+    runHearthScenario(state, HERO_POS);
+
+    expect(state.scenarioFlags?.hearthBreached).toBe(true);
+    expect(state.mapData.tiles[16][4]).toBe(FLOOR); // the door burst open
+    const wave = state.enemies?.length ?? 0;
+    expect(wave).toBeGreaterThanOrEqual(3);
+    expect(state.enemies?.every((e) => e.kind === "fire-goblin")).toBe(true);
+
+    runHearthScenario(state, HERO_POS);
+    expect(state.enemies?.length).toBe(wave); // no second wave
+  });
+
+  it("clearing every goblin marks the house defended", () => {
+    const state = buildHearthHomeState("chris");
+    state.hasSword = true;
+    runHearthScenario(state, HERO_POS);
+    state.enemies = [];
+    runHearthScenario(state, HERO_POS);
+    expect(state.scenarioFlags?.hearthDefended).toBe(true);
+  });
+
+  it("full loop: keys open the chest, stepping in grabs the sword, goblins arrive", () => {
+    let state = buildHearthHomeState("chris");
+    state.hasKey = true; // as if the bookshelf was already searched
+    state.scenarioFlags = { hearthKeysFound: true };
+    teleportHero(state, 7, 9); // beside the master-bedroom chest
+
+    state = movePlayer(state, Direction.RIGHT); // bump: unlocks + opens in place
+    const opened = state.mapData.subtypes[7][10];
+    expect(opened).toContain(TileSubtype.OPEN_CHEST);
+    expect(opened).toContain(TileSubtype.SWORD);
+    expect(opened).not.toContain(TileSubtype.CHEST);
+
+    state = movePlayer(state, Direction.RIGHT); // step in: take the sword
+    expect(state.hasSword).toBe(true);
+
+    state = movePlayer(state, Direction.LEFT); // one more step — the door bursts
+    expect(state.scenarioFlags?.hearthBreached).toBe(true);
+    expect(state.enemies?.length ?? 0).toBeGreaterThanOrEqual(3);
+  });
+
+  it("family dialogue tracks the scenario stages", () => {
+    const state = buildHearthHomeState("chris");
+    expect(
+      resolveNpcDialogueScript("npc-annie", state.storyFlags, state)
+    ).toBe("home-annie-chest-hint");
+
+    state.scenarioFlags = { hearthKeysFound: true, hearthBreached: true };
+    expect(
+      resolveNpcDialogueScript("npc-claire", state.storyFlags, state)
+    ).toBe("home-claire-battle");
+
+    state.scenarioFlags.hearthDefended = true;
+    expect(
+      resolveNpcDialogueScript("npc-emerson", state.storyFlags, state)
+    ).toBe("home-emerson-defended");
+  });
+});

--- a/__tests__/lib/party_combat.test.ts
+++ b/__tests__/lib/party_combat.test.ts
@@ -1,0 +1,152 @@
+import {
+  buildHearthHomeState,
+  handleControlledMemberDeath,
+} from "../../lib/story/hearth_home_mode";
+import { runPartyCombat } from "../../lib/map/game-state";
+import { FAMILY_HOUSE_SPAWN } from "../../lib/story/rooms/home";
+import { TileSubtype, type GameState } from "../../lib/map";
+import { Enemy, updateEnemies } from "../../lib/enemy";
+import { FLOOR } from "../../lib/map";
+
+function goblinAt(y: number, x: number, health?: number): Enemy {
+  const e = new Enemy({ y, x });
+  e.kind = "fire-goblin";
+  if (health !== undefined) e.health = health;
+  return e;
+}
+
+function npcOf(state: GameState, id: string) {
+  const npc = (state.npcs ?? []).find((n) => n.id === id);
+  if (!npc) throw new Error(`missing ${id}`);
+  return npc;
+}
+
+const HERO_POS = FAMILY_HOUSE_SPAWN;
+
+describe("runPartyCombat", () => {
+  it("family members strike adjacent enemies and can kill them", () => {
+    const state = buildHearthHomeState("chris");
+    const annie = npcOf(state, "npc-annie");
+    state.enemies = [goblinAt(annie.y, annie.x + 1, 1)];
+
+    runPartyCombat(state, HERO_POS);
+
+    expect(state.enemies).toHaveLength(0);
+    expect(state.stats.enemiesDefeated).toBe(1);
+    expect(state.defeatedEnemies?.[0]?.kind).toBe("fire-goblin");
+  });
+
+  it("enemies away from the hero swing back at one adjacent family member", () => {
+    const state = buildHearthHomeState("chris");
+    const annie = npcOf(state, "npc-annie");
+    const goblin = goblinAt(annie.y, annie.x + 1); // full health, survives her hit
+    const goblinHp = goblin.health;
+    state.enemies = [goblin];
+
+    runPartyCombat(state, HERO_POS);
+
+    expect(goblin.health).toBe(goblinHp - 1); // Annie's strike landed
+    expect(annie.health).toBe(4); // and the goblin swung back
+    expect(state.party?.find((p) => p.id === "annie")?.health).toBe(4); // roster synced
+  });
+
+  it("enemies engaged with the hero do not also hit allies", () => {
+    const state = buildHearthHomeState("chris");
+    const [hy, hx] = HERO_POS;
+    const opal = npcOf(state, "npc-opal");
+    opal.y = hy - 1;
+    opal.x = hx - 1;
+    const goblin = goblinAt(hy - 1, hx); // adjacent to hero AND to Opal
+    const goblinHp = goblin.health;
+    state.enemies = [goblin];
+
+    runPartyCombat(state, HERO_POS);
+
+    expect(goblin.health).toBe(goblinHp - 1); // Opal still bites it
+    expect(opal.health).toBe(5); // but it stays focused on the hero
+  });
+
+  it("a fallen family member is removed and marked dead (permadeath)", () => {
+    const state = buildHearthHomeState("chris");
+    const claire = npcOf(state, "npc-claire");
+    claire.health = 1;
+    state.enemies = [goblinAt(claire.y + 1, claire.x)];
+
+    runPartyCombat(state, HERO_POS);
+
+    expect((state.npcs ?? []).some((n) => n.id === "npc-claire")).toBe(false);
+    expect(state.party?.find((p) => p.id === "claire")?.alive).toBe(false);
+  });
+
+  it("does nothing outside party scenes", () => {
+    const state = buildHearthHomeState("chris");
+    delete state.party;
+    const annie = npcOf(state, "npc-annie");
+    state.enemies = [goblinAt(annie.y, annie.x + 1, 1)];
+    runPartyCombat(state, HERO_POS);
+    expect(state.enemies).toHaveLength(1);
+  });
+});
+
+describe("controlled-member permadeath", () => {
+  it("hands control to the next living member; the body does not return", () => {
+    const state = buildHearthHomeState("chris");
+    const next = handleControlledMemberDeath(state);
+
+    expect(next.activeHeroId).toBe("annie");
+    expect(next.party?.find((p) => p.id === "chris")?.alive).toBe(false);
+    expect((next.npcs ?? []).some((n) => n.id === "npc-chris")).toBe(false);
+    expect((next.npcs ?? []).some((n) => n.id === "npc-annie")).toBe(false);
+    // PLAYER now stands where Annie stood.
+    const annieHome = [6, 3];
+    expect(next.mapData.subtypes[annieHome[0]][annieHome[1]]).toContain(
+      TileSubtype.PLAYER
+    );
+    expect(next.heroSprite).toBe("/images/family/annie-front.png");
+  });
+
+  it("dead members cannot be possessed and stay out of the roster", () => {
+    const state = buildHearthHomeState("chris");
+    const afterDeath = handleControlledMemberDeath(state); // chris falls
+    const claireTurnToo = {
+      ...afterDeath,
+      party: afterDeath.party!.map((p) =>
+        p.id === "emerson" ? { ...p, alive: false } : p
+      ),
+    };
+    // Follow orders stay contiguous for the survivors.
+    const orders = (claireTurnToo.npcs ?? []).map(
+      (n) => n.metadata?.followOrder
+    );
+    expect(orders).toEqual([0, 1, 2]);
+  });
+
+  it("resets to a fresh visit when the whole family has fallen", () => {
+    let state = buildHearthHomeState("opal");
+    state = {
+      ...state,
+      party: state.party!.map((p) =>
+        p.id === "opal" ? p : { ...p, alive: false }
+      ),
+    };
+    const next = handleControlledMemberDeath(state); // last one falls
+    expect(next.activeHeroId).toBe("chris");
+    expect(next.party?.every((p) => p.alive)).toBe(true);
+  });
+});
+
+describe("enemies treat family members as solid", () => {
+  it("never ends a tick on a blocked tile", () => {
+    const grid = Array.from({ length: 3 }, () =>
+      Array.from({ length: 6 }, () => FLOOR)
+    );
+    const subtypes = Array.from({ length: 3 }, () =>
+      Array.from({ length: 6 }, () => [] as number[])
+    );
+    const goblin = goblinAt(1, 1);
+    updateEnemies(grid, subtypes, [goblin], { y: 1, x: 4 }, {
+      blockedTiles: [[1, 2]],
+    });
+    expect([goblin.y, goblin.x]).not.toEqual([1, 2]);
+  });
+});

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,9 +1,23 @@
 "use client";
 
-import React, { useEffect, useMemo, useState } from "react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
 import { TilemapGrid } from "../../components/TilemapGrid";
-import { tileTypes } from "../../lib/map";
-import { buildHearthHomeState } from "../../lib/story/hearth_home_mode";
+import {
+  tileTypes,
+  type GameState,
+  type PartyMemberState,
+} from "../../lib/map";
+import {
+  buildHearthHomeState,
+  handleControlledMemberDeath,
+  switchPartyMember,
+} from "../../lib/story/hearth_home_mode";
 import {
   FAMILY_MEMBERS,
   type FamilyMemberId,
@@ -16,32 +30,87 @@ function isFamilyMemberId(value: string | null): value is FamilyMemberId {
 }
 
 export default function HearthHomePage() {
+  // Who the scene boots as (mount-time only; restored from the last visit).
+  const [initialHeroId, setInitialHeroId] = useState<FamilyMemberId>("chris");
+  // Who is currently controlled — the picker highlight. Switching happens
+  // LIVE inside the running scene (possession), not by rebuilding it.
   const [heroId, setHeroId] = useState<FamilyMemberId>("chris");
+  const [externalAction, setExternalAction] = useState<
+    { seq: number; apply: (state: GameState) => GameState } | undefined
+  >(undefined);
+  const seqRef = useRef(0);
+  // Live roster mirror from the grid: who's alive, who's controlled.
+  const [party, setParty] = useState<PartyMemberState[] | undefined>(undefined);
 
-  // Remember who this device plays as, so Emerson's phone stays Emerson.
+  const handlePartyChange = useCallback(
+    (roster: PartyMemberState[], activeHeroId?: string) => {
+      setParty(roster);
+      // Deaths can hand control to someone else — keep the highlight honest.
+      if (isFamilyMemberId(activeHeroId ?? null)) {
+        setHeroId(activeHeroId as FamilyMemberId);
+      }
+    },
+    []
+  );
+
+  // Permadeath: when the controlled member falls, control jumps to the next
+  // living family member; when nobody is left, the visit starts over.
+  const handleDeath = useCallback(() => {
+    seqRef.current += 1;
+    setExternalAction({
+      seq: seqRef.current,
+      apply: (state) => handleControlledMemberDeath(state),
+    });
+  }, []);
+
   useEffect(() => {
     try {
       const saved = window.localStorage.getItem(HERO_CHOICE_KEY);
-      if (isFamilyMemberId(saved)) setHeroId(saved);
+      if (isFamilyMemberId(saved)) {
+        setInitialHeroId(saved);
+        setHeroId(saved);
+      }
     } catch {
       // localStorage unavailable — default to Chris.
     }
   }, []);
 
-  const pickHero = (id: FamilyMemberId) => {
+  const pickHero = useCallback((id: FamilyMemberId) => {
     setHeroId(id);
     try {
       window.localStorage.setItem(HERO_CHOICE_KEY, id);
     } catch {
       // Non-fatal: the choice just won't survive a refresh.
     }
-  };
+    seqRef.current += 1;
+    setExternalAction({
+      seq: seqRef.current,
+      apply: (state) => switchPartyMember(state, id),
+    });
+  }, []);
 
-  // Built in the SAME render as a heroId change so the keyed remount below
-  // always receives the matching state. (Building it in an effect left the
-  // remounted grid holding the previous character's state — the effect ran
-  // one render too late, and the grid ignores initialGameState after mount.)
-  const initialState = useMemo(() => buildHearthHomeState(heroId), [heroId]);
+  // 1-5 jump straight into that family member, in roster order.
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (
+        event.target instanceof HTMLInputElement ||
+        event.target instanceof HTMLTextAreaElement
+      ) {
+        return;
+      }
+      const index = Number.parseInt(event.key, 10) - 1;
+      if (Number.isNaN(index)) return;
+      const member = FAMILY_MEMBERS[index];
+      if (member) pickHero(member.id);
+    };
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [pickHero]);
+
+  const initialState = useMemo(
+    () => buildHearthHomeState(initialHeroId),
+    [initialHeroId]
+  );
 
   return (
     <div
@@ -59,31 +128,44 @@ export default function HearthHomePage() {
         </h1>
         <div className="flex flex-col items-center gap-1">
           <div className="flex flex-wrap justify-center gap-2">
-            {FAMILY_MEMBERS.map((member) => (
-              <button
-                key={member.id}
-                type="button"
-                onClick={() => pickHero(member.id)}
-                className={`rounded border px-3 py-1 text-sm transition ${
-                  heroId === member.id
-                    ? "border-amber-300 bg-amber-300/20 text-amber-100"
-                    : "border-white/30 bg-black/40 text-gray-300 hover:bg-white/10"
-                }`}
-              >
-                {member.name}
-              </button>
-            ))}
+            {FAMILY_MEMBERS.map((member, index) => {
+              const fallen =
+                party?.find((p) => p.id === member.id)?.alive === false;
+              return (
+                <button
+                  key={member.id}
+                  type="button"
+                  onClick={() => pickHero(member.id)}
+                  disabled={fallen}
+                  className={`rounded border px-3 py-1 text-sm transition ${
+                    fallen
+                      ? "border-white/10 bg-black/40 text-gray-600 line-through"
+                      : heroId === member.id
+                      ? "border-amber-300 bg-amber-300/20 text-amber-100"
+                      : "border-white/30 bg-black/40 text-gray-300 hover:bg-white/10"
+                  }`}
+                >
+                  <span className="mr-1 text-xs text-gray-400">
+                    {index + 1}
+                  </span>
+                  {member.name}
+                </button>
+              );
+            })}
           </div>
           <p className="text-xs text-gray-400">
-            Pick who&apos;s walking in the front door.
+            Switch who you&apos;re controlling any time — click or press 1-5.
           </p>
         </div>
         <TilemapGrid
-          key={heroId}
+          key={initialHeroId}
           tileTypes={tileTypes}
           initialGameState={initialState}
           forceDaylight={true}
           storageSlot="home"
+          externalAction={externalAction}
+          onPartyChange={handlePartyChange}
+          onDeath={handleDeath}
         />
       </div>
     </div>

--- a/components/TilemapGrid.tsx
+++ b/components/TilemapGrid.tsx
@@ -18,6 +18,7 @@ import {
   reviveFromLastCheckpoint,
   serializeEnemies,
   serializeNPCs,
+  type PartyMemberState,
   type RoomSnapshot,
 } from "../lib/map";
 import { coilPieceFor, coilHeadPoseFor } from "../lib/bosses/coilwyrm";
@@ -308,6 +309,15 @@ interface TilemapGridProps {
   onDeath?: (finalState: GameState) => void;
   storageSlot?: GameStorageSlot;
   /**
+   * One-shot state transform injected from OUTSIDE the grid (e.g. Hearth &
+   * Home's mid-play control switch). Applied whenever `seq` changes; `apply`
+   * must be pure and return the input unchanged for no-ops. This is the only
+   * sanctioned way for a parent to touch live game state after mount.
+   */
+  externalAction?: { seq: number; apply: (state: GameState) => GameState };
+  /** Fires when the party roster or controlled member changes (Hearth & Home picker). */
+  onPartyChange?: (party: PartyMemberState[], activeHeroId?: string) => void;
+  /**
    * /daily-preview date override (YYYY-MM-DD). When set, floor advancement is seeded from THIS
    * date instead of today, and every analytics event /stats reads is suppressed so a test replay
    * never lands in production numbers. Only ever passed by the /daily-preview route.
@@ -333,6 +343,8 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
   onWin,
   onDeath,
   storageSlot,
+  externalAction,
+  onPartyChange,
   dailyDateOverride,
   onLocationChange,
 }) => {
@@ -352,9 +364,11 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
   const shouldAnimateHeroDeath =
     resolvedStorageSlot === 'story' || isDailyChallenge || isEndless;
 
+
   // Router removed; daily flow handled via onDailyComplete callback
 
   // Initialize game state
+  const lastExternalActionSeq = useRef(0);
   const [gameState, setGameState] = useState<GameState>(() => {
     if (initialGameState) {
       return initialGameState;
@@ -398,6 +412,24 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
       throw new Error("Either initialGameState or tilemap must be provided");
     }
   });
+
+  // Externally injected one-shot state transforms (see the prop docs).
+  useEffect(() => {
+    if (!externalAction) return;
+    if (externalAction.seq === lastExternalActionSeq.current) return;
+    lastExternalActionSeq.current = externalAction.seq;
+    setGameState((prev) => externalAction.apply(prev));
+    // An external transform may hand control to a living body after a death
+    // (Hearth & Home possession) — re-arm death/completion processing so the
+    // NEXT death fires the hooks again.
+    setGameCompletionProcessed(false);
+  }, [externalAction]);
+
+  // Report party roster changes upward (Hearth & Home picker state).
+  useEffect(() => {
+    if (!onPartyChange || !gameState.party) return;
+    onPartyChange(gameState.party, gameState.activeHeroId);
+  }, [onPartyChange, gameState.party, gameState.activeHeroId]);
 
   // Find player position in the grid
   const [playerPosition, setPlayerPosition] = useState<[number, number] | null>(
@@ -3540,7 +3572,13 @@ export const TilemapGrid: React.FC<TilemapGridProps> = ({
 
     // Sandbox/test hook: the parent owns the death (in-place reset). Skip the
     // death screen, analytics, and every redirect; just clear our save slot.
-    if (onDeath && !isDailyChallenge && gameState.mode !== "story") {
+    // Party scenes (activeHeroId set) run in story mode but own their deaths —
+    // control jumps to the next family member instead of ending the run.
+    if (
+      onDeath &&
+      !isDailyChallenge &&
+      (gameState.mode !== "story" || gameState.activeHeroId)
+    ) {
       setGameCompletionProcessed(true);
       triggerScreenShake(400);
       try {

--- a/lib/enemy.ts
+++ b/lib/enemy.ts
@@ -619,6 +619,9 @@ export function updateEnemies(
     // Hero's predicted end-of-turn tile (after their pending move resolves). Used
     // by ranged attackers to gate LOS so they can't fire at a hero rounding a corner.
     playerNext?: { y: number; x: number };
+    // Tiles no enemy may end its tick on (Hearth & Home party allies). Purely
+    // additive: absent everywhere except party scenes.
+    blockedTiles?: Array<[number, number]>;
   }
 ): number;
 export function updateEnemies(
@@ -637,6 +640,9 @@ export function updateEnemies(
     // Hero's predicted end-of-turn tile (after their pending move resolves). Used
     // by ranged attackers to gate LOS so they can't fire at a hero rounding a corner.
     playerNext?: { y: number; x: number };
+    // Tiles no enemy may end its tick on (Hearth & Home party allies). Purely
+    // additive: absent everywhere except party scenes.
+    blockedTiles?: Array<[number, number]>;
   }
 ): { damage: number; attackingEnemies: EnemyAttackInfo[] };
 export function updateEnemies(
@@ -654,6 +660,9 @@ export function updateEnemies(
     // Hero's predicted end-of-turn tile (after their pending move resolves). Used
     // by ranged attackers to gate LOS so they can't fire at a hero rounding a corner.
     playerNext?: { y: number; x: number };
+    // Tiles no enemy may end its tick on (Hearth & Home party allies). Purely
+    // additive: absent everywhere except party scenes.
+    blockedTiles?: Array<[number, number]>;
   },
   opts?: {
     rng?: () => number;
@@ -666,6 +675,9 @@ export function updateEnemies(
     // Hero's predicted end-of-turn tile (after their pending move resolves). Used
     // by ranged attackers to gate LOS so they can't fire at a hero rounding a corner.
     playerNext?: { y: number; x: number };
+    // Tiles no enemy may end its tick on (Hearth & Home party allies). Purely
+    // additive: absent everywhere except party scenes.
+    blockedTiles?: Array<[number, number]>;
   }
 ): number | { damage: number; attackingEnemies: EnemyAttackInfo[] } {
   // Handle backward compatibility: old signature was (grid, enemies, player, opts)
@@ -702,6 +714,10 @@ export function updateEnemies(
   // entity vs. tile state and can strand the run — the pink goblin's ring teleport
   // once did exactly that.
   occupied.add(`${player.y},${player.x}`);
+  // Party allies (Hearth & Home) are solid to enemies, exactly like the hero.
+  for (const [by, bx] of finalOpts?.blockedTiles ?? []) {
+    occupied.add(`${by},${bx}`);
+  }
   // Boss adds — the summon channel (Quarrymaster hatches, Coilwyrm growth, ...).
   // Buffered rather than pushed straight onto `enemies`: the loop below captures its bound,
   // so an immediate push would let a newborn act on the very turn it appeared. Appended

--- a/lib/map.ts
+++ b/lib/map.ts
@@ -110,7 +110,11 @@ export {
   initializeGameStateForMultiTier,
 } from "./map/game-state";
 
-export type { GameState, CheckpointSnapshot } from "./map/game-state";
+export type {
+  GameState,
+  CheckpointSnapshot,
+  PartyMemberState,
+} from "./map/game-state";
 
 export {
   initializeGameStateForEndless,

--- a/lib/map/game-state.ts
+++ b/lib/map/game-state.ts
@@ -15,6 +15,7 @@ import {
   type NPCInteractionEvent,
 } from "../npc";
 import { resolveNpcDialogueScript } from "../story/npc_script_registry";
+import { runHearthScenario } from "../story/hearth_scenario";
 import {
   createInitialStoryFlags,
   type StoryCondition,
@@ -23,7 +24,12 @@ import {
 import { processEnemyDefeat, createDefeatedEnemyInfo } from "./enemy-defeat-handler";
 import { updateConditionalNpcs } from "../story/story_mode";
 import { determineRoomNpcs } from "../story/npc_conditions";
-import { updateDogBehavior, updateWanderBehavior } from "../npc_behaviors";
+import {
+  updateDogBehavior,
+  updateFollowBehavior,
+  updateGotoBehavior,
+  updateWanderBehavior,
+} from "../npc_behaviors";
 import {
   DEFAULT_ROOM_ID,
   Direction,
@@ -325,6 +331,126 @@ function updateNPCBehaviors(state: GameState, playerPos: [number, number]): void
       };
       
       updateWanderBehavior(ctx);
+    } else if (behavior === "follow") {
+      // Party line (Hearth & Home): trail the controlled hero in order
+      const ctx = {
+        npc,
+        grid: state.mapData.tiles,
+        subtypes: state.mapData.subtypes,
+        player: { y: py, x: px },
+        npcs: state.npcs,
+        enemies: state.enemies,
+        rng: state.combatRng,
+      };
+
+      updateFollowBehavior(ctx);
+    } else if (behavior === "goto") {
+      // Scenario-directed walk to a fixed tile (e.g. Opal leading the family
+      // to the bookshelf in Hearth & Home).
+      const ctx = {
+        npc,
+        grid: state.mapData.tiles,
+        subtypes: state.mapData.subtypes,
+        player: { y: py, x: px },
+        npcs: state.npcs,
+        enemies: state.enemies,
+        rng: state.combatRng,
+      };
+
+      updateGotoBehavior(ctx);
+    }
+  }
+
+  runPartyCombat(state, playerPos);
+  runHearthScenario(state, playerPos);
+}
+
+/**
+ * Tiles occupied by living party allies (Hearth & Home). Handed to
+ * updateEnemies as blockedTiles so enemies can't end a tick standing inside a
+ * family member. Undefined everywhere a party doesn't exist.
+ */
+function partyAllyTiles(state: GameState): Array<[number, number]> | undefined {
+  if (!state.party || !state.npcs?.length) return undefined;
+  const tiles = state.npcs
+    .filter((npc) => npc.metadata?.partyId)
+    .map((npc) => [npc.y, npc.x] as [number, number]);
+  return tiles.length > 0 ? tiles : undefined;
+}
+
+/**
+ * Hearth & Home party combat, run once per world tick after NPC movement:
+ *   1. every ally standing next to an enemy strikes it (roster attack)
+ *   2. every enemy NOT engaged with the hero strikes one adjacent ally
+ * Allies who fall are removed and their roster entry marked dead (permadeath).
+ * No-op unless the state carries a party.
+ */
+export function runPartyCombat(
+  state: GameState,
+  playerPos: [number, number]
+): void {
+  const party = state.party;
+  let enemies: Enemy[] | undefined = state.enemies;
+  if (!party || !state.npcs?.length || !enemies?.length) return;
+  const allies = state.npcs.filter((npc) => npc.metadata?.partyId);
+  if (allies.length === 0) return;
+  const [py, px] = playerPos;
+  const adjacent = (
+    a: { y: number; x: number },
+    b: { y: number; x: number }
+  ) => Math.abs(a.y - b.y) + Math.abs(a.x - b.x) === 1;
+
+  // 1. Family strikes.
+  for (const ally of allies) {
+    const target: Enemy | undefined = enemies.find((e) => adjacent(e, ally));
+    if (!target) continue;
+    const entry = party.find((p) => p.id === ally.metadata?.partyId);
+    // A chest sword doubles a family member's swing, mirroring the hero rule.
+    const damage = entry?.hasSword ? 2 : entry?.attack ?? 1;
+    target.health -= damage;
+    state.stats.damageDealt += damage;
+    if (target.health <= 0) {
+      enemies = enemies.filter((e) => e !== target);
+      state.enemies = enemies;
+      state.stats.enemiesDefeated += 1;
+      trackEnemyKill(state.stats, target.kind, state.currentFloor ?? 1);
+      const defeated = state.defeatedEnemies ?? [];
+      defeated.push({
+        y: target.y,
+        x: target.x,
+        kind: target.kind,
+        id: target.id,
+        behaviorMemory: { ...target.behaviorMemory },
+      });
+      state.defeatedEnemies = defeated;
+    }
+  }
+
+  // 2. Enemy counter-strikes on the family. An enemy busy with the hero
+  // (adjacent to the player) keeps its existing hero attack from the enemy
+  // tick; everyone else swings at one neighboring family member.
+  for (const enemy of enemies) {
+    if (adjacent(enemy, { y: py, x: px })) continue;
+    const victim = allies.find(
+      (ally) => ally.health > 0 && adjacent(enemy, ally)
+    );
+    if (!victim) continue;
+    const damage = enemy.attack ?? 1;
+    victim.health = Math.max(0, victim.health - damage);
+    state.stats.damageTaken += damage;
+    enemy.facing =
+      victim.y < enemy.y
+        ? "UP"
+        : victim.y > enemy.y
+        ? "DOWN"
+        : victim.x < enemy.x
+        ? "LEFT"
+        : "RIGHT";
+    const entry = party.find((p) => p.id === victim.metadata?.partyId);
+    if (entry) entry.health = victim.health;
+    if (victim.health <= 0) {
+      if (entry) entry.alive = false;
+      state.npcs = state.npcs.filter((npc) => npc !== victim);
     }
   }
 }
@@ -1965,6 +2091,26 @@ export interface PortalLocation {
 /**
  * Game state interface for tracking player inventory and game progress
  */
+/**
+ * One member of the Hearth & Home family party. The controlled member's
+ * stats live in the singular hero fields while they're being played; this is
+ * the at-rest copy, written back whenever control switches away.
+ */
+export interface PartyMemberState {
+  id: string;
+  health: number;
+  maxHealth: number;
+  attack: number;
+  alive: boolean;
+  hasSword: boolean;
+  hasShield: boolean;
+  rockCount: number;
+  runeCount: number;
+  bombCount: number;
+  foodCount: number;
+  potionCount: number;
+}
+
 export interface GameState {
   hasKey: boolean; // Player has the universal generic key
   hasExitKey: boolean;
@@ -2089,6 +2235,14 @@ export interface GameState {
   // Hearth & Home (/home) only — which family member the player is controlling.
   // Unset in daily/story/endless; dialogue rules may branch on it via customCondition.
   activeHeroId?: string;
+  // Hearth & Home (/home) only — the family party roster. Each member keeps
+  // their own stats/inventory; the controlled member's entry is projected
+  // into the singular hero fields and written back on every control switch.
+  // Unset in daily/story/endless.
+  party?: PartyMemberState[];
+  // Hearth & Home (/home) only — scripted-scenario progress flags (see
+  // lib/story/hearth_scenario.ts). Unset in daily/story/endless.
+  scenarioFlags?: Record<string, boolean>;
   // Hearth & Home (/home) only — sprite paths that replace the hero art.
   // heroSprite is the front view and the fallback for all facings; back/side
   // are optional (side art faces right, mirrored for left). Unset = default
@@ -4297,6 +4451,8 @@ function movePlayerCore(
           newGameState.heroTorchLit = lit;
         },
         playerNext: playerNextPos,
+        // Family party members are solid to enemies (Hearth & Home only).
+        blockedTiles: partyAllyTiles(newGameState),
         // Pink mist blinds enemies standing in it (no move/attack) — EXCEPT pink goblins,
         // which instead shuffle one tile toward the nearest clear tile (handled in their
         // behavior via the `mist` context below). The realm haze tiles are passed so that

--- a/lib/npc_behaviors.ts
+++ b/lib/npc_behaviors.ts
@@ -313,6 +313,179 @@ export function getRandomDogBackSprite(rng?: () => number): string {
 }
 
 /**
+ * Follow behavior: the party line. Each follower steps toward its leader —
+ * the previous follower in `metadata.followOrder`, or the player for the
+ * front of the line — and stops once adjacent, forming a trailing conga.
+ * Facing turns with each step for NPCs with directional art; dogs swap their
+ * walk frames instead.
+ */
+export function updateFollowBehavior(ctx: NPCBehaviorContext): NPCBehaviorResult {
+  const { npc, grid, player, npcs, enemies } = ctx;
+
+  // Hold the line: a follower standing next to an enemy squares up and
+  // fights (the strike itself lands in the party-combat pass) instead of
+  // trailing off after its leader.
+  const engaged = enemies?.find(
+    (e) => Math.abs(e.y - npc.y) + Math.abs(e.x - npc.x) === 1
+  );
+  if (engaged) {
+    if (npc.metadata?.directionalSprites) {
+      npc.facing =
+        engaged.y < npc.y
+          ? Direction.UP
+          : engaged.y > npc.y
+          ? Direction.DOWN
+          : engaged.x < npc.x
+          ? Direction.LEFT
+          : Direction.RIGHT;
+    }
+    return { moved: false };
+  }
+
+  const myOrder = (npc.metadata?.followOrder as number) ?? 0;
+  const leader =
+    npcs
+      .filter(
+        (other) =>
+          other.id !== npc.id &&
+          other.metadata?.behavior === "follow" &&
+          ((other.metadata?.followOrder as number) ?? Infinity) < myOrder
+      )
+      .sort(
+        (a, b) =>
+          ((b.metadata?.followOrder as number) ?? 0) -
+          ((a.metadata?.followOrder as number) ?? 0)
+      )[0] ?? player;
+
+  const dy = leader.y - npc.y;
+  const dx = leader.x - npc.x;
+  if (Math.abs(dy) + Math.abs(dx) <= 1) {
+    return { moved: false }; // already in line
+  }
+
+  // Close the larger gap first; fall back to the other axis when blocked.
+  const stepY: Array<[number, number]> = dy !== 0 ? [[Math.sign(dy), 0]] : [];
+  const stepX: Array<[number, number]> = dx !== 0 ? [[0, Math.sign(dx)]] : [];
+  const candidates =
+    Math.abs(dy) >= Math.abs(dx) ? [...stepY, ...stepX] : [...stepX, ...stepY];
+
+  for (const [moveY, moveX] of candidates) {
+    const targetY = npc.y + moveY;
+    const targetX = npc.x + moveX;
+
+    if (!isValidPosition(grid, targetY, targetX)) continue;
+
+    const targetSubtypes = ctx.subtypes?.[targetY]?.[targetX];
+    if (targetSubtypes) {
+      const hasBlockingSubtype = targetSubtypes.some(
+        (subtype) =>
+          subtype === TileSubtype.WALL_TORCH ||
+          subtype === TileSubtype.TOWN_SIGN ||
+          subtype === TileSubtype.CHECKPOINT ||
+          subtype === TileSubtype.BOOKSHELF
+      );
+      if (hasBlockingSubtype) continue;
+    }
+
+    if (targetY === player.y && targetX === player.x) continue;
+    if (
+      npcs.some(
+        (other) => other.id !== npc.id && other.y === targetY && other.x === targetX
+      )
+    ) {
+      continue;
+    }
+    if (enemies?.some((e) => e.y === targetY && e.x === targetX)) continue;
+
+    npc.y = targetY;
+    npc.x = targetX;
+
+    if (npc.tags?.includes("dog")) {
+      updateDogSprite(npc, moveY, moveX);
+    } else if (npc.metadata?.directionalSprites) {
+      npc.facing =
+        moveY < 0
+          ? Direction.UP
+          : moveY > 0
+          ? Direction.DOWN
+          : moveX < 0
+          ? Direction.LEFT
+          : Direction.RIGHT;
+    }
+
+    return { moved: true };
+  }
+
+  return { moved: false };
+}
+
+/**
+ * Goto behavior: walk to `metadata.gotoTarget` and wait there (scenario
+ * direction — Opal leading the family to the bookshelf). Same stepping and
+ * blocking rules as follow; arrival means standing on or beside the target.
+ */
+export function updateGotoBehavior(ctx: NPCBehaviorContext): NPCBehaviorResult {
+  const { npc, grid, player, npcs, enemies } = ctx;
+  const target = npc.metadata?.gotoTarget as { y: number; x: number } | undefined;
+  if (!target) return { moved: false };
+
+  const dy = target.y - npc.y;
+  const dx = target.x - npc.x;
+  if (Math.abs(dy) + Math.abs(dx) <= 1) {
+    return { moved: false }; // arrived
+  }
+
+  const stepY: Array<[number, number]> = dy !== 0 ? [[Math.sign(dy), 0]] : [];
+  const stepX: Array<[number, number]> = dx !== 0 ? [[0, Math.sign(dx)]] : [];
+  const candidates =
+    Math.abs(dy) >= Math.abs(dx) ? [...stepY, ...stepX] : [...stepX, ...stepY];
+
+  for (const [moveY, moveX] of candidates) {
+    const targetY = npc.y + moveY;
+    const targetX = npc.x + moveX;
+    if (!isValidPosition(grid, targetY, targetX)) continue;
+    const targetSubtypes = ctx.subtypes?.[targetY]?.[targetX];
+    if (
+      targetSubtypes?.some(
+        (subtype) =>
+          subtype === TileSubtype.WALL_TORCH ||
+          subtype === TileSubtype.TOWN_SIGN ||
+          subtype === TileSubtype.CHECKPOINT ||
+          subtype === TileSubtype.BOOKSHELF
+      )
+    ) {
+      continue;
+    }
+    if (targetY === player.y && targetX === player.x) continue;
+    if (
+      npcs.some(
+        (other) => other.id !== npc.id && other.y === targetY && other.x === targetX
+      )
+    ) {
+      continue;
+    }
+    if (enemies?.some((e) => e.y === targetY && e.x === targetX)) continue;
+
+    npc.y = targetY;
+    npc.x = targetX;
+    if (npc.tags?.includes("dog")) {
+      updateDogSprite(npc, moveY, moveX);
+    } else if (npc.metadata?.directionalSprites) {
+      npc.facing =
+        moveY < 0
+          ? Direction.UP
+          : moveY > 0
+          ? Direction.DOWN
+          : moveX < 0
+          ? Direction.LEFT
+          : Direction.RIGHT;
+    }
+    return { moved: true };
+  }
+  return { moved: false };
+}
+
+/**
  * Wander behavior: NPC randomly moves within specified bounds
  * 50% chance to move each turn, picks a random adjacent direction
  */

--- a/lib/story/dialogue_registry.ts
+++ b/lib/story/dialogue_registry.ts
@@ -1210,6 +1210,68 @@ const DIALOGUE_SCRIPTS: Record<string, DialogueScript> = {
       { speaker: "Opal", text: "Woof! Woof woof! (Her whole back half is wagging.)" },
     ],
   },
+
+  // Hearth & Home intro scenario stages (see lib/story/hearth_scenario.ts):
+  // chest hints before the keys are found, battle lines during the break-in,
+  // aftermath lines once the house is defended.
+  "home-annie-chest-hint": {
+    id: "home-annie-chest-hint",
+    lines: [
+      { speaker: "Annie", text: "There is a LOCKED CHEST in our bedroom. Was that always there?" },
+      { speaker: "Annie", text: "And Opal keeps staring at the bookshelf like it owes her a treat. Follow the dog." },
+    ],
+  },
+  "home-emerson-chest-hint": {
+    id: "home-emerson-chest-hint",
+    lines: [
+      { speaker: "Emerson", text: "There's a treasure chest in my room!! It's locked. This is the best mystery ever." },
+      { speaker: "Emerson", text: "Opal keeps sniffing the bookshelf. She knows something. She always knows." },
+    ],
+  },
+  "home-claire-chest-hint": {
+    id: "home-claire-chest-hint",
+    lines: [
+      { speaker: "Claire", text: "...there's a chest in my room. I didn't put it there." },
+      { speaker: "Claire", text: "Opal's trying to tell us something. Follow her." },
+    ],
+  },
+  "home-annie-battle": {
+    id: "home-annie-battle",
+    lines: [
+      { speaker: "Annie", text: "GOBLINS. IN MY LIVING ROOM." },
+      { speaker: "Annie", text: "Everyone stay together! Swing at anything green!" },
+    ],
+  },
+  "home-emerson-battle": {
+    id: "home-emerson-battle",
+    lines: [
+      { speaker: "Emerson", text: "GOBLINS! This is the best day of my LIFE!" },
+    ],
+  },
+  "home-claire-battle": {
+    id: "home-claire-battle",
+    lines: [{ speaker: "Claire", text: "...behind me, Emerson." }],
+  },
+  "home-annie-defended": {
+    id: "home-annie-defended",
+    lines: [
+      { speaker: "Annie", text: "Is everyone okay? Okay. Good." },
+      { speaker: "Annie", text: "Now. WHY does our house come with swords? Who built this place?" },
+    ],
+  },
+  "home-emerson-defended": {
+    id: "home-emerson-defended",
+    lines: [
+      { speaker: "Emerson", text: "Did you SEE me?! I got one! Can goblins come back tomorrow?" },
+    ],
+  },
+  "home-claire-defended": {
+    id: "home-claire-defended",
+    lines: [
+      { speaker: "Claire", text: "...we did good. The house is safe." },
+      { speaker: "Claire", text: "I'm keeping the sword." },
+    ],
+  },
 };
 
 export function getDialogueScript(id: string): DialogueScript | undefined {

--- a/lib/story/hearth_home_mode.ts
+++ b/lib/story/hearth_home_mode.ts
@@ -14,15 +14,19 @@
 import {
   Direction,
   TileSubtype,
+  findPlayerPosition,
   type GameState,
   type MapData,
+  type PartyMemberState,
 } from "../map";
 import { rehydrateNPCs, serializeNPCs } from "../npc";
 import { createInitialStoryFlags } from "./event_registry";
 import {
   buildFamilyHouse,
+  createFamilyNpc,
   getFamilyMember,
   FAMILY_HOUSE_SPAWN,
+  FAMILY_MEMBERS,
   type FamilyMemberId,
 } from "./rooms/home";
 
@@ -38,6 +42,23 @@ function addPlayer(mapData: MapData, position: [number, number]): MapData {
     clone.subtypes[py][px] = [...cell, TileSubtype.PLAYER];
   }
   return clone;
+}
+
+function freshPartyMember(id: FamilyMemberId): PartyMemberState {
+  return {
+    id,
+    health: 5,
+    maxHealth: 5,
+    attack: 1,
+    alive: true,
+    hasSword: false,
+    hasShield: false,
+    rockCount: 0,
+    runeCount: 0,
+    bombCount: 0,
+    foodCount: 0,
+    potionCount: 0,
+  };
 }
 
 export function buildHearthHomeState(
@@ -77,6 +98,7 @@ export function buildHearthHomeState(
     heroAttack: 1,
     heroTorchLit: false,
     activeHeroId: hero.id,
+    party: FAMILY_MEMBERS.map((m) => freshPartyMember(m.id)),
     heroSprite: hero.sprite,
     heroSpriteBack: hero.spriteBack,
     heroSpriteSide: hero.spriteSide,
@@ -102,4 +124,163 @@ export function buildHearthHomeState(
   };
 
   return gameState;
+}
+
+/**
+ * Core of possession: hand control of the world to `targetId`. Assumes the
+ * roster in `state.party` is already up to date (write-backs and death
+ * marking happen in the callers). The PLAYER tile moves to the target's body,
+ * the target's roster entry is projected into the singular hero fields, and
+ * the NPC roster is rebuilt in family order — living members keep their live
+ * positions and health; the ex-hero re-enters as an NPC only when
+ * `includeExHeroAsNpc` (false after a death: the body is gone).
+ */
+function projectControlTo(
+  state: GameState,
+  targetId: FamilyMemberId,
+  opts: { includeExHeroAsNpc: boolean }
+): GameState {
+  const party = state.party ?? [];
+  const targetEntry = party.find((p) => p.id === targetId);
+  if (!targetEntry || !targetEntry.alive) return state;
+
+  const currentId = state.activeHeroId as FamilyMemberId | undefined;
+  const targetMember = getFamilyMember(targetId);
+
+  const heroPos = findPlayerPosition(state.mapData);
+  const targetNpc = (state.npcs ?? []).find(
+    (npc) => npc.id === targetMember.npcId
+  );
+  if (!heroPos || !targetNpc) return state;
+
+  // Move the PLAYER tile from the old body to the new one.
+  const mapData = cloneMapData(state.mapData);
+  const [hy, hx] = heroPos;
+  mapData.subtypes[hy][hx] = (mapData.subtypes[hy][hx] ?? []).filter(
+    (t) => t !== TileSubtype.PLAYER
+  );
+  const targetCell = mapData.subtypes[targetNpc.y][targetNpc.x] ?? [];
+  if (!targetCell.includes(TileSubtype.PLAYER)) {
+    mapData.subtypes[targetNpc.y][targetNpc.x] = [
+      ...targetCell,
+      TileSubtype.PLAYER,
+    ];
+  }
+
+  // Rebuild the NPC roster in family order from the living members.
+  const liveById = new Map((state.npcs ?? []).map((npc) => [npc.id, npc]));
+  const npcs = FAMILY_MEMBERS.filter((m) => {
+    if (m.id === targetId) return false;
+    const entry = party.find((p) => p.id === m.id);
+    if (!entry?.alive) return false;
+    if (m.id === currentId && !opts.includeExHeroAsNpc) return false;
+    return true;
+  }).map((m, index) => {
+    const entry = party.find((p) => p.id === m.id);
+    if (m.id === currentId) {
+      return createFamilyNpc(m, {
+        y: hy,
+        x: hx,
+        facing: state.playerDirection,
+        followOrder: index,
+        health: entry?.health,
+        maxHealth: entry?.maxHealth,
+      });
+    }
+    const live = liveById.get(m.npcId);
+    return createFamilyNpc(m, {
+      y: live?.y ?? m.home[0],
+      x: live?.x ?? m.home[1],
+      facing: live?.facing ?? m.facing,
+      followOrder: index,
+      health: live?.health ?? entry?.health,
+      maxHealth: live?.maxHealth ?? entry?.maxHealth,
+    });
+  });
+
+  return {
+    ...state,
+    mapData,
+    npcs,
+    party,
+    activeHeroId: targetId,
+    heroSprite: targetMember.sprite,
+    heroSpriteBack: targetMember.spriteBack,
+    heroSpriteSide: targetMember.spriteSide,
+    heroSpriteScale: targetMember.heroSpriteScale,
+    playerDirection: targetNpc.facing,
+    heroHealth: targetEntry.health,
+    heroMaxHealth: targetEntry.maxHealth,
+    heroAttack: targetEntry.attack,
+    hasSword: targetEntry.hasSword,
+    hasShield: targetEntry.hasShield,
+    rockCount: targetEntry.rockCount,
+    runeCount: targetEntry.runeCount,
+    bombCount: targetEntry.bombCount,
+    foodCount: targetEntry.foodCount,
+    potionCount: targetEntry.potionCount,
+  };
+}
+
+/**
+ * Switch control to another living family member, mid-play, world intact.
+ * The current hero's live stats are written back into the roster first.
+ * Returns the input state unchanged for no-ops (same member, dead, unknown).
+ */
+export function switchPartyMember(
+  state: GameState,
+  targetId: FamilyMemberId
+): GameState {
+  if (state.activeHeroId === targetId) return state;
+  const targetEntry = state.party?.find((p) => p.id === targetId);
+  if (!targetEntry || !targetEntry.alive) return state;
+
+  const currentId = state.activeHeroId as FamilyMemberId | undefined;
+  if (!currentId) return state;
+
+  const party = (state.party ?? []).map((p) =>
+    p.id === currentId
+      ? {
+          ...p,
+          health: state.heroHealth ?? p.health,
+          maxHealth: state.heroMaxHealth ?? p.maxHealth,
+          attack: state.heroAttack ?? p.attack,
+          hasSword: !!state.hasSword,
+          hasShield: !!state.hasShield,
+          rockCount: state.rockCount ?? 0,
+          runeCount: state.runeCount ?? 0,
+          bombCount: state.bombCount ?? 0,
+          foodCount: state.foodCount ?? 0,
+          potionCount: state.potionCount ?? 0,
+        }
+      : p
+  );
+
+  return projectControlTo({ ...state, party }, targetId, {
+    includeExHeroAsNpc: true,
+  });
+}
+
+/**
+ * The controlled member just died (permadeath). Control jumps to the first
+ * living member in family order; their fallen body does not re-enter the
+ * world. When nobody is left, the visit starts over fresh.
+ */
+export function handleControlledMemberDeath(state: GameState): GameState {
+  const currentId = state.activeHeroId as FamilyMemberId | undefined;
+  if (!currentId) return state;
+
+  const party = (state.party ?? []).map((p) =>
+    p.id === currentId ? { ...p, alive: false, health: 0 } : p
+  );
+  const successor = FAMILY_MEMBERS.find((m) =>
+    party.some((p) => p.id === m.id && p.alive)
+  );
+  if (!successor) {
+    // The whole family has fallen — the house resets to a fresh visit.
+    return buildHearthHomeState();
+  }
+  return projectControlTo({ ...state, party }, successor.id, {
+    includeExHeroAsNpc: false,
+  });
 }

--- a/lib/story/hearth_scenario.ts
+++ b/lib/story/hearth_scenario.ts
@@ -1,0 +1,119 @@
+/**
+ * Hearth & Home — the intro scenario (Chris's script):
+ *
+ *   Whoever comes home, we discover chests in our rooms. Then Opal leads us
+ *   to keys hidden in a bookshelf. We find swords, and while we're wondering
+ *   why, goblins bust into our house — and the adventure begins.
+ *
+ * Runs once per world tick (from updateNPCBehaviors) and no-ops outside party
+ * scenes. Progress lives in GameState.scenarioFlags:
+ *   hearthKeysFound   — the bookshelf gave up the chest keys
+ *   hearthBreached    — the goblins burst through the front door
+ *   hearthDefended    — every goblin is down; the house is safe
+ *
+ * Type-only game-state import: game-state itself calls into this module, so
+ * a runtime import back at it would be a cycle.
+ */
+
+import { FLOOR, TileSubtype } from "../map/constants";
+import { Enemy } from "../enemy";
+import type { GameState } from "../map/game-state";
+
+/** Where Opal waits: beside the living-room bookshelf. */
+const OPAL_LEAD_TARGET = { y: 14, x: 1 };
+
+/** The front door tile that the goblins burst through. */
+const FRONT_DOOR: [number, number] = [16, 4];
+
+/** Doorway-adjacent tiles the break-in wave tries to spawn on, in order. */
+const BREACH_SPOTS: Array<[number, number]> = [
+  [16, 4],
+  [15, 4],
+  [15, 3],
+  [15, 5],
+  [14, 4],
+  [14, 3],
+  [14, 5],
+];
+
+const BREACH_WAVE_SIZE = 4;
+
+export function runHearthScenario(
+  state: GameState,
+  playerPos: [number, number]
+): void {
+  if (!state.party) return;
+  const flags = (state.scenarioFlags ??= {});
+
+  // Beat 2: the bookshelf hides the chest keys. The bump is intercepted here
+  // before the library UI (which consumes this queue in other modes) sees it.
+  // Story mode's master key is deliberately non-consuming, so one find opens
+  // every bedroom chest.
+  if ((state.bookshelfInteractionQueue?.length ?? 0) > 0) {
+    state.bookshelfInteractionQueue = [];
+    if (!flags.hearthKeysFound) {
+      flags.hearthKeysFound = true;
+      state.hasKey = true;
+    }
+  }
+
+  // Opal leads the way to the bookshelf until the keys are found, then falls
+  // back in line with everyone else.
+  const opal = (state.npcs ?? []).find(
+    (npc) => npc.metadata?.partyId === "opal"
+  );
+  if (opal) {
+    if (!flags.hearthKeysFound) {
+      if (opal.metadata?.behavior !== "goto") {
+        opal.metadata = {
+          ...opal.metadata,
+          behavior: "goto",
+          gotoTarget: OPAL_LEAD_TARGET,
+        };
+      }
+    } else if (opal.metadata?.behavior === "goto") {
+      opal.metadata = { ...opal.metadata, behavior: "follow" };
+    }
+  }
+
+  // Beat 4: the first sword out of a chest springs the ambush.
+  if (!flags.hearthBreached) {
+    const armed =
+      !!state.hasSword || (state.party ?? []).some((p) => p.hasSword);
+    if (armed) {
+      flags.hearthBreached = true;
+      breach(state, playerPos);
+    }
+    return;
+  }
+
+  // Beat 5: the house is defended.
+  if (!flags.hearthDefended && (state.enemies?.length ?? 0) === 0) {
+    flags.hearthDefended = true;
+  }
+}
+
+/** The front door bursts open and a goblin wave pours into the living room. */
+function breach(state: GameState, playerPos: [number, number]): void {
+  const [dy, dx] = FRONT_DOOR;
+  state.mapData.tiles[dy][dx] = FLOOR;
+  state.mapData.subtypes[dy][dx] = [];
+
+  const [py, px] = playerPos;
+  const taken = (y: number, x: number) =>
+    (y === py && x === px) ||
+    (state.npcs ?? []).some((npc) => npc.y === y && npc.x === x) ||
+    (state.enemies ?? []).some((e) => e.y === y && e.x === x);
+
+  let spawned = 0;
+  for (const [y, x] of BREACH_SPOTS) {
+    if (spawned >= BREACH_WAVE_SIZE) break;
+    if (state.mapData.tiles[y]?.[x] !== FLOOR) continue;
+    if (state.mapData.subtypes[y]?.[x]?.includes(TileSubtype.PLAYER)) continue;
+    if (taken(y, x)) continue;
+    const goblin = new Enemy({ y, x });
+    goblin.kind = "fire-goblin";
+    state.enemies = [...(state.enemies ?? []), goblin];
+    spawned += 1;
+  }
+}

--- a/lib/story/npc_script_registry.ts
+++ b/lib/story/npc_script_registry.ts
@@ -586,6 +586,33 @@ const NPC_DIALOGUE_RULES: NPCDialogueRule[] = [
     scriptId: "home-opal-default",
     priority: PRIORITIES.DEFAULT,
   },
+  // Hearth & Home intro scenario stages, highest priority first: battle
+  // (goblins inside), aftermath (house defended), chest hints (before the
+  // bookshelf gives up the keys). All gated on the party being present.
+  ...(["annie", "emerson", "claire"] as const).flatMap((member) => [
+    {
+      npcId: `npc-${member}`,
+      scriptId: `home-${member}-battle`,
+      priority: 30,
+      customCondition: (gameState: GameState) =>
+        !!gameState.scenarioFlags?.hearthBreached &&
+        !gameState.scenarioFlags?.hearthDefended,
+    },
+    {
+      npcId: `npc-${member}`,
+      scriptId: `home-${member}-defended`,
+      priority: 25,
+      customCondition: (gameState: GameState) =>
+        !!gameState.scenarioFlags?.hearthDefended,
+    },
+    {
+      npcId: `npc-${member}`,
+      scriptId: `home-${member}-chest-hint`,
+      priority: 20,
+      customCondition: (gameState: GameState) =>
+        !!gameState.party && !gameState.scenarioFlags?.hearthKeysFound,
+    },
+  ]),
 ];
 
 export function listNpcDialogueRules(): NPCDialogueRule[] {

--- a/lib/story/rooms/home/family_house.ts
+++ b/lib/story/rooms/home/family_house.ts
@@ -15,7 +15,7 @@
  * placeholders until the real family set is generated.
  */
 
-import { Direction } from "../../../map"
+import { Direction, TileSubtype } from "../../../map"
 import type { StoryRoom } from "../types"
 import { buildRoom, type RoomConfig } from "../room-builder"
 import { NPC } from "../../../npc"
@@ -102,7 +102,7 @@ export const FAMILY_MEMBERS: FamilyMember[] = [
     heroSpriteScale: 126,
     home: [13, 2],
     facing: Direction.DOWN,
-    canMove: false,
+    canMove: true,
     // metadata.scale is the NPC-layer size (heroSpriteScale / 85, the NPC standard)
     metadata: { scale: 1.48 },
   },
@@ -118,11 +118,7 @@ export const FAMILY_MEMBERS: FamilyMember[] = [
     home: [6, 3],
     facing: Direction.DOWN,
     canMove: true,
-    metadata: {
-      behavior: "wander",
-      wanderBounds: { minY: 4, maxY: 7, minX: 3, maxX: 5 },
-      scale: 1.48,
-    },
+    metadata: { scale: 1.48 },
   },
   // Emerson — his room, never standing still. Real assets; 12 and a little
   // small, so he renders below the kid baseline.
@@ -137,11 +133,7 @@ export const FAMILY_MEMBERS: FamilyMember[] = [
     home: [13, 8],
     facing: Direction.LEFT,
     canMove: true,
-    metadata: {
-      behavior: "wander",
-      wanderBounds: { minY: 13, maxY: 15, minX: 7, maxX: 8 },
-      scale: 1.29,
-    },
+    metadata: { scale: 1.29 },
   },
   // Claire — her room, calm and still. Real assets; 14, ~75% of the adults.
   {
@@ -154,7 +146,7 @@ export const FAMILY_MEMBERS: FamilyMember[] = [
     heroSpriteScale: 116,
     home: [10, 8],
     facing: Direction.DOWN,
-    canMove: false,
+    canMove: true,
     metadata: { scale: 1.36 },
   },
   // Opal — starts in the living room, roams the house
@@ -170,7 +162,7 @@ export const FAMILY_MEMBERS: FamilyMember[] = [
     canMove: true,
     tags: ["dog", "pet"],
     // NPC dogs already render at 51% via their own CSS class; scale is relative to that.
-    metadata: { behavior: "dog", scale: 0.7 },
+    metadata: { scale: 0.7 },
   },
 ];
 
@@ -180,29 +172,63 @@ export function getFamilyMember(id: FamilyMemberId): FamilyMember {
   return member;
 }
 
+/**
+ * Build one family member's NPC at a given spot. Used for the initial roster
+ * and by the control switch (the ex-hero re-enters the world as an NPC).
+ */
+export function createFamilyNpc(
+  member: FamilyMember,
+  at: {
+    y: number;
+    x: number;
+    facing: Direction;
+    followOrder: number;
+    health?: number;
+    maxHealth?: number;
+  }
+): NPC {
+  return new NPC({
+    id: member.npcId,
+    name: member.name,
+    sprite: member.sprite,
+    y: at.y,
+    x: at.x,
+    facing: at.facing,
+    canMove: member.canMove,
+    maxHealth: at.maxHealth,
+    health: at.health,
+    tags: member.tags,
+    metadata: {
+      ...member.metadata,
+      // Marks this NPC as a combat-capable party member and links it back to
+      // its roster entry (game-state's party combat keys off this).
+      partyId: member.id,
+      // The family moves as a party: everyone trails the controlled hero
+      // in roster order (the good guys fight together).
+      behavior: "follow",
+      followOrder: at.followOrder,
+      // Members with real directional art render it by facing; the NPC
+      // layer falls back to legacy single-sprite behavior otherwise.
+      ...(member.spriteBack || member.spriteSide
+        ? {
+            directionalSprites: {
+              back: member.spriteBack,
+              side: member.spriteSide,
+            },
+          }
+        : {}),
+    },
+  });
+}
+
 function buildFamilyNpcs(excludeId?: FamilyMemberId): NPC[] {
-  return FAMILY_MEMBERS.filter((m) => m.id !== excludeId).map(
-    (m) =>
-      new NPC({
-        id: m.npcId,
-        name: m.name,
-        sprite: m.sprite,
-        y: m.home[0],
-        x: m.home[1],
-        facing: m.facing,
-        canMove: m.canMove,
-        tags: m.tags,
-        metadata: {
-          ...m.metadata,
-          // Members with real directional art render it by facing; the NPC
-          // layer falls back to legacy single-sprite behavior otherwise.
-          ...(m.spriteBack || m.spriteSide
-            ? {
-                directionalSprites: { back: m.spriteBack, side: m.spriteSide },
-              }
-            : {}),
-        },
-      })
+  return FAMILY_MEMBERS.filter((m) => m.id !== excludeId).map((m, index) =>
+    createFamilyNpc(m, {
+      y: m.home[0],
+      x: m.home[1],
+      facing: m.facing,
+      followOrder: index,
+    })
   );
 }
 
@@ -223,5 +249,21 @@ export function buildFamilyHouse(activeHeroId?: FamilyMemberId): StoryRoom {
     environment: "house",
     npcs: buildFamilyNpcs(activeHeroId),
   };
-  return buildRoom(config);
+  const room = buildRoom(config);
+
+  // Intro beat 1: a locked chest in every bedroom with a sword inside. The
+  // keys are hidden in the living-room bookshelf (see lib/story/hearth_scenario.ts).
+  const chestTiles: Array<[number, number]> = [
+    [7, 10], // Chris & Annie's room
+    [11, 9], // Claire's room
+    [15, 9], // Emerson's room
+  ];
+  for (const [y, x] of chestTiles) {
+    room.mapData.subtypes[y][x] = [
+      TileSubtype.CHEST,
+      TileSubtype.LOCK,
+      TileSubtype.SWORD,
+    ];
+  }
+  return room;
 }

--- a/lib/story/rooms/home/index.ts
+++ b/lib/story/rooms/home/index.ts
@@ -1,5 +1,6 @@
 export {
   buildFamilyHouse,
+  createFamilyNpc,
   getFamilyMember,
   FAMILY_MEMBERS,
   FAMILY_HOUSE_SPAWN,


### PR DESCRIPTION
Mid-play possession + permadeath, a follow-train that fights, family members striking and taking hits, and the full intro scenario (bedroom chests → Opal leads to the bookshelf → keys → swords → goblin break-in → stage-aware dialogue).

All party/scenario logic is gated on `state.party`; daily, endless, and story are unaffected (the daily enemy tick's RNG is byte-identical when `blockedTiles` is absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)